### PR TITLE
Use SQL integer type names in Spark and Trino

### DIFF
--- a/src/main/kotlin/org/partiql/scribe/targets/spark/SparkDialect.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/spark/SparkDialect.kt
@@ -5,6 +5,7 @@ import org.partiql.ast.Expr
 import org.partiql.ast.From
 import org.partiql.ast.Identifier
 import org.partiql.ast.Select
+import org.partiql.ast.Type
 import org.partiql.ast.exprPathStepSymbol
 import org.partiql.ast.identifierSymbol
 import org.partiql.ast.selectProjectItemExpression
@@ -93,6 +94,11 @@ public open class SparkDialect : SqlDialect() {
         }
     }
 
+    override fun visitTypeInt2(node: Type.Int2, head: SqlBlock): SqlBlock = head concat r("SMALLINT")
+
+    override fun visitTypeInt4(node: Type.Int4, head: SqlBlock): SqlBlock = head concat r("INT")
+
+    override fun visitTypeInt8(node: Type.Int8, head: SqlBlock): SqlBlock = head concat r("BIGINT")
 
     private fun r(text: String): SqlBlock = SqlBlock.Text(text)
 

--- a/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoDialect.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoDialect.kt
@@ -88,6 +88,12 @@ public open class TrinoDialect : SqlDialect() {
         }
     }
 
+    override fun visitTypeInt2(node: Type.Int2, head: SqlBlock): SqlBlock = head concat r("SMALLINT")
+
+    override fun visitTypeInt4(node: Type.Int4, head: SqlBlock): SqlBlock = head concat r("INT")
+
+    override fun visitTypeInt8(node: Type.Int8, head: SqlBlock): SqlBlock = head concat r("BIGINT")
+
     private fun r(text: String): SqlBlock = SqlBlock.Text(text)
 
     private fun list(


### PR DESCRIPTION
*Description of changes:*

- INT2 -> SMALLINT
- INT4 -> INT
- INT8 -> BIGINT

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
