### PR TITLE
Spark date add

### DIFF
--- a/src/main/kotlin/org/partiql/scribe/targets/spark/SparkCalls.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/spark/SparkCalls.kt
@@ -1,17 +1,23 @@
 package org.partiql.scribe.targets.spark
 
+import org.partiql.ast.DatetimeField
 import org.partiql.ast.Expr
 import org.partiql.ast.Identifier
+import org.partiql.ast.exprBinary
 import org.partiql.ast.exprCall
 import org.partiql.ast.exprLit
 import org.partiql.ast.identifierSymbol
 import org.partiql.scribe.ProblemCallback
+import org.partiql.scribe.error
 import org.partiql.scribe.info
 import org.partiql.scribe.sql.SqlArg
+import org.partiql.scribe.sql.SqlArgs
 import org.partiql.scribe.sql.SqlCallFn
 import org.partiql.scribe.sql.SqlCalls
 import org.partiql.scribe.sql.SqlTransform.Companion.id
+import org.partiql.scribe.warn
 import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.int32Value
 import org.partiql.value.stringValue
 
 public open class SparkCalls(private val log: ProblemCallback) : SqlCalls() {
@@ -35,7 +41,6 @@ public open class SparkCalls(private val log: ProblemCallback) : SqlCalls() {
         log.info("PartiQL CURRENT_USER was replaced by Spark `current_user()`")
         return exprCall(currentUser, emptyList())
     }
-
 
     // convert_timezone('UTC', current_timestamp())
     // the default return of current_timestamp function is session time zone dependent.
@@ -63,5 +68,81 @@ public open class SparkCalls(private val log: ProblemCallback) : SqlCalls() {
         val elementVar = sqlArgs[1].expr
         val elementExpr = sqlArgs[2].expr
         return exprCall(fnName, listOf(arrayExpr, elementVar, elementExpr))
+    }
+
+    /**
+     * PartiQL: date_add(part: datetime_part, quantity: int, date: date|timestamp) -> date|timestamp`
+     * Spark:   date + interval
+     *
+     * We perform the conversion by a
+     *
+     * Notes:
+     *  > https://spark.apache.org/docs/2.3.0/api/sql/index.html#date_add
+     *  > https://spark.apache.org/docs/latest/api/java/org/apache/spark/sql/functions.html#date_add(org.apache.spark.sql.Column,int)
+     *  > https://spark.apache.org/docs/latest/api/java/org/apache/spark/sql/functions.html#add_months(org.apache.spark.sql.Column,int)
+     *  > The number of days to can be negative to subtract days
+     */
+    @OptIn(PartiQLValueExperimental::class)
+    override fun dateAdd(part: DatetimeField, args: SqlArgs): Expr {
+        var quantity = args[0].expr
+        var date = args[1].expr
+        var parts = arrayOfNulls<Expr>(7)
+        when (part) {
+            DatetimeField.YEAR -> parts[0] = quantity
+            DatetimeField.MONTH -> parts[1] = quantity
+            // skip weeks
+            DatetimeField.DAY -> parts[3] = quantity
+            DatetimeField.HOUR -> parts[4] = quantity
+            DatetimeField.MINUTE -> parts[5] = quantity
+            DatetimeField.SECOND -> parts[6] = quantity
+            else -> error("Unexpected datetime part `$part`")
+        }
+        val interval = exprCall(id("make_interval"), parts.map { it ?:  exprLit(int32Value(0)) })
+
+        // Add detailed warning about this translation.
+        val intervalString = parts.joinToString(
+            prefix = "make_interval(",
+            postfix = ")",
+            separator = ", "
+        ) {
+           if (it != null) "<quantity>" else "0"
+        }
+        log.warn("PartiQL `date_add($part, <quantity>, <date>)` was replaced by Spark `<date> + $intervalString`.")
+
+        return exprBinary(
+            op = Expr.Binary.Op.PLUS,
+            lhs = date,
+            rhs = interval,
+        )
+    }
+
+    /**
+     * PartiQL's date_diff accepts a part whereas Spark's datediff returns the difference in days.
+     *
+     * We extract the datetime part and perform the difference.
+     *
+     * Notes:
+     *  > https://github.com/partiql/partiql-lang-kotlin/wiki/Functions#date_diff----since-v010
+     *  > https://spark.apache.org/docs/latest/api/java/org/apache/spark/sql/functions.html#datediff(org.apache.spark.sql.Column,org.apache.spark.sql.Column)
+     *  > https://spark.apache.org/docs/2.3.0/api/sql/index.html#datediff
+     */
+    @OptIn(PartiQLValueExperimental::class)
+    override fun dateDiff(part: DatetimeField, args: SqlArgs): Expr {
+        val extract = when (part) {
+            DatetimeField.YEAR -> "year"
+            DatetimeField.MONTH -> "month"
+            DatetimeField.DAY -> "day"
+            DatetimeField.HOUR -> "hour"
+            DatetimeField.MINUTE -> "minute"
+            DatetimeField.SECOND -> "second"
+            else -> error("Unexpected datetime part `$part`")
+        }
+        val d1 = exprCall(id(extract), listOf(args[0].expr))
+        val d2 = exprCall(id(extract), listOf(args[1].expr))
+        return exprBinary(
+            op = Expr.Binary.Op.PLUS,
+            lhs = d2,
+            rhs = d1,
+        )
     }
 }

