### PR TITLE
Attempt to rewrite CASE WHEN back to coalesce, nullif

### DIFF
--- a/src/main/kotlin/org/partiql/scribe/sql/SqlTarget.kt
+++ b/src/main/kotlin/org/partiql/scribe/sql/SqlTarget.kt
@@ -1,14 +1,23 @@
 package org.partiql.scribe.sql
 
+import org.partiql.ast.AstNode
+import org.partiql.ast.Expr
+import org.partiql.ast.Type
+import org.partiql.ast.exprCase
+import org.partiql.ast.exprCoalesce
+import org.partiql.ast.exprLit
+import org.partiql.ast.exprNullIf
 import org.partiql.ast.sql.SqlDialect
 import org.partiql.ast.sql.SqlLayout
 import org.partiql.ast.sql.sql
+import org.partiql.ast.util.AstRewriter
 import org.partiql.plan.PartiQLPlan
 import org.partiql.scribe.ProblemCallback
 import org.partiql.scribe.ScribeOutput
 import org.partiql.scribe.ScribeTarget
 import org.partiql.types.StaticType
-import org.partiql.ast.Statement as AstStatement
+import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.nullValue
 import org.partiql.plan.Statement as PlanStatement
 
 public class SqlOutput(schema: StaticType, value: String) : ScribeOutput<String>(schema, value) {
@@ -69,11 +78,84 @@ public abstract class SqlTarget : ScribeTarget<String> {
         return SqlOutput(schema, sql)
     }
 
+    private class CaseWhenRewriter: AstRewriter<Unit>() {
+        @OptIn(PartiQLValueExperimental::class)
+        private fun isNullIf(caseWhen: Expr.Case): Boolean {
+            val branches = caseWhen.branches
+            val default = caseWhen.default
+
+            if (default == null) {
+                return false
+            }
+            if (branches.size != 1) {
+                return false
+            }
+            val v1 = branches.first()
+            if (v1.expr != exprLit(nullValue())) {
+                if (v1.expr is Expr.Cast && (v1.expr as Expr.Cast).value == exprLit(nullValue())) {
+                    // continue TODO figure out if this cast addition is necessary
+                } else {
+                    return false
+                }
+            }
+            val v1When = v1.condition
+            if (v1When is Expr.Binary && v1When.op == Expr.Binary.Op.EQ) {
+                if (v1When.lhs == default) {
+                    return true
+                }
+            }
+            return false
+        }
+
+        private fun isCoalesce(caseWhen: Expr.Case): Boolean {
+            return caseWhen.branches.all { branch ->
+                val whenExpr = branch.condition
+                val thenExpr = branch.expr
+                if (whenExpr is Expr.Unary && whenExpr.op == Expr.Unary.Op.NOT) {
+                    val innerExpr = whenExpr.expr
+                    if (innerExpr is Expr.IsType && innerExpr.type == Type.NullType()) {
+                        return@all innerExpr.value == thenExpr || innerExpr.value == (thenExpr as Expr.Cast).value
+                    }
+                } else if (whenExpr is Expr.IsType && whenExpr.type == Type.NullType() && whenExpr.not == true) {
+                    // Redshift constant folds NOT IS TYPE to IS NOT TYPE
+                    val innerExpr = whenExpr.value
+                    return@all whenExpr.value == thenExpr || innerExpr == (thenExpr as Expr.Cast).value
+                }
+                false
+            }
+        }
+
+        @OptIn(PartiQLValueExperimental::class)
+        override fun visitExprCase(node: Expr.Case, ctx: Unit): AstNode {
+            val case = super.visitExprCase(node, ctx) as Expr.Case
+            val branches = case.branches
+            val default = case.default ?: exprLit(nullValue())
+            val caseWhen = when (branches.isEmpty()) {
+                true -> default
+                false -> {
+                    if (isCoalesce(case)) { // rewrite back into coalesce
+                        val exprs = branches.map {
+                            it.expr
+                        }
+                        exprCoalesce(exprs)
+                    } else if (isNullIf(case)) {  // rewrite back into nullif
+                        val equality = (branches.first().condition) as Expr.Binary
+                        exprNullIf(equality.lhs, equality.rhs)
+                    } else {
+                        exprCase(expr = null, branches = branches, default = default)
+                    }
+                }
+            }
+            return caseWhen
+        }
+    }
+
     /**
      * Default Plan to AST translation. This method is only for potential edge cases
      */
-    open fun unplan(plan: PartiQLPlan, onProblem: ProblemCallback): AstStatement {
+    open fun unplan(plan: PartiQLPlan, onProblem: ProblemCallback): AstNode {
         val transform = SqlTransform(plan.catalogs, getCalls(onProblem), onProblem)
-        return transform.apply(plan.statement)
+        val statement = transform.apply(plan.statement)
+        return CaseWhenRewriter().visitStatement(statement, Unit)
     }
 }

--- a/src/test/resources/inputs/builtins/coalesce.sql
+++ b/src/test/resources/inputs/builtins/coalesce.sql
@@ -6,3 +6,6 @@ SELECT coalesce(a, b) FROM T;
 
 --#[builtins-coalesce-02]
 SELECT coalesce(a, b, c) FROM T;
+
+--#[builtins-coalesce-03]
+SELECT coalesce(coalesce(coalesce(a, b, c), b), c) FROM T;

--- a/src/test/resources/inputs/builtins/nullif.sql
+++ b/src/test/resources/inputs/builtins/nullif.sql
@@ -1,0 +1,11 @@
+--#[builtins-nullif-00]
+SELECT nullif(a, b) FROM T;
+
+--#[builtins-nullif-01]
+SELECT nullif(b, a) FROM T;
+
+--#[builtins-nullif-02]
+SELECT nullif((nullif(a, b), c), d) FROM T;
+
+--#[builtins-nullif-03]
+SELECT coalesce(nullif(coalesce(a, b, c), b), c) FROM T;

--- a/src/test/resources/outputs/partiql/builtins/coalesce.sql
+++ b/src/test/resources/outputs/partiql/builtins/coalesce.sql
@@ -1,0 +1,11 @@
+--#[builtins-coalesce-00]
+SELECT COALESCE("T"['a']) AS "_1" FROM "default"."T" AS "T";
+
+--#[builtins-coalesce-01]
+SELECT COALESCE("T"['a'], "T"['b']) AS "_1" FROM "default"."T" AS "T";
+
+--#[builtins-coalesce-02]
+SELECT COALESCE("T"['a'], "T"['b'], "T"['c']) AS "_1" FROM "default"."T" AS "T";
+
+--#[builtins-coalesce-03]
+SELECT COALESCE(COALESCE(COALESCE("T"['a'], "T"['b'], "T"['c']), "T"['b']), "T"['c']) AS "_1" FROM "default"."T" AS "T";

--- a/src/test/resources/outputs/partiql/builtins/nullif.sql
+++ b/src/test/resources/outputs/partiql/builtins/nullif.sql
@@ -1,0 +1,11 @@
+--#[builtins-nullif-00]
+SELECT NULLIF("T"['a'], "T"['b']) AS "_1" FROM "default"."T" AS "T";
+
+--#[builtins-nullif-01]
+SELECT NULLIF("T"['b'], "T"['a']) AS "_1" FROM "default"."T" AS "T";
+
+--#[builtins-nullif-02]
+SELECT NULLIF((NULLIF("T"['a'], "T"['b']), "T"['c']), "T"['d']) AS "_1" FROM "default"."T" AS "T";
+
+--#[builtins-nullif-03]
+SELECT COALESCE(NULLIF(COALESCE("T"['a'], "T"['b'], "T"['c']), "T"['b']), "T"['c']) AS "_1" FROM "default"."T" AS "T";


### PR DESCRIPTION
Attempts to rewrite `CASE WHEN` expressions back into `COALESCE` and `NULLIF`. The existing ast to plan rewriter in partiql-lang-kotlin converts `COALESCE` and `NULLIF` into `CASE WHEN` expressions as defined by the SQL spec. This can result in very large plans and thus asts, which can be problematic for the current `SqlDialect` (can result in stackoverflow error if large enough).

Should be able to fix the issue seen in https://github.com/partiql/partiql-scribe/issues/26. We'll need to decide if this is suitable or try a different approach (e.g. not doing the rewrite to `CASE WHEN` for ast to plan conversion).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
