### PR TITLE
Add a `.flatten()` to the Trino comparison

### DIFF
--- a/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoTypes.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoTypes.kt
@@ -58,7 +58,7 @@ internal object TrinoTypes {
         return false
     }
 
-    private fun candidates(t: StaticType): Set<KClass<*>> = t.allTypes
+    private fun candidates(t: StaticType): Set<KClass<*>> = t.flatten().allTypes
         .filter { it !is NullType && it !is MissingType }
         .flatMap { types[it::class]?.toList() ?: emptyList() }
         .toSet()

--- a/src/test/kotlin/org/partiql/scribe/targets/trino/TrinoTypesTest.kt
+++ b/src/test/kotlin/org/partiql/scribe/targets/trino/TrinoTypesTest.kt
@@ -87,4 +87,14 @@ class TrinoTypesTest {
         test(StaticType.LIST, StaticType.LIST)
     }
 
+    @Test
+    fun unionOfTypes() {
+        test(StaticType.unionOf(StaticType.INT, StaticType.INT2), StaticType.DECIMAL)
+        test(StaticType.unionOf(StaticType.INT, StaticType.STRING), StaticType.STRING)
+        // below should have been flattened at some point
+        test(StaticType.unionOf(StaticType.unionOf(StaticType.INT, StaticType.INT2)), StaticType.DECIMAL)
+        test(StaticType.unionOf(StaticType.unionOf(StaticType.INT, StaticType.STRING)), StaticType.DECIMAL)
+        test(StaticType.unionOf(StaticType.unionOf(StaticType.unionOf(StaticType.INT, StaticType.INT2))), StaticType.DECIMAL)
+        test(StaticType.unionOf(StaticType.unionOf(StaticType.unionOf(StaticType.INT))), StaticType.DECIMAL)
+    }
 }


### PR DESCRIPTION
Fixes issue where calling the Trino comparison function on an unflattened `StaticType.AnyOfType` would not return the correct Trino comparability result.

Calling `TrinoTypes.comparable` with:
- `StaticType.STRING.asNullable()` and `StaticType.STRING` returns true
while calling it with
- `StaticType.unionOf(StaticType.STRING.asNullable())` (without the flatten) and `StaticType.STRING` returns false
Both will output `union(string, null)` when converted to a string (with the current `.toString` for `AnyOfType`. The string output issue should be fixed in https://github.com/partiql/partiql-lang-kotlin/pull/1393.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