--- a/src/main/kotlin/org/partiql/scribe/targets/spark/SparkCalls.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/spark/SparkCalls.kt
@@ -117,7 +117,7 @@ public open class SparkCalls(private val log: ProblemCallback) : SqlCalls() {
     }
 
     /**
-     * PartiQL's date_diff accepts a part whereas Spark's datediff returns the difference in days.
+     * PartiQL's date_diff accepts a part whereas Spark's date_diff returns the difference in days between two dates.
      *
      * We extract the datetime part and perform the difference.
      *
@@ -126,7 +126,6 @@ public open class SparkCalls(private val log: ProblemCallback) : SqlCalls() {
      *  > https://spark.apache.org/docs/latest/api/java/org/apache/spark/sql/functions.html#datediff(org.apache.spark.sql.Column,org.apache.spark.sql.Column)
      *  > https://spark.apache.org/docs/2.3.0/api/sql/index.html#datediff
      */
-    @OptIn(PartiQLValueExperimental::class)
     override fun dateDiff(part: DatetimeField, args: SqlArgs): Expr {
         val extract = when (part) {
             DatetimeField.YEAR -> "year"

--- a/src/main/kotlin/org/partiql/scribe/targets/spark/SparkCalls.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/spark/SparkCalls.kt
@@ -107,7 +107,7 @@ public open class SparkCalls(private val log: ProblemCallback) : SqlCalls() {
         ) {
            if (it != null) "<quantity>" else "0"
         }
-        log.warn("PartiQL `date_add($part, <quantity>, <date>)` was replaced by Spark `<date> + $intervalString`.")
+        log.info("PartiQL `date_add($part, <quantity>, <date>)` was replaced by Spark `<date> + $intervalString`.")
 
         return exprBinary(
             op = Expr.Binary.Op.PLUS,
@@ -137,6 +137,7 @@ public open class SparkCalls(private val log: ProblemCallback) : SqlCalls() {
             DatetimeField.SECOND -> "second"
             else -> error("Unexpected datetime part `$part`")
         }
+        log.info("PartiQL `date_diff($part, <date_1>, <date_2>)` was replaced by Spark `$extract(<date_2>) - $extract(<date_1>)`.")
         val d1 = exprCall(id(extract), listOf(args[0].expr))
         val d2 = exprCall(id(extract), listOf(args[1].expr))
         return exprBinary(

--- a/src/main/kotlin/org/partiql/scribe/targets/spark/SparkCalls.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/spark/SparkCalls.kt
@@ -140,7 +140,7 @@ public open class SparkCalls(private val log: ProblemCallback) : SqlCalls() {
         val d1 = exprCall(id(extract), listOf(args[0].expr))
         val d2 = exprCall(id(extract), listOf(args[1].expr))
         return exprBinary(
-            op = Expr.Binary.Op.PLUS,
+            op = Expr.Binary.Op.MINUS,
             lhs = d2,
             rhs = d1,
         )

--- a/src/test/resources/catalogs/default/T.ion
+++ b/src/test/resources/catalogs/default/T.ion
@@ -49,7 +49,15 @@
       {
         name: "v",
         type: "string",
-      }
+      },
+      {
+        name: "timestamp_1",
+        type: "timestamp",
+      },
+      {
+        name: "timestamp_2",
+        type: "timestamp",
+      },
     ]
   }
 }

--- a/src/test/resources/inputs/builtins/datetime.sql
+++ b/src/test/resources/inputs/builtins/datetime.sql
@@ -44,4 +44,22 @@ SELECT DATE_ADD(MONTH, 5, CURRENT_DATE) FROM T;
 SELECT DATE_ADD(YEAR, 5, CURRENT_DATE) FROM T;
 
 --#[datetime-15]
-SELECT DATE_DIFF(DAY, CURRENT_DATE, CURRENT_DATE) FROM T;
+SELECT DATE_DIFF(DAY, timestamp_1, timestamp_2) FROM T;
+
+--#[datetime-15]
+SELECT DATE_DIFF(YEAR, timestamp_1, timestamp_2) FROM T;
+
+--#[datetime-16]
+SELECT DATE_DIFF(MONTH, timestamp_1, timestamp_2) FROM T;
+
+--#[datetime-17]
+SELECT DATE_DIFF(DAY, timestamp_1, timestamp_2) FROM T;
+
+--#[datetime-18]
+SELECT DATE_DIFF(HOUR, timestamp_1, timestamp_2) FROM T;
+
+--#[datetime-19]
+SELECT DATE_DIFF(MINUTE, timestamp_1, timestamp_2) FROM T;
+
+--#[datetime-20]
+SELECT DATE_DIFF(SECOND, timestamp_1, timestamp_2) FROM T;

--- a/src/test/resources/inputs/builtins/datetime.sql
+++ b/src/test/resources/inputs/builtins/datetime.sql
@@ -44,9 +44,6 @@ SELECT DATE_ADD(MONTH, 5, CURRENT_DATE) FROM T;
 SELECT DATE_ADD(YEAR, 5, CURRENT_DATE) FROM T;
 
 --#[datetime-15]
-SELECT DATE_DIFF(DAY, timestamp_1, timestamp_2) FROM T;
-
---#[datetime-15]
 SELECT DATE_DIFF(YEAR, timestamp_1, timestamp_2) FROM T;
 
 --#[datetime-16]

--- a/src/test/resources/outputs/partiql/builtins/datetime.sql
+++ b/src/test/resources/outputs/partiql/builtins/datetime.sql
@@ -44,4 +44,19 @@ SELECT DATE_ADD(MONTH, 5, CURRENT_DATE) AS "_1" FROM "default"."T" AS "T";
 SELECT DATE_ADD(YEAR, 5, CURRENT_DATE) AS "_1" FROM "default"."T" AS "T";
 
 --#[datetime-15]
-SELECT DATE_DIFF(DAY, CURRENT_DATE, CURRENT_DATE) AS "_1" FROM "default"."T" AS "T";
+SELECT DATE_DIFF(YEAR, "T"['timestamp_1'], "T"['timestamp_2']) AS "_1" FROM "default"."T" AS "T";
+
+--#[datetime-16]
+SELECT DATE_DIFF(MONTH, "T"['timestamp_1'], "T"['timestamp_2']) AS "_1" FROM "default"."T" AS "T";
+
+--#[datetime-17]
+SELECT DATE_DIFF(DAY, "T"['timestamp_1'], "T"['timestamp_2']) AS "_1" FROM "default"."T" AS "T";
+
+--#[datetime-18]
+SELECT DATE_DIFF(HOUR, "T"['timestamp_1'], "T"['timestamp_2']) AS "_1" FROM "default"."T" AS "T";
+
+--#[datetime-19]
+SELECT DATE_DIFF(MINUTE, "T"['timestamp_1'], "T"['timestamp_2']) AS "_1" FROM "default"."T" AS "T";
+
+--#[datetime-20]
+SELECT DATE_DIFF(SECOND, "T"['timestamp_1'], "T"['timestamp_2']) AS "_1" FROM "default"."T" AS "T";

--- a/src/test/resources/outputs/redshift/builtins/datetime.sql
+++ b/src/test/resources/outputs/redshift/builtins/datetime.sql
@@ -22,4 +22,19 @@ SELECT DATEADD(MONTH, 5, CURRENT_DATE) AS "_1" FROM "default"."T" AS "T";
 SELECT DATEADD(YEAR, 5, CURRENT_DATE) AS "_1" FROM "default"."T" AS "T";
 
 --#[datetime-15]
-SELECT DATEDIFF(DAY, CURRENT_DATE, CURRENT_DATE) AS "_1" FROM "default"."T" AS "T";
+SELECT DATEDIFF(YEAR, "T"."timestamp_1", "T"."timestamp_2") AS "_1" FROM "default"."T" AS "T";
+
+--#[datetime-16]
+SELECT DATEDIFF(MONTH, "T"."timestamp_1", "T"."timestamp_2") AS "_1" FROM "default"."T" AS "T";
+
+--#[datetime-17]
+SELECT DATEDIFF(DAY, "T"."timestamp_1", "T"."timestamp_2") AS "_1" FROM "default"."T" AS "T";
+
+--#[datetime-18]
+SELECT DATEDIFF(HOUR, "T"."timestamp_1", "T"."timestamp_2") AS "_1" FROM "default"."T" AS "T";
+
+--#[datetime-19]
+SELECT DATEDIFF(MINUTE, "T"."timestamp_1", "T"."timestamp_2") AS "_1" FROM "default"."T" AS "T";
+
+--#[datetime-20]
+SELECT DATEDIFF(SECOND, "T"."timestamp_1", "T"."timestamp_2") AS "_1" FROM "default"."T" AS "T";

--- a/src/test/resources/outputs/spark/builtins/builtins.sql
+++ b/src/test/resources/outputs/spark/builtins/builtins.sql
@@ -1,0 +1,38 @@
+--#[datetime-08]
+SELECT CURRENT_DATE AS `CURRENT_DATE` FROM `default`.`T` AS `T`;
+
+--#[datetime-09]
+SELECT CURRENT_DATE + `make_interval`(0, 0, 0, 0, 0, 0, 5) AS `_1` FROM `default`.`T` AS `T`;
+
+--#[datetime-10]
+SELECT CURRENT_DATE + `make_interval`(0, 0, 0, 0, 0, 5, 0) AS `_1` FROM `default`.`T` AS `T`;
+
+--#[datetime-11]
+SELECT CURRENT_DATE + `make_interval`(0, 0, 0, 0, 5, 0, 0) AS `_1` FROM `default`.`T` AS `T`;
+
+--#[datetime-12]
+SELECT CURRENT_DATE + `make_interval`(0, 0, 0, 5, 0, 0, 0) AS `_1` FROM `default`.`T` AS `T`;
+
+--#[datetime-13]
+SELECT CURRENT_DATE + `make_interval`(0, 5, 0, 0, 0, 0, 0) AS `_1` FROM `default`.`T` AS `T`;
+
+--#[datetime-14]
+SELECT CURRENT_DATE + `make_interval`(5, 0, 0, 0, 0, 0, 0) AS `_1` FROM `default`.`T` AS `T`;
+
+--#[datetime-15]
+SELECT `year`(`T`.`timestamp_2`) - `year`(`T`.`timestamp_1`) AS `_1` FROM `default`.`T` AS `T`;
+
+--#[datetime-16]
+SELECT `month`(`T`.`timestamp_2`) - `month`(`T`.`timestamp_1`) AS `_1` FROM `default`.`T` AS `T`;
+
+--#[datetime-17]
+SELECT `day`(`T`.`timestamp_2`) - `day`(`T`.`timestamp_1`) AS `_1` FROM `default`.`T` AS `T`;
+
+--#[datetime-18]
+SELECT `hour`(`T`.`timestamp_2`) - `hour`(`T`.`timestamp_1`) AS `_1` FROM `default`.`T` AS `T`;
+
+--#[datetime-19]
+SELECT `minute`(`T`.`timestamp_2`) - `minute`(`T`.`timestamp_1`) AS `_1` FROM `default`.`T` AS `T`;
+
+--#[datetime-20]
+SELECT `second`(`T`.`timestamp_2`) - `second`(`T`.`timestamp_1`) AS `_1` FROM `default`.`T` AS `T`;

--- a/src/test/resources/outputs/trino/builtins/datetime.sql
+++ b/src/test/resources/outputs/trino/builtins/datetime.sql
@@ -19,5 +19,21 @@ SELECT date_add('month', 5, current_date) AS "_1" FROM "default"."T" AS "T";
 --#[datetime-14]
 SELECT date_add('year', 5, current_date) AS "_1" FROM "default"."T" AS "T";
 
+
 --#[datetime-15]
-SELECT date_diff('day', current_date, current_date) AS "_1" FROM "default"."T" AS "T";
+SELECT date_diff('year', "T"."timestamp_1", "T"."timestamp_2") AS "_1" FROM "default"."T" AS "T";
+
+--#[datetime-16]
+SELECT date_diff('month', "T"."timestamp_1", "T"."timestamp_2") AS "_1" FROM "default"."T" AS "T";
+
+--#[datetime-17]
+SELECT date_diff('day', "T"."timestamp_1", "T"."timestamp_2") AS "_1" FROM "default"."T" AS "T";
+
+--#[datetime-18]
+SELECT date_diff('hour', "T"."timestamp_1", "T"."timestamp_2") AS "_1" FROM "default"."T" AS "T";
+
+--#[datetime-19]
+SELECT date_diff('minute', "T"."timestamp_1", "T"."timestamp_2") AS "_1" FROM "default"."T" AS "T";
+
+--#[datetime-20]
+SELECT date_diff('second', "T"."timestamp_1", "T"."timestamp_2") AS "_1" FROM "default"."T" AS "T";


### PR DESCRIPTION
### **date_add**

**Translation**

```
-- partiql
date_add(<part>, <quantity>, <date>)

-- spark
<date> + <interval>
```

**Notes**

The PartiQL date_add is similar to Redshift and Trino’s in which it accepts a datetime part and a quantity. For example, `date_add(months, 2, date)` would add two months to the `date`. Spark only allows adding *days* which means we may need to translate adding years and months; however, this is problematic because of situations like below:

I’ve left out the time part of the timestamp.

* `date_add(month, 1, CAST('2024-01-31' AS TIMESTAMP))`
    * PartiQL → `'2024-02-29'`
    * Trino → `'2024-02-29'`
    * Redshift → `'2024-02-29'`
* `date_add(day, 30, CAST('2024-01-31' AS TIMESTAMP))`
    * PartiQL → `'2024-03-01'`
    * Trino →  `'2024-03-01'`
    * Redshift → `'2024-03-01'`


**Choices**


1. We only allowing adding the `DAYS` datetime part as this is the safest.
2. We make a year = 365 days and a month = 30 days. This can result in errors because a year is 365.25 and a month varies.
3. **CHOSEN: We can do `timestamp  + interval` which allows us to support the PartiQL datetime parts. No obvious drawbacks except perhaps undocumented edge cases?**


**References**

* https://spark.apache.org/docs/2.3.0/api/sql/index.html#date_add
* https://spark.apache.org/docs/latest/api/java/org/apache/spark/sql/functions.html#date_add(org.apache.spark.sql.Column,int)
* https://rawgit.com/rstudio/cheatsheets/main/lubridate.pdf



### **date_diff**

**Translation**

```
-- partiql
date_diff(<part>, <d1>, <d2>)

-- spark
<part>(<d2>) - <part>(<d1>)
```


**Notes**

The PartiQL date_diff, given a datetime part and two valid timestamps, returns the difference in datetime parts. 
 On the other hand, Spark’s datediff does not accept a datetime part, and only returns the difference in days.

**Choices**

* **CHOSEN: Extract the datetime part and perform the difference.**
* Only support day and month parts with datediff and months_between


**References**

* https://github.com/partiql/partiql-lang-kotlin/wiki/Functions#date_diff----since-v010
* https://spark.apache.org/docs/latest/api/java/org/apache/spark/sql/functions.html#datediff(org.apache.spark.sql.Column,org.apache.spark.sql.Column)
* https://spark.apache.org/docs/2.3.0/api/sql/index.html#datediff



























By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
