### PR TITLE
Upgrades Scribe to PartiQL 0.14.5

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ object Versions {
     const val jline = "3.21.0"
     const val junit5 = "5.9.3"
     const val picoCli = "4.7.0"
-    const val partiql = "0.14.4"
+    const val partiql = "0.14.5"
 }
 
 object Deps {

--- a/src/main/kotlin/org/partiql/scribe/sql/RexConverter.kt
+++ b/src/main/kotlin/org/partiql/scribe/sql/RexConverter.kt
@@ -7,7 +7,9 @@ import org.partiql.ast.SetQuantifier
 import org.partiql.ast.exprCall
 import org.partiql.ast.exprCase
 import org.partiql.ast.exprCaseBranch
+import org.partiql.ast.exprCoalesce
 import org.partiql.ast.exprLit
+import org.partiql.ast.exprNullIf
 import org.partiql.ast.exprPath
 import org.partiql.ast.exprPathStepIndex
 import org.partiql.ast.exprPathStepSymbol
@@ -170,6 +172,17 @@ public open class RexConverter(
             true -> default
             false -> exprCase(expr = null, branches = branches, default = default)
         }
+    }
+
+    override fun visitRexOpNullif(node: Rex.Op.Nullif, ctx: StaticType): Expr {
+        val value = visitRex(node.value, StaticType.ANY)
+        val nullifier = visitRex(node.nullifier, StaticType.ANY)
+        return exprNullIf(value, nullifier)
+    }
+
+    override fun visitRexOpCoalesce(node: Rex.Op.Coalesce, ctx: StaticType): Expr {
+        val args = node.args.map { visitRex(it, it.type) }
+        return exprCoalesce(args)
     }
 
     override fun visitRexOpCall(node: Rex.Op.Call, ctx: StaticType): Expr {

--- a/src/main/kotlin/org/partiql/scribe/sql/SqlTarget.kt
+++ b/src/main/kotlin/org/partiql/scribe/sql/SqlTarget.kt
@@ -1,20 +1,11 @@
 package org.partiql.scribe.sql
 
 import org.partiql.ast.AstNode
-import org.partiql.ast.Expr
-import org.partiql.ast.Type
-import org.partiql.ast.exprCase
-import org.partiql.ast.exprCoalesce
-import org.partiql.ast.exprLit
-import org.partiql.ast.exprNullIf
-import org.partiql.ast.util.AstRewriter
 import org.partiql.plan.PartiQLPlan
 import org.partiql.scribe.ProblemCallback
 import org.partiql.scribe.ScribeOutput
 import org.partiql.scribe.ScribeTarget
 import org.partiql.types.StaticType
-import org.partiql.value.PartiQLValueExperimental
-import org.partiql.value.nullValue
 import org.partiql.plan.Statement as PlanStatement
 
 public class SqlOutput(schema: StaticType, value: String) : ScribeOutput<String>(schema, value) {
@@ -75,84 +66,12 @@ public abstract class SqlTarget : ScribeTarget<String> {
         return SqlOutput(schema, sql)
     }
 
-    private class CaseWhenRewriter: AstRewriter<Unit>() {
-        @OptIn(PartiQLValueExperimental::class)
-        private fun isNullIf(caseWhen: Expr.Case): Boolean {
-            val branches = caseWhen.branches
-            val default = caseWhen.default
-
-            if (default == null) {
-                return false
-            }
-            if (branches.size != 1) {
-                return false
-            }
-            val v1 = branches.first()
-            if (v1.expr != exprLit(nullValue())) {
-                if (v1.expr is Expr.Cast && (v1.expr as Expr.Cast).value == exprLit(nullValue())) {
-                    // continue TODO figure out if this cast addition is necessary
-                } else {
-                    return false
-                }
-            }
-            val v1When = v1.condition
-            if (v1When is Expr.Binary && v1When.op == Expr.Binary.Op.EQ) {
-                if (v1When.lhs == default) {
-                    return true
-                }
-            }
-            return false
-        }
-
-        private fun isCoalesce(caseWhen: Expr.Case): Boolean {
-            return caseWhen.branches.all { branch ->
-                val whenExpr = branch.condition
-                val thenExpr = branch.expr
-                if (whenExpr is Expr.Unary && whenExpr.op == Expr.Unary.Op.NOT) {
-                    val innerExpr = whenExpr.expr
-                    if (innerExpr is Expr.IsType && innerExpr.type == Type.NullType()) {
-                        return@all innerExpr.value == thenExpr || innerExpr.value == (thenExpr as Expr.Cast).value
-                    }
-                } else if (whenExpr is Expr.IsType && whenExpr.type == Type.NullType() && whenExpr.not == true) {
-                    // Redshift constant folds NOT IS TYPE to IS NOT TYPE
-                    val innerExpr = whenExpr.value
-                    return@all whenExpr.value == thenExpr || innerExpr == (thenExpr as Expr.Cast).value
-                }
-                false
-            }
-        }
-
-        @OptIn(PartiQLValueExperimental::class)
-        override fun visitExprCase(node: Expr.Case, ctx: Unit): AstNode {
-            val case = super.visitExprCase(node, ctx) as Expr.Case
-            val branches = case.branches
-            val default = case.default ?: exprLit(nullValue())
-            val caseWhen = when (branches.isEmpty()) {
-                true -> default
-                false -> {
-                    if (isCoalesce(case)) { // rewrite back into coalesce
-                        val exprs = branches.map {
-                            it.expr
-                        }
-                        exprCoalesce(exprs)
-                    } else if (isNullIf(case)) {  // rewrite back into nullif
-                        val equality = (branches.first().condition) as Expr.Binary
-                        exprNullIf(equality.lhs, equality.rhs)
-                    } else {
-                        exprCase(expr = null, branches = branches, default = default)
-                    }
-                }
-            }
-            return caseWhen
-        }
-    }
-
     /**
      * Default Plan to AST translation. This method is only for potential edge cases
      */
     open fun unplan(plan: PartiQLPlan, onProblem: ProblemCallback): AstNode {
         val transform = SqlTransform(plan.catalogs, getCalls(onProblem), onProblem)
         val statement = transform.apply(plan.statement)
-        return CaseWhenRewriter().visitStatement(statement, Unit)
+        return statement
     }
 }

--- a/src/main/kotlin/org/partiql/scribe/sql/rewriters/CaseWhenRewrite.kt
+++ b/src/main/kotlin/org/partiql/scribe/sql/rewriters/CaseWhenRewrite.kt
@@ -1,0 +1,93 @@
+package org.partiql.scribe.sql.rewriters
+
+import org.partiql.ast.AstNode
+import org.partiql.ast.Expr
+import org.partiql.ast.Type
+import org.partiql.ast.exprCase
+import org.partiql.ast.exprCoalesce
+import org.partiql.ast.exprLit
+import org.partiql.ast.exprNullIf
+import org.partiql.ast.util.AstRewriter
+import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.nullValue
+
+/**
+ * The RewriteCaseWhen is able to reduce certain CASE-WHEN identities to a simpler COALESCE or NULLIF when applicable.
+ */
+internal object RewriteCaseWhen : Rewriter {
+
+    override fun apply(ast: AstNode): AstNode = ast.accept(Visitor(), Unit)
+
+    private class Visitor : AstRewriter<Unit>() {
+
+        @OptIn(PartiQLValueExperimental::class)
+        private fun isNullIf(caseWhen: Expr.Case): Boolean {
+            val branches = caseWhen.branches
+            val default = caseWhen.default
+
+            if (default == null) {
+                return false
+            }
+            if (branches.size != 1) {
+                return false
+            }
+            val v1 = branches.first()
+            if (v1.expr != exprLit(nullValue())) {
+                if (v1.expr is Expr.Cast && (v1.expr as Expr.Cast).value == exprLit(nullValue())) {
+                    // continue TODO figure out if this cast addition is necessary
+                } else {
+                    return false
+                }
+            }
+            val v1When = v1.condition
+            if (v1When is Expr.Binary && v1When.op == Expr.Binary.Op.EQ) {
+                if (v1When.lhs == default) {
+                    return true
+                }
+            }
+            return false
+        }
+
+        private fun isCoalesce(caseWhen: Expr.Case): Boolean {
+            return caseWhen.branches.all { branch ->
+                val whenExpr = branch.condition
+                val thenExpr = branch.expr
+                if (whenExpr is Expr.Unary && whenExpr.op == Expr.Unary.Op.NOT) {
+                    val innerExpr = whenExpr.expr
+                    if (innerExpr is Expr.IsType && innerExpr.type == Type.NullType()) {
+                        return@all innerExpr.value == thenExpr || innerExpr.value == (thenExpr as Expr.Cast).value
+                    }
+                } else if (whenExpr is Expr.IsType && whenExpr.type == Type.NullType() && whenExpr.not == true) {
+                    // Redshift constant folds NOT IS TYPE to IS NOT TYPE
+                    val innerExpr = whenExpr.value
+                    return@all whenExpr.value == thenExpr || innerExpr == (thenExpr as Expr.Cast).value
+                }
+                false
+            }
+        }
+
+        @OptIn(PartiQLValueExperimental::class)
+        override fun visitExprCase(node: Expr.Case, ctx: Unit): AstNode {
+            val case = super.visitExprCase(node, ctx) as Expr.Case
+            val branches = case.branches
+            val default = case.default ?: exprLit(nullValue())
+            val caseWhen = when (branches.isEmpty()) {
+                true -> default
+                false -> {
+                    if (isCoalesce(case)) { // rewrite back into coalesce
+                        val exprs = branches.map {
+                            it.expr
+                        }
+                        exprCoalesce(exprs)
+                    } else if (isNullIf(case)) {  // rewrite back into nullif
+                        val equality = (branches.first().condition) as Expr.Binary
+                        exprNullIf(equality.lhs, equality.rhs)
+                    } else {
+                        exprCase(expr = null, branches = branches, default = default)
+                    }
+                }
+            }
+            return caseWhen
+        }
+    }
+}

--- a/src/main/kotlin/org/partiql/scribe/sql/rewriters/Rewriter.kt
+++ b/src/main/kotlin/org/partiql/scribe/sql/rewriters/Rewriter.kt
@@ -1,0 +1,9 @@
+package org.partiql.scribe.sql.rewriters
+
+import org.partiql.ast.AstNode
+
+internal interface Rewriter {
+
+    fun apply(ast: AstNode): AstNode
+
+}

--- a/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftFeatures.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftFeatures.kt
@@ -34,6 +34,8 @@ public open class RedshiftFeatures : SqlFeatures.Defensive() {
         Rex.Op.Call.Static::class.java,
         Rex.Op.Case::class.java,
         Rex.Op.Case.Branch::class.java,
+        Rex.Op.Coalesce::class.java,
+        Rex.Op.Nullif::class.java,
         Rex.Op.Collection::class.java,
         Rex.Op.Global::class.java,
         Rex.Op.Lit::class.java,

--- a/src/main/kotlin/org/partiql/scribe/targets/spark/SparkFeatures.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/spark/SparkFeatures.kt
@@ -29,6 +29,8 @@ public open class SparkFeatures : SqlFeatures.Defensive() {
         Rex.Op.Call.Static::class.java,
         Rex.Op.Case::class.java,
         Rex.Op.Case.Branch::class.java,
+        Rex.Op.Coalesce::class.java,
+        Rex.Op.Nullif::class.java,
         Rex.Op.Collection::class.java,
         Rex.Op.Global::class.java,
         Rex.Op.Lit::class.java,

--- a/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoFeatures.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoFeatures.kt
@@ -34,6 +34,8 @@ public open class TrinoFeatures : SqlFeatures.Defensive() {
         Rex.Op.Call.Static::class.java,
         Rex.Op.Case::class.java,
         Rex.Op.Case.Branch::class.java,
+        Rex.Op.Coalesce::class.java,
+        Rex.Op.Nullif::class.java,
         Rex.Op.Collection::class.java,
         Rex.Op.Global::class.java,
         Rex.Op.Lit::class.java,


### PR DESCRIPTION
*Description of changes:*

This adds the translation for the COALESCE and NULLIF plan nodes which were added to PartiQL 0.14.5. I moved the rewriter to its own internal package as it is not necessarily needed now. I think, as we improve scribe, we can include more rewrites like this one.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
