### PR TITLE
Fix IN predicate to be SQL compatible.

### DIFF
--- a/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftDialect.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftDialect.kt
@@ -60,6 +60,13 @@ public open class RedshiftDialect : SqlDialect() {
         return t
     }
 
+    /**
+     * Use (...) syntax for ALL collections.
+     */
+    override fun visitExprCollection(node: Expr.Collection, tail: SqlBlock): SqlBlock {
+        return tail concat list { node.values }
+    }
+
     override fun visitTypeString(node: Type.String, tail: SqlBlock): SqlBlock = tail concat "VARCHAR"
 
     private fun list(

--- a/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftDialect.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftDialect.kt
@@ -61,10 +61,18 @@ public open class RedshiftDialect : SqlDialect() {
     }
 
     /**
-     * Use (...) syntax for ALL collections.
+     * - LIST   -> https://docs.aws.amazon.com/redshift/latest/dg/r_expression_lists.html
+     * - ARRAY  -> https://docs.aws.amazon.com/redshift/latest/dg/r_array.html
      */
     override fun visitExprCollection(node: Expr.Collection, tail: SqlBlock): SqlBlock {
-        return tail concat list { node.values }
+        val (start, end) = when (node.type) {
+            Expr.Collection.Type.ARRAY -> "ARRAY(" to ")"
+            Expr.Collection.Type.VALUES -> "VALUES (" to ")"
+            Expr.Collection.Type.SEXP,
+            Expr.Collection.Type.BAG,
+            Expr.Collection.Type.LIST -> "(" to ")"
+        }
+        return tail concat list(start, end) { node.values }
     }
 
     override fun visitTypeString(node: Type.String, tail: SqlBlock): SqlBlock = tail concat "VARCHAR"

--- a/src/main/kotlin/org/partiql/scribe/targets/spark/SparkCalls.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/spark/SparkCalls.kt
@@ -7,7 +7,6 @@ import org.partiql.ast.exprCall
 import org.partiql.ast.exprCast
 import org.partiql.ast.exprLit
 import org.partiql.ast.typeBigint
-import org.partiql.ast.typeInt
 import org.partiql.scribe.ProblemCallback
 import org.partiql.scribe.info
 import org.partiql.scribe.sql.SqlArg
@@ -35,7 +34,7 @@ public open class SparkCalls(private val log: ProblemCallback) : SqlCalls() {
         return exprCall(call, args.map { it.expr })
     }
 
-    private fun currentUser(sqlArgs: List<SqlArg>): Expr {
+    private fun currentUser(args: List<SqlArg>): Expr {
         val currentUser = id("current_user")
         log.info("PartiQL CURRENT_USER was replaced by Spark `current_user()`")
         return exprCall(currentUser, emptyList())
@@ -46,7 +45,7 @@ public open class SparkCalls(private val log: ProblemCallback) : SqlCalls() {
     // current_timestamp() : https://spark.apache.org/docs/latest/api/sql/index.html#current_timestamp
     // convert_timezone() : https://spark.apache.org/docs/latest/api/sql/index.html#convert_timezone
     @OptIn(PartiQLValueExperimental::class)
-    private fun utcnow(sqlArgs: List<SqlArg>): Expr {
+    private fun utcnow(args: List<SqlArg>): Expr {
         val convertTimeZone = id("convert_timezone")
         log.info("PartiQL `utcnow()` was replaced by Spark `convert_timezone('UTC', current_timestamp())`")
         val currentTimestamp = id("current_timestamp")
@@ -61,11 +60,11 @@ public open class SparkCalls(private val log: ProblemCallback) : SqlCalls() {
     // e.g. SELECT transform(array(1, 2, 3), x -> x + 1) outputs [2, 3, 4]
     // encode as `transform(<arrayExpr>, <elementVar>, <elementExpr>)`
     // which gets translated to `transform(<arrayExpr>, <elementVar> -> <elementExpr>)` in RexConverter
-    private fun transform(sqlArgs: List<SqlArg>): Expr {
+    private fun transform(args: List<SqlArg>): Expr {
         val fnName = id("transform")
-        val arrayExpr = sqlArgs[0].expr
-        val elementVar = sqlArgs[1].expr
-        val elementExpr = sqlArgs[2].expr
+        val arrayExpr = args[0].expr
+        val elementVar = args[1].expr
+        val elementExpr = args[2].expr
         return exprCall(fnName, listOf(arrayExpr, elementVar, elementExpr))
     }
 
@@ -83,9 +82,9 @@ public open class SparkCalls(private val log: ProblemCallback) : SqlCalls() {
      */
     @OptIn(PartiQLValueExperimental::class)
     override fun dateAdd(part: DatetimeField, args: SqlArgs): Expr {
-        var quantity = args[0].expr
-        var date = args[1].expr
-        var parts = arrayOfNulls<Expr>(7)
+        val quantity = args[0].expr
+        val date = args[1].expr
+        val parts = arrayOfNulls<Expr>(7)
         when (part) {
             DatetimeField.YEAR -> parts[0] = quantity
             DatetimeField.MONTH -> parts[1] = quantity

--- a/src/main/kotlin/org/partiql/scribe/targets/spark/SparkDialect.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/spark/SparkDialect.kt
@@ -102,6 +102,17 @@ public open class SparkDialect : SqlDialect() {
 
     override fun visitTypeInt8(node: Type.Int8, tail: SqlBlock): SqlBlock = tail concat "BIGINT"
 
+    /**
+     * Use array(...) syntax for ALL collections.
+     */
+    override fun visitExprCollection(node: Expr.Collection, tail: SqlBlock): SqlBlock {
+        return tail concat list("array(", ")") { node.values }
+    }
+
+    override fun visitExprValues(node: Expr.Values, tail: SqlBlock): SqlBlock {
+        return super.visitExprValues(node, tail)
+    }
+
     // Spark, has no notion of case sensitivity
     // https://spark.apache.org/docs/latest/sql-ref-identifier.html
     private fun Identifier.Symbol.sql() = "`$symbol`"

--- a/src/main/kotlin/org/partiql/scribe/targets/spark/SparkDialect.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/spark/SparkDialect.kt
@@ -102,15 +102,15 @@ public open class SparkDialect : SqlDialect() {
 
     override fun visitTypeInt8(node: Type.Int8, tail: SqlBlock): SqlBlock = tail concat "BIGINT"
 
-    /**
-     * Use array(...) syntax for ALL collections.
-     */
     override fun visitExprCollection(node: Expr.Collection, tail: SqlBlock): SqlBlock {
-        return tail concat list("array(", ")") { node.values }
-    }
-
-    override fun visitExprValues(node: Expr.Values, tail: SqlBlock): SqlBlock {
-        return super.visitExprValues(node, tail)
+        val (start, end) = when (node.type) {
+            Expr.Collection.Type.ARRAY -> "array(" to ")"
+            Expr.Collection.Type.VALUES -> "VALUES (" to ")"
+            Expr.Collection.Type.SEXP,
+            Expr.Collection.Type.BAG,
+            Expr.Collection.Type.LIST -> "(" to ")"
+        }
+        return tail concat list(start, end) { node.values }
     }
 
     // Spark, has no notion of case sensitivity

--- a/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoDialect.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoDialect.kt
@@ -101,6 +101,13 @@ public open class TrinoDialect : SqlDialect() {
 
     override fun visitTypeString(node: Type.String, tail: SqlBlock): SqlBlock = tail concat "VARCHAR"
 
+    /**
+     * Use ARRAY[...] syntax for ALL collections.
+     */
+    override fun visitExprCollection(node: Expr.Collection, tail: SqlBlock): SqlBlock {
+        return tail concat list("ARRAY[", "]") { node.values }
+    }
+
     private fun list(
         start: String? = "(",
         end: String? = ")",

--- a/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoDialect.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoDialect.kt
@@ -101,11 +101,15 @@ public open class TrinoDialect : SqlDialect() {
 
     override fun visitTypeString(node: Type.String, tail: SqlBlock): SqlBlock = tail concat "VARCHAR"
 
-    /**
-     * Use ARRAY[...] syntax for ALL collections.
-     */
     override fun visitExprCollection(node: Expr.Collection, tail: SqlBlock): SqlBlock {
-        return tail concat list("ARRAY[", "]") { node.values }
+        val (start, end) = when (node.type) {
+            Expr.Collection.Type.ARRAY -> "ARRAY[" to "]"
+            Expr.Collection.Type.VALUES -> "VALUES (" to ")"
+            Expr.Collection.Type.SEXP,
+            Expr.Collection.Type.BAG,
+            Expr.Collection.Type.LIST -> "(" to ")"
+        }
+        return tail concat list(start, end) { node.values }
     }
 
     private fun list(

--- a/src/test/resources/inputs/operators/in.sql
+++ b/src/test/resources/inputs/operators/in.sql
@@ -6,3 +6,9 @@ SELECT * FROM T WHERE b IN [1, 2];
 
 --#[in-02]
 SELECT * FROM T WHERE b IN << 1, 2 >>;
+
+--#[in-03]
+SELECT * FROM T WHERE b IN SEXP (1, 2);
+
+-- #[in-04]
+-- SELECT * FROM T WHERE b IN VALUES (1, 2);

--- a/src/test/resources/inputs/operators/in.sql
+++ b/src/test/resources/inputs/operators/in.sql
@@ -8,7 +8,10 @@ SELECT * FROM T WHERE b IN [1, 2];
 SELECT * FROM T WHERE b IN << 1, 2 >>;
 
 --#[in-03]
-SELECT * FROM T WHERE b IN SEXP (1, 2);
+SELECT * FROM T WHERE b NOT IN (1, 2);
 
--- #[in-04]
--- SELECT * FROM T WHERE b IN VALUES (1, 2);
+--#[in-04]
+SELECT * FROM T WHERE b NOT IN [1, 2];
+
+--#[in-05]
+SELECT * FROM T WHERE b NOT IN << 1, 2 >>;

--- a/src/test/resources/outputs/partiql/basics/select.sql
+++ b/src/test/resources/outputs/partiql/basics/select.sql
@@ -44,46 +44,46 @@ SELECT VALUE {"T"['z']: "T"['a']} FROM "default"."T" AS "T";
 SELECT "T".* FROM "default"."T" AS "T" WHERE "T"['b'] BETWEEN 0 AND 2;
 
 --#[select-15]
-SELECT "T".* FROM "default"."T" AS "T" WHERE NOT ("T"['b'] BETWEEN 0 AND 2);
+SELECT "T".* FROM "default"."T" AS "T" WHERE "T"['b'] NOT BETWEEN 0 AND 2;
 
 --#[select-16]
-SELECT "T".* FROM "default"."T" AS "T" WHERE NOT ("T"['b'] BETWEEN 0 AND 2);
+SELECT "T".* FROM "default"."T" AS "T" WHERE "T"['b'] NOT BETWEEN 0 AND 2;
 
 --#[select-17]
-SELECT "T".* FROM "default"."T" AS "T" WHERE NOT (NOT ("T"['b'] BETWEEN 0 AND 2));
+SELECT "T".* FROM "default"."T" AS "T" WHERE "T"['b'] BETWEEN 0 AND 2;
 
 --#[select-18]
 SELECT "T".* FROM "default"."T" AS "T" WHERE "T"['b'] IN (0, 1, 2);
 
 --#[select-19]
-SELECT "T".* FROM "default"."T" AS "T" WHERE NOT ("T"['b'] IN (0, 1, 2));
+SELECT "T".* FROM "default"."T" AS "T" WHERE "T"['b'] NOT IN (0, 1, 2);
 
 --#[select-20]
-SELECT "T".* FROM "default"."T" AS "T" WHERE NOT ("T"['b'] IN (0, 1, 2));
+SELECT "T".* FROM "default"."T" AS "T" WHERE "T"['b'] NOT IN (0, 1, 2);
 
 --#[select-21]
-SELECT "T".* FROM "default"."T" AS "T" WHERE NOT (NOT ("T"['b'] IN (0, 1, 2)));
+SELECT "T".* FROM "default"."T" AS "T" WHERE "T"['b'] IN (0, 1, 2);
 
 --#[select-22]
 SELECT "T".* FROM "default"."T" AS "T" WHERE "T"['b'] IS NULL;
 
 --#[select-23]
-SELECT "T".* FROM "default"."T" AS "T" WHERE NOT ("T"['b'] IS NULL);
+SELECT "T".* FROM "default"."T" AS "T" WHERE "T"['b'] IS NOT NULL;
 
 --#[select-24]
-SELECT "T".* FROM "default"."T" AS "T" WHERE NOT ("T"['b'] IS NULL);
+SELECT "T".* FROM "default"."T" AS "T" WHERE "T"['b'] IS NOT NULL;
 
 --#[select-25]
-SELECT "T".* FROM "default"."T" AS "T" WHERE NOT (NOT ("T"['b'] IS NULL));
+SELECT "T".* FROM "default"."T" AS "T" WHERE "T"['b'] IS NULL;
 
 --#[select-26]
 SELECT "T".* FROM "default"."T" AS "T" WHERE "T"['c'] LIKE 'abc';
 
 --#[select-27]
-SELECT "T".* FROM "default"."T" AS "T" WHERE NOT ("T"['c'] LIKE 'abc');
+SELECT "T".* FROM "default"."T" AS "T" WHERE "T"['c'] NOT LIKE 'abc';
 
 --#[select-28]
-SELECT "T".* FROM "default"."T" AS "T" WHERE NOT ("T"['c'] LIKE 'abc');
+SELECT "T".* FROM "default"."T" AS "T" WHERE "T"['c'] NOT LIKE 'abc';
 
 --#[select-29]
-SELECT "T".* FROM "default"."T" AS "T" WHERE NOT (NOT ("T"['c'] LIKE 'abc'));
+SELECT "T".* FROM "default"."T" AS "T" WHERE "T"['c'] LIKE 'abc';

--- a/src/test/resources/outputs/partiql/basics/simple.sql
+++ b/src/test/resources/outputs/partiql/basics/simple.sql
@@ -68,19 +68,19 @@ NOT ("default"."T1");
 "default"."T1" IS NULL;
 
 --#[expr-11]
-NOT ("default"."T1" IS NULL);
+"default"."T1" IS NOT NULL;
 
 --#[expr-12]
 "default"."T1" IS MISSING;
 
 --#[expr-13]
-NOT ("default"."T1" IS MISSING);
+"default"."T1" IS NOT MISSING;
 
 --#[expr-14]
 "default"."T1" IS SMALLINT;
 
 --#[expr-15]
-NOT ("default"."T1" IS SMALLINT);
+"default"."T1" IS NOT SMALLINT;
 
 --#[expr-16]
 -- TODO USE INT as the default INT4 name.
@@ -88,7 +88,7 @@ NOT ("default"."T1" IS SMALLINT);
 
 --#[expr-17]
 -- TODO USE INT as the default INT4 name.
-NOT ("default"."T1" IS INT);
+"default"."T1" IS NOT INT;
 
 --#[expr-18]
 -- TODO USE BIGINT as the default BIGINT/INT8 name.
@@ -96,115 +96,115 @@ NOT ("default"."T1" IS INT);
 
 --#[expr-19]
 -- TODO USE BIGINT as the default BIGINT/INT8 name.
-NOT ("default"."T1" IS BIGINT);
+"default"."T1" IS NOT BIGINT;
 
 --#[expr-20]
 "default"."T1" IS INT;
 
 --#[expr-21]
-NOT ("default"."T1" IS INT);
+"default"."T1" IS NOT INT;
 
 --#[expr-22]
 "default"."T1" IS DECIMAL;
 
 --#[expr-23]
-NOT ("default"."T1" IS DECIMAL);
+"default"."T1" IS NOT DECIMAL;
 
 --#[expr-24]
 "default"."T1" IS DOUBLE PRECISION;
 
 --#[expr-25]
-NOT ("default"."T1" IS DOUBLE PRECISION);
+"default"."T1" IS NOT DOUBLE PRECISION;
 
 --#[expr-26]
 "default"."T1" IS BOOL;
 
 --#[expr-27]
-NOT ("default"."T1" IS BOOL);
+"default"."T1" IS NOT BOOL;
 
 --#[expr-28]
 "default"."T1" IS SYMBOL;
 
 --#[expr-29]
-NOT ("default"."T1" IS SYMBOL);
+"default"."T1" IS NOT SYMBOL;
 
 --#[expr-30]
 "default"."T1" IS DATE;
 
 --#[expr-31]
-NOT ("default"."T1" IS DATE);
+"default"."T1" IS NOT DATE;
 
 --#[expr-32]
 "default"."T1" IS TIME;
 
 --#[expr-33]
-NOT ("default"."T1" IS TIME);
+"default"."T1" IS NOT TIME;
 
 --#[expr-34]
 "default"."T1" IS TIMESTAMP;
 
 --#[expr-35]
-NOT ("default"."T1" IS TIMESTAMP);
+"default"."T1" IS NOT TIMESTAMP;
 
 --#[expr-36]
 "default"."T1" IS STRING;
 
 --#[expr-37]
-NOT ("default"."T1" IS STRING);
+"default"."T1" IS NOT STRING;
 
 --#[expr-38]
 "default"."T1" IS CLOB;
 
 --#[expr-39]
-NOT ("default"."T1" IS CLOB);
+"default"."T1" IS NOT CLOB;
 
 --#[expr-40]
 "default"."T1" IS BLOB;
 
 --#[expr-41]
-NOT ("default"."T1" IS BLOB);
+"default"."T1" IS NOT BLOB;
 
 --#[expr-42]
 "default"."T1" IS LIST;
 
 --#[expr-43]
-NOT ("default"."T1" IS LIST);
+"default"."T1" IS NOT LIST;
 
 --#[expr-44]
 "default"."T1" IS SEXP;
 
 --#[expr-45]
-NOT ("default"."T1" IS SEXP);
+"default"."T1" IS NOT SEXP;
 
 --#[expr-46]
 "default"."T1" IS STRUCT;
 
 --#[expr-47]
-NOT ("default"."T1" IS STRUCT);
+"default"."T1" IS NOT STRUCT;
 
 --#[expr-48]
 "default"."T1" IS BAG;
 
 --#[expr-49]
-NOT ("default"."T1" IS BAG);
+"default"."T1" IS NOT BAG;
 
 --#[expr-50]
 "default"."T1" IN (true);
 
 --#[expr-51]
-NOT ("default"."T1" IN (false));
+"default"."T1" NOT IN (false);
 
 --#[expr-52]
 "default"."T1" IN "default"."T1";
 
 --#[expr-53]
-NOT ("default"."T1" IN "default"."T1");
+"default"."T1" NOT IN "default"."T1";
 
 --#[expr-54]
 "default"."T1" LIKE "default"."T1";
 
 --#[expr-55]
-NOT ("default"."T1" LIKE "default"."T1");
+"default"."T1" NOT LIKE "default"."T1";
 
 --#[expr-56]
 "default"."T1" LIKE "default"."T1" ESCAPE "default"."T1";
@@ -213,7 +213,7 @@ NOT ("default"."T1" LIKE "default"."T1");
 "default"."T1" BETWEEN "default"."T1" AND "default"."T1";
 
 --#[expr-58]
-NOT ("default"."T1" BETWEEN "default"."T1" AND "default"."T1");
+"default"."T1" NOT BETWEEN "default"."T1" AND "default"."T1";
 
 --#[expr-59]
 "default"."T1" || "default"."T1";

--- a/src/test/resources/outputs/redshift/operators/in.sql
+++ b/src/test/resources/outputs/redshift/operators/in.sql
@@ -1,0 +1,14 @@
+--#[in-00]
+SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IN (1, 2);
+
+--#[in-01]
+SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IN (1, 2);
+
+--#[in-02]
+SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IN (1, 2);
+
+--#[in-03]
+SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IN (1, 2);
+
+-- #[in-04]
+-- SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IN (1, 2);

--- a/src/test/resources/outputs/redshift/operators/in.sql
+++ b/src/test/resources/outputs/redshift/operators/in.sql
@@ -8,7 +8,10 @@ SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IN (1, 2);
 SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IN (1, 2);
 
 --#[in-03]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IN (1, 2);
+SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" NOT IN (1, 2);
 
--- #[in-04]
--- SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IN (1, 2);
+--#[in-04]
+SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" NOT IN (1, 2);
+
+--#[in-05]
+SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" NOT IN (1, 2);

--- a/src/test/resources/outputs/spark/basics/subquery.sql
+++ b/src/test/resources/outputs/spark/basics/subquery.sql
@@ -10,10 +10,7 @@
 --#[subquery-02]
 SELECT `upper`(`T`.`v`) AS `_1`
     FROM `default`.`T` AS `T`
-    WHERE `array_contains`(`T`.`b`,
-            SELECT `T`.`b` AS `b`
-                FROM `default`.`T` AS `T`
-                WHERE `T`.`a`)
+    WHERE `T`.`b` IN (SELECT `T`.`b` AS `b` FROM `default`.`T` AS `T` WHERE `T`.`a`)
 
 -- #[subquery-03]
 -- Spark does not support top level expression.

--- a/src/test/resources/outputs/spark/operators/in.sql
+++ b/src/test/resources/outputs/spark/operators/in.sql
@@ -1,14 +1,17 @@
 --#[in-00]
-SELECT `T`.* FROM `default`.`T` AS `T` WHERE `array_contains`(`T`.`b`, array(1, 2));
+SELECT `T`.* FROM `default`.`T` AS `T` WHERE `T`.`b` IN (1, 2);
 
 --#[in-01]
-SELECT `T`.* FROM `default`.`T` AS `T` WHERE `array_contains`(`T`.`b`, array(1, 2));
+SELECT `T`.* FROM `default`.`T` AS `T` WHERE `T`.`b` IN (1, 2);
 
 --#[in-02]
-SELECT `T`.* FROM `default`.`T` AS `T` WHERE `array_contains`(`T`.`b`, array(1, 2));
+SELECT `T`.* FROM `default`.`T` AS `T` WHERE `T`.`b` IN (1, 2);
 
 --#[in-03]
-SELECT `T`.* FROM `default`.`T` AS `T` WHERE `array_contains`(`T`.`b`, array(1, 2));
+SELECT `T`.* FROM `default`.`T` AS `T` WHERE `T`.`b` NOT IN (1, 2);
 
--- #[in-04]
--- SELECT `T`.* FROM `default`.`T` AS `T` WHERE `array_contains`(`T`.`b`, array(1, 2));
+--#[in-04]
+SELECT `T`.* FROM `default`.`T` AS `T` WHERE `T`.`b` NOT IN (1, 2);
+
+--#[in-05]
+SELECT `T`.* FROM `default`.`T` AS `T` WHERE `T`.`b` NOT IN (1, 2);

--- a/src/test/resources/outputs/spark/operators/in.sql
+++ b/src/test/resources/outputs/spark/operators/in.sql
@@ -1,0 +1,14 @@
+--#[in-00]
+SELECT `T`.* FROM `default`.`T` AS `T` WHERE `array_contains`(`T`.`b`, array(1, 2));
+
+--#[in-01]
+SELECT `T`.* FROM `default`.`T` AS `T` WHERE `array_contains`(`T`.`b`, array(1, 2));
+
+--#[in-02]
+SELECT `T`.* FROM `default`.`T` AS `T` WHERE `array_contains`(`T`.`b`, array(1, 2));
+
+--#[in-03]
+SELECT `T`.* FROM `default`.`T` AS `T` WHERE `array_contains`(`T`.`b`, array(1, 2));
+
+-- #[in-04]
+-- SELECT `T`.* FROM `default`.`T` AS `T` WHERE `array_contains`(`T`.`b`, array(1, 2));

--- a/src/test/resources/outputs/trino/operators/in.sql
+++ b/src/test/resources/outputs/trino/operators/in.sql
@@ -1,14 +1,17 @@
 --#[in-00]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IN ARRAY[1, 2];
+SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IN (1, 2);
 
 --#[in-01]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IN ARRAY[1, 2];
+SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IN (1, 2);
 
 --#[in-02]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IN ARRAY[1, 2];
+SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IN (1, 2);
 
 --#[in-03]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IN ARRAY[1, 2];
+SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" NOT IN (1, 2);
 
--- #[in-04]
--- SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IN ARRAY[1, 2];
+--#[in-04]
+SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" NOT IN (1, 2);
+
+--#[in-05]
+SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" NOT IN (1, 2);

--- a/src/test/resources/outputs/trino/operators/in.sql
+++ b/src/test/resources/outputs/trino/operators/in.sql
@@ -1,0 +1,14 @@
+--#[in-00]
+SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IN ARRAY[1, 2];
+
+--#[in-01]
+SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IN ARRAY[1, 2];
+
+--#[in-02]
+SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IN ARRAY[1, 2];
+
+--#[in-03]
+SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IN ARRAY[1, 2];
+
+-- #[in-04]
+-- SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IN ARRAY[1, 2];


### PR DESCRIPTION
*Issue #, if available:*

#42 

*Description of changes:*

Overrides logic for array literals,

```sql
array(...) -- spark
ARRAY[...] -- trino
(...)      -- redshift
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
