### PR TITLE
Fix Trino transpilation of nullable single field `ROW` generated from `EXCLUDE`

### DIFF
--- a/src/test/resources/catalogs/default/datatypes/T_CHAR_16_NULL.ion
+++ b/src/test/resources/catalogs/default/datatypes/T_CHAR_16_NULL.ion
@@ -1,0 +1,32 @@
+{
+  type: "bag",
+  items: {
+    type: "struct",
+    constraints: [ closed, ordered, unique ],
+    fields: [
+      {
+        name: "foo",
+        type: {
+          type: "struct",
+          constraints: [ closed, ordered, unique ],
+          fields: [
+            {
+              name: "bar",
+              type: "string",
+            },
+            {
+              name: "keep",
+              type: [
+                {
+                  type: "char",
+                  length: 16
+                },
+                "null"
+              ]
+            }
+          ]
+        },
+      },
+    ]
+  }
+}

--- a/src/test/resources/catalogs/default/datatypes/T_INT32_NULL.ion
+++ b/src/test/resources/catalogs/default/datatypes/T_INT32_NULL.ion
@@ -1,0 +1,26 @@
+{
+  type: "bag",
+  items: {
+    type: "struct",
+    constraints: [ closed, ordered, unique ],
+    fields: [
+      {
+        name: "foo",
+        type: {
+          type: "struct",
+          constraints: [ closed, ordered, unique ],
+          fields: [
+            {
+              name: "bar",
+              type: "string",
+            },
+            {
+              name: "keep",
+              type: [ "int32", "null" ]
+            },
+          ]
+        },
+      },
+    ]
+  }
+}

--- a/src/test/resources/catalogs/default/datatypes/T_STRING_16_NULL.ion
+++ b/src/test/resources/catalogs/default/datatypes/T_STRING_16_NULL.ion
@@ -1,0 +1,32 @@
+{
+  type: "bag",
+  items: {
+    type: "struct",
+    constraints: [ closed, ordered, unique ],
+    fields: [
+      {
+        name: "foo",
+        type: {
+          type: "struct",
+          constraints: [ closed, ordered, unique ],
+          fields: [
+            {
+              name: "bar",
+              type: "string",
+            },
+            {
+              name: "keep",
+              type: [
+                {
+                  type: "string",
+                  length: 16
+                },
+                "null"
+              ]
+            }
+          ]
+        },
+      },
+    ]
+  }
+}

--- a/src/test/resources/catalogs/default/datatypes/T_STRING_NULL.ion
+++ b/src/test/resources/catalogs/default/datatypes/T_STRING_NULL.ion
@@ -1,0 +1,26 @@
+{
+  type: "bag",
+  items: {
+    type: "struct",
+    constraints: [ closed, ordered, unique ],
+    fields: [
+      {
+        name: "foo",
+        type: {
+          type: "struct",
+          constraints: [ closed, ordered, unique ],
+          fields: [
+            {
+              name: "bar",
+              type: "string",
+            },
+            {
+              name: "keep",
+              type: [ "string", "null" ]
+            },
+          ]
+        },
+      },
+    ]
+  }
+}

--- a/src/test/resources/inputs/basics/exclude.sql
+++ b/src/test/resources/inputs/basics/exclude.sql
@@ -123,3 +123,19 @@ SELECT * EXCLUDE t.foo.bar FROM datatypes.T_TIME_6 AS t;
 -- timestamp(6)
 --#[exclude-31]
 SELECT * EXCLUDE t.foo.bar FROM datatypes.T_TIMESTAMP_6 AS t;
+
+-- union(string, null)
+--#[exclude-32]
+SELECT * EXCLUDE t.foo.bar FROM datatypes.T_STRING_NULL AS t;
+
+-- union(int32, null)
+--#[exclude-33]
+SELECT * EXCLUDE t.foo.bar FROM datatypes.T_INT32_NULL AS t;
+
+-- union(varchar(16), null)
+--#[exclude-34]
+SELECT * EXCLUDE t.foo.bar FROM datatypes.T_STRING_16_NULL AS t;
+
+-- union(char(16), null)
+--#[exclude-35]
+SELECT * EXCLUDE t.foo.bar FROM datatypes.T_CHAR_16_NULL AS t;

--- a/src/test/resources/outputs/trino/basics/exclude.sql
+++ b/src/test/resources/outputs/trino/basics/exclude.sql
@@ -121,3 +121,19 @@ SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep
 -- timestamp(6)
 --#[exclude-31]
 SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep TIMESTAMP(6)))) AS ROW(foo ROW(keep TIMESTAMP(6)))) AS "t" FROM "default"."datatypes"."T_TIMESTAMP_6" AS "t") AS "$__EXCLUDE_ALIAS__";
+
+-- union(string, null)
+--#[exclude-32]
+SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep VARCHAR))) AS ROW(foo ROW(keep VARCHAR))) AS "t" FROM "default"."datatypes"."T_STRING_NULL" AS "t") AS "$__EXCLUDE_ALIAS__";
+
+-- union(int32, null)
+--#[exclude-33]
+SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep INTEGER))) AS ROW(foo ROW(keep INTEGER))) AS "t" FROM "default"."datatypes"."T_INT32_NULL" AS "t") AS "$__EXCLUDE_ALIAS__";
+
+-- union(varchar(16), null)
+--#[exclude-34]
+SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep VARCHAR(16)))) AS ROW(foo ROW(keep VARCHAR(16)))) AS "t" FROM "default"."datatypes"."T_STRING_16_NULL" AS "t") AS "$__EXCLUDE_ALIAS__";
+
+-- union(char(16), null)
+--#[exclude-35]
+SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep CHAR(16)))) AS ROW(foo ROW(keep CHAR(16)))) AS "t" FROM "default"."datatypes"."T_CHAR_16_NULL" AS "t") AS "$__EXCLUDE_ALIAS__";


### PR DESCRIPTION
*Issue #, if available:*
- Resolves #44 

*Description of changes:*
- For background, PartiQL structs are represented by a `ROW` type. When there is just **one** field within the `ROW` type, then we must know the type when constructing the `ROW`.

```
-- in PartiQL, a struct with single field `a` of type `int4`
struct(a: int4)
```

```
-- in Trino, a row with a single field `a` of type `int4`
CAST(ROW(a) AS ROW(a INTEGER))
```
- The bug mentioned in #44 comes from when we transpile `EXCLUDE` and there is a `ROW` with a single field
- Adds logic to handle the construction of a single field `ROW` when the field's type is a `union(<some single type>, null)`. New logic will remove the `null` from the `union` since Trino types are nullable by default.
	- Note: this behavior will be fixed w/ the next PLK release, 0.15+, due to https://github.com/partiql/partiql-lang-kotlin/pull/1463.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
