### PR TITLE
Adds decimal, char, varchar, and timestamp constraint parsing

### DIFF
--- a/src/main/kotlin/org/partiql/plugins/local/LocalSchema.kt
+++ b/src/main/kotlin/org/partiql/plugins/local/LocalSchema.kt
@@ -144,7 +144,7 @@ private object LocalSchema {
     private fun StructElement.int32(): StaticType = StaticType.INT4
 
     // constraints?
-    private fun StructElement.int64(): StaticType = StaticType.INT4
+    private fun StructElement.int64(): StaticType = StaticType.INT8
 
     // constraints?
     private fun StructElement.int(): StaticType = StaticType.INT
@@ -205,7 +205,11 @@ private object LocalSchema {
     private fun StructElement.date(): StaticType = StaticType.DATE
 
     // constraints?
-    private fun StructElement.time(): StaticType = StaticType.TIME
+    private fun StructElement.time(): StaticType {
+        val precision = getMaybe<IntElement>("precision")?.longValue?.toInt()
+        val withTimeZone = getMaybe<BoolElement>("withTimeZone")?.booleanValue ?: false
+        return TimeType(precision, withTimeZone)
+    }
 
     // constraints?
     @OptIn(PartiQLTimestampExperimental::class)


### PR DESCRIPTION

*Description of changes:*

Improve local plugin type parsing to set up for constraint parsing. For now parse basic decimal, char, varchar, and timestamp constraints.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
