### PR TITLE
Uses INT and BIGINT as default 32-bit and 64-bit integer names

### DIFF
--- a/src/main/kotlin/org/partiql/scribe/sql/SqlCalls.kt
+++ b/src/main/kotlin/org/partiql/scribe/sql/SqlCalls.kt
@@ -16,6 +16,7 @@ import org.partiql.ast.exprUnary
 import org.partiql.ast.identifierSymbol
 import org.partiql.ast.typeAny
 import org.partiql.ast.typeBag
+import org.partiql.ast.typeBigint
 import org.partiql.ast.typeBlob
 import org.partiql.ast.typeBool
 import org.partiql.ast.typeChar
@@ -33,6 +34,7 @@ import org.partiql.ast.typeList
 import org.partiql.ast.typeMissing
 import org.partiql.ast.typeNullType
 import org.partiql.ast.typeSexp
+import org.partiql.ast.typeSmallint
 import org.partiql.ast.typeString
 import org.partiql.ast.typeStruct
 import org.partiql.ast.typeSymbol
@@ -287,9 +289,9 @@ public abstract class SqlCalls {
             PartiQLValueType.ANY -> typeAny()
             PartiQLValueType.BOOL -> typeBool()
             PartiQLValueType.INT8 -> typeInt()
-            PartiQLValueType.INT16 -> typeInt2()
-            PartiQLValueType.INT32 -> typeInt4()
-            PartiQLValueType.INT64 -> typeInt8()
+            PartiQLValueType.INT16 -> typeSmallint()
+            PartiQLValueType.INT32 -> typeInt()
+            PartiQLValueType.INT64 -> typeBigint()
             PartiQLValueType.INT -> typeInt()
             PartiQLValueType.DECIMAL_ARBITRARY -> typeDecimal(null, null)
             PartiQLValueType.DECIMAL -> typeDecimal(null, null)
@@ -327,9 +329,9 @@ public abstract class SqlCalls {
             PartiQLValueType.ANY -> typeAny()
             PartiQLValueType.BOOL -> typeBool()
             PartiQLValueType.INT8 -> error("unsupported")
-            PartiQLValueType.INT16 -> typeInt2()
-            PartiQLValueType.INT32 -> typeInt4()
-            PartiQLValueType.INT64 -> typeInt8()
+            PartiQLValueType.INT16 -> typeSmallint()
+            PartiQLValueType.INT32 -> typeInt()
+            PartiQLValueType.INT64 -> typeBigint()
             PartiQLValueType.INT -> typeInt()
             PartiQLValueType.DECIMAL_ARBITRARY -> typeDecimal(null, null)
             PartiQLValueType.DECIMAL -> typeDecimal(typeArg0?.toInt(), typeArg1?.toInt())

--- a/src/test/resources/inputs/operators/cast.sql
+++ b/src/test/resources/inputs/operators/cast.sql
@@ -1,5 +1,11 @@
 --#[cast-00]
-CAST('1' AS INT4);
+CAST('1' AS INT);
 
 --#[cast-01]
-SELECT CAST('foo' AS STRING) AS s FROM T;
+CAST('1' AS INT4);
+
+--#[cast-02]
+CAST('1' AS INT8);
+
+--#[cast-03]
+CAST('1' AS BIGINT);

--- a/src/test/resources/outputs/partiql/basics/simple.sql
+++ b/src/test/resources/outputs/partiql/basics/simple.sql
@@ -77,22 +77,26 @@ NOT ("default"."T1" IS NULL);
 NOT ("default"."T1" IS MISSING);
 
 --#[expr-14]
-"default"."T1" IS INT2;
+"default"."T1" IS SMALLINT;
 
 --#[expr-15]
-NOT ("default"."T1" IS INT2);
+NOT ("default"."T1" IS SMALLINT);
 
 --#[expr-16]
-"default"."T1" IS INT4;
+-- TODO USE INT as the default INT4 name.
+"default"."T1" IS INT;
 
 --#[expr-17]
-NOT ("default"."T1" IS INT4);
+-- TODO USE INT as the default INT4 name.
+NOT ("default"."T1" IS INT);
 
 --#[expr-18]
-"default"."T1" IS INT8;
+-- TODO USE BIGINT as the default BIGINT/INT8 name.
+"default"."T1" IS BIGINT;
 
 --#[expr-19]
-NOT ("default"."T1" IS INT8);
+-- TODO USE BIGINT as the default BIGINT/INT8 name.
+NOT ("default"."T1" IS BIGINT);
 
 --#[expr-20]
 "default"."T1" IS INT;

--- a/src/test/resources/outputs/partiql/operators/cast.sql
+++ b/src/test/resources/outputs/partiql/operators/cast.sql
@@ -1,5 +1,11 @@
 --#[cast-00]
-CAST('1' AS INT4);
+CAST('1' AS INT);
 
 --#[cast-01]
-SELECT CAST('foo' AS STRING) AS "s" FROM "default"."T" AS "T";
+CAST('1' AS INT);
+
+--#[cast-02]
+CAST('1' AS BIGINT);
+
+--#[cast-03]
+CAST('1' AS BIGINT);

--- a/src/test/resources/outputs/redshift/operators/cast.sql
+++ b/src/test/resources/outputs/redshift/operators/cast.sql
@@ -1,5 +1,11 @@
 --#[cast-00]
-CAST('1' AS INT4);
+CAST('1' AS INT);
 
 --#[cast-01]
-SELECT CAST('foo' AS VARCHAR) AS "s" FROM "default"."T" AS "T";
+CAST('1' AS INT);
+
+--#[cast-02]
+CAST('1' AS BIGINT);
+
+--#[cast-03]
+CAST('1' AS BIGINT);

--- a/src/test/resources/outputs/spark/operators/cast.sql
+++ b/src/test/resources/outputs/spark/operators/cast.sql
@@ -1,5 +1,11 @@
-----#[cast-00]
---CAST('1' AS INT4);
+-- #[cast-00]
+-- SELECT CAST('1' AS INT);
 
---#[cast-01]
-SELECT CAST('foo' AS STRING) AS `s` FROM `default`.`T` AS `T`;
+-- #[cast-01]
+-- SELECT CAST('1' AS INT);
+
+-- #[cast-02]
+-- SELECT CAST('1' AS BIGINT);
+
+-- #[cast-03]
+-- SELECT CAST('1' AS BIGINT);

--- a/src/test/resources/outputs/trino/operators/cast.sql
+++ b/src/test/resources/outputs/trino/operators/cast.sql
@@ -1,5 +1,11 @@
-----#[cast-00]
---CAST('1' AS INT4);
+--#[cast-00]
+CAST('1' AS INT);
 
 --#[cast-01]
-SELECT CAST('foo' AS VARCHAR) AS "s" FROM "default"."T" AS "T";
+CAST('1' AS INT);
+
+--#[cast-02]
+CAST('1' AS BIGINT);
+
+--#[cast-03]
+CAST('1' AS BIGINT);


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/partiql/partiql-lang-kotlin/issues/1471 and #35 

*Description of changes:*

Scribe had been using INT4 and INT8 for the 32-bit and 64-bit integer names, but our target systems use INT and BIGINT respectively. This PR adds an AST workaround to alias INT to INT4, but then emits INT as the default name for INT/INT4.

Similarly, this PR updates AST output to use BIGINT as the default name rather than INT8.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
