### PR TITLE
Fix STRING CASTs for Redshift and Trino dialects

### DIFF
--- a/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftDialect.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftDialect.kt
@@ -4,6 +4,7 @@ import org.partiql.ast.AstNode
 import org.partiql.ast.Expr
 import org.partiql.ast.Identifier
 import org.partiql.ast.Select
+import org.partiql.ast.Type
 import org.partiql.ast.exprPathStepSymbol
 import org.partiql.ast.identifierSymbol
 import org.partiql.scribe.sql.SqlBlock
@@ -58,6 +59,8 @@ public open class RedshiftDialect : SqlDialect() {
         t = visitExprWrapped(node.value, t)
         return t
     }
+
+    override fun visitTypeString(node: Type.String, tail: SqlBlock): SqlBlock = tail concat "VARCHAR"
 
     private fun list(
         start: String? = "(",

--- a/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoDialect.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoDialect.kt
@@ -99,6 +99,8 @@ public open class TrinoDialect : SqlDialect() {
 
     override fun visitTypeInt8(node: Type.Int8, tail: SqlBlock): SqlBlock = tail concat "BIGINT"
 
+    override fun visitTypeString(node: Type.String, tail: SqlBlock): SqlBlock = tail concat "VARCHAR"
+
     private fun list(
         start: String? = "(",
         end: String? = ")",

--- a/src/test/resources/inputs/operators/cast.sql
+++ b/src/test/resources/inputs/operators/cast.sql
@@ -1,2 +1,5 @@
 --#[cast-00]
 CAST('1' AS INT4);
+
+--#[cast-01]
+SELECT CAST('foo' AS STRING) AS s FROM T;

--- a/src/test/resources/outputs/partiql/operators/cast.sql
+++ b/src/test/resources/outputs/partiql/operators/cast.sql
@@ -1,0 +1,5 @@
+--#[cast-00]
+CAST('1' AS INT4);
+
+--#[cast-01]
+SELECT CAST('foo' AS STRING) AS "s" FROM "default"."T" AS "T";

--- a/src/test/resources/outputs/redshift/operators/cast.sql
+++ b/src/test/resources/outputs/redshift/operators/cast.sql
@@ -1,0 +1,5 @@
+--#[cast-00]
+CAST('1' AS INT4);
+
+--#[cast-01]
+SELECT CAST('foo' AS VARCHAR) AS "s" FROM "default"."T" AS "T";

--- a/src/test/resources/outputs/spark/operators/cast.sql
+++ b/src/test/resources/outputs/spark/operators/cast.sql
@@ -1,0 +1,5 @@
+----#[cast-00]
+--CAST('1' AS INT4);
+
+--#[cast-01]
+SELECT CAST('foo' AS STRING) AS `s` FROM `default`.`T` AS `T`;

--- a/src/test/resources/outputs/trino/operators/cast.sql
+++ b/src/test/resources/outputs/trino/operators/cast.sql
@@ -1,0 +1,5 @@
+----#[cast-00]
+--CAST('1' AS INT4);
+
+--#[cast-01]
+SELECT CAST('foo' AS VARCHAR) AS "s" FROM "default"."T" AS "T";


### PR DESCRIPTION
Redshift and Spark don't support the `STRING` type:
- https://trino.io/docs/current/language/types.html#string
- https://docs.aws.amazon.com/redshift/latest/dg/c_Supported_data_types.html

The equivalents seem to be `VARCHAR` for both dialects. This PR adds the override for the `STRING` type printing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
