### PR TITLE
Handle simple EXCLUDE top-level column case in Redshift; expand out SELECT *

### DIFF
--- a/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftTarget.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftTarget.kt
@@ -122,6 +122,9 @@ public open class RedshiftTarget : SqlTarget() {
 
         @OptIn(PartiQLValueExperimental::class)
         private fun expandStruct(op: Rex.Op, structType: StructType): List<Rex> {
+            if (structType.fields.isEmpty()) {
+                error("Struct fields $structType must be non-empty")
+            }
             return structType.fields.map { field ->
                 // Create a new struct for each field
                 Rex(

--- a/src/test/resources/catalogs/default/T_EXCLUDE_TOP_LEVEL.ion
+++ b/src/test/resources/catalogs/default/T_EXCLUDE_TOP_LEVEL.ion
@@ -1,0 +1,46 @@
+{
+  type: "bag",
+  items: {
+    type: "struct",
+    constraints: [ closed, ordered, unique ],
+    fields: [
+      {
+        name: "a",
+        type: "bool",
+      },
+      {
+        name: "b",
+        type: "int32",
+      },
+      {
+        name: "c",
+        type: "string",
+      },
+      {
+        name: "d",
+        type: {
+          type: "struct",
+          constraints: [ closed, ordered, unique ],
+          fields: [
+            {
+              name: "e",
+              type: "string"
+            }
+          ]
+        },
+      },
+      {
+        name: "e",
+        type: "timestamp"
+      },
+      {
+        name: "f",
+        type: "date"
+      },
+      {
+        name: "g",
+        type: "time"
+      }
+    ]
+  }
+}

--- a/src/test/resources/inputs/basics/exclude.sql
+++ b/src/test/resources/inputs/basics/exclude.sql
@@ -139,3 +139,65 @@ SELECT * EXCLUDE t.foo.bar FROM datatypes.T_STRING_16_NULL AS t;
 -- union(char(16), null)
 --#[exclude-35]
 SELECT * EXCLUDE t.foo.bar FROM datatypes.T_CHAR_16_NULL AS t;
+
+-- Tests for EXCLUDE on top-level columns only --
+-- Baseline query without `EXCLUDE`
+--#[exclude-36]
+SELECT * FROM T_EXCLUDE_TOP_LEVEL AS t;
+
+-- EXCLUDE single top-level column (no `t.a`)
+--#[exclude-37]
+SELECT * EXCLUDE t.a FROM T_EXCLUDE_TOP_LEVEL AS t;
+
+-- EXCLUDE multiple top-level columns (no `t.a` through `t.e`)
+--#[exclude-38]
+SELECT * EXCLUDE t.a, t.b, t.c, t.d, t.e FROM T_EXCLUDE_TOP_LEVEL AS t;
+
+-- EXCLUDE top-level columns with WHERE
+--#[exclude-39]
+SELECT * EXCLUDE t.a, t.b FROM T_EXCLUDE_TOP_LEVEL AS t WHERE t.a AND t.c = 'remove';
+
+-- EXCLUDE top-level columns with explicit SELECT list
+--#[exclude-40]
+SELECT t.c, t.d, t.e, t.f, t.g EXCLUDE t.a, t.b FROM T_EXCLUDE_TOP_LEVEL AS t WHERE t.a AND t.c = 'remove';
+
+-- EXCLUDE top-level with subquery
+--#[exclude-41]
+SELECT subq.* EXCLUDE subq.remove_me FROM (SELECT t.*, 'foo' AS remove_me FROM T_EXCLUDE_TOP_LEVEL AS t WHERE t.a) AS subq;
+
+-- EXCLUDE top-level columns with JOIN
+--#[exclude-42]
+SELECT * EXCLUDE t1.a, t2.b, t1.c, t2.d, t1.e, t2.f, t1.g FROM T_EXCLUDE_TOP_LEVEL AS t1, T_EXCLUDE_TOP_LEVEL AS t2;
+
+-- EXCLUDE top-level columns with JOIN and WHERE
+--#[exclude-43]
+SELECT * EXCLUDE t1.a, t2.b, t1.c, t2.d, t1.e, t2.f, t1.g FROM T_EXCLUDE_TOP_LEVEL AS t1, T_EXCLUDE_TOP_LEVEL AS t2 WHERE t1.a AND t2.a;
+
+-- EXCLUDE top-level columns with JOIN and WHERE and specified SELECT element
+--#[exclude-44]
+SELECT t1.* EXCLUDE t1.a, t2.b, t1.c, t2.d, t1.e, t2.f, t1.g FROM T_EXCLUDE_TOP_LEVEL AS t1, T_EXCLUDE_TOP_LEVEL AS t2 WHERE t1.a AND t2.a;
+
+-- EXCLUDE top-level columns with JOIN and WHERE and specified SELECT elements
+--#[exclude-45]
+SELECT t1.*, t2.a AS special EXCLUDE t1.a, t2.b, t1.c, t2.d, t1.e, t2.f, t1.g FROM T_EXCLUDE_TOP_LEVEL AS t1, T_EXCLUDE_TOP_LEVEL AS t2 WHERE t1.a AND t2.a;
+
+-- EXCLUDE top-level columns with multiple JOINs
+--#[exclude-46]
+SELECT *
+EXCLUDE
+          t1.b, t1.c, t1.d, t1.e, t1.f, t1.g,
+    t2.a,       t2.c, t2.d, t2.e, t2.f, t2.g,
+    t3.a, t3.b,       t3.d, t3.e, t3.f, t3.g,
+    t4.a, t4.b, t4.c,       t4.e, t4.f, t4.g,
+    t5.a, t5.b, t5.c, t5.d,       t5.f, t5.g,
+    t6.a, t6.b, t6.c, t6.d, t6.e,       t6.g,
+    t7.a, t7.b, t7.c, t7.d, t7.e, t7.f
+FROM T_EXCLUDE_TOP_LEVEL AS t1 JOIN
+    T_EXCLUDE_TOP_LEVEL AS t2 ON t2.a LEFT JOIN
+    T_EXCLUDE_TOP_LEVEL AS t3 ON t3.a INNER JOIN
+    T_EXCLUDE_TOP_LEVEL AS t4 ON t4.a RIGHT JOIN
+    T_EXCLUDE_TOP_LEVEL AS t5 ON t5.a FULL JOIN
+    T_EXCLUDE_TOP_LEVEL AS t6 ON t6.a,
+    T_EXCLUDE_TOP_LEVEL AS t7
+WHERE
+    t1.a AND t2.a;

--- a/src/test/resources/outputs/redshift/basics/exclude.sql
+++ b/src/test/resources/outputs/redshift/basics/exclude.sql
@@ -1,9 +1,9 @@
 --#[exclude-00]
 -- Exclude a top-level field
-SELECT "$__EXCLUDE_ALIAS__"."t"."flds" AS "flds" FROM (SELECT OBJECT('flds', OBJECT('a', OBJECT('field_x', "t"."flds"."a"."field_x", 'field_y', "t"."flds"."a"."field_y"), 'b', OBJECT('field_x', "t"."flds"."b"."field_x", 'field_y', "t"."flds"."b"."field_y"), 'c', OBJECT('field_x', "t"."flds"."c"."field_x", 'field_y', "t"."flds"."c"."field_y"))) AS "t" FROM "default"."EXCLUDE_T" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "t"."flds" AS "flds" FROM "default"."EXCLUDE_T" AS "t";
 
 --#[exclude-01]
-SELECT "$__EXCLUDE_ALIAS__"."t"."foo" AS "foo" FROM (SELECT OBJECT('foo', "t"."foo") AS "t" FROM "default"."EXCLUDE_T" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "t"."foo" AS "foo" FROM "default"."EXCLUDE_T" AS "t";
 
 --#[exclude-02]
 SELECT "$__EXCLUDE_ALIAS__"."t"."flds" AS "flds", "$__EXCLUDE_ALIAS__"."t"."foo" AS "foo" FROM (SELECT OBJECT('flds', OBJECT('a', OBJECT('field_x', "t"."flds"."a"."field_x", 'field_y', "t"."flds"."a"."field_y"), 'c', OBJECT('field_x', "t"."flds"."c"."field_x", 'field_y', "t"."flds"."c"."field_y")), 'foo', "t"."foo") AS "t" FROM "default"."EXCLUDE_T" AS "t") AS "$__EXCLUDE_ALIAS__";
@@ -41,3 +41,63 @@ SELECT "$__EXCLUDE_ALIAS__"."t1"."flds" AS "flds", "$__EXCLUDE_ALIAS__"."t1"."fo
 --#[exclude-11]
 -- EXCLUDE with select projection list and multiple JOINs
 SELECT "$__EXCLUDE_ALIAS__"."t1"."flds" AS "flds", "$__EXCLUDE_ALIAS__"."t2"."flds" AS "flds", "$__EXCLUDE_ALIAS__"."t3"."flds" AS "flds" FROM (SELECT OBJECT('flds', OBJECT('b', OBJECT('field_x', "t1"."flds"."b"."field_x", 'field_y', "t1"."flds"."b"."field_y"), 'c', OBJECT('field_x', "t1"."flds"."c"."field_x", 'field_y', "t1"."flds"."c"."field_y")), 'foo', "t1"."foo") AS "t1", OBJECT('flds', OBJECT('a', OBJECT('field_x', "t2"."flds"."a"."field_x", 'field_y', "t2"."flds"."a"."field_y"), 'c', OBJECT('field_x', "t2"."flds"."c"."field_x", 'field_y', "t2"."flds"."c"."field_y")), 'foo', "t2"."foo") AS "t2", OBJECT('flds', OBJECT('a', OBJECT('field_x', "t3"."flds"."a"."field_x", 'field_y', "t3"."flds"."a"."field_y"), 'b', OBJECT('field_x', "t3"."flds"."b"."field_x", 'field_y', "t3"."flds"."b"."field_y")), 'foo', "t3"."foo") AS "t3" FROM "default"."EXCLUDE_T" AS "t1" INNER JOIN "default"."EXCLUDE_T" AS "t2" ON true INNER JOIN "default"."EXCLUDE_T" AS "t3" ON true WHERE ("t1"."foo" = "t2"."foo") AND ("t2"."foo" = "t3"."foo")) AS "$__EXCLUDE_ALIAS__";
+
+-- Tests for EXCLUDE on top-level columns only --
+-- Baseline query without `EXCLUDE`
+--#[exclude-36]
+SELECT "t"."a" AS "a", "t"."b" AS "b", "t"."c" AS "c", "t"."d" AS "d", "t"."e" AS "e", "t"."f" AS "f", "t"."g" AS "g" FROM "default"."T_EXCLUDE_TOP_LEVEL" AS "t";
+
+-- EXCLUDE single top-level column (no `t.a`)
+--#[exclude-37]
+SELECT "t"."b" AS "b", "t"."c" AS "c", "t"."d" AS "d", "t"."e" AS "e", "t"."f" AS "f", "t"."g" AS "g" FROM "default"."T_EXCLUDE_TOP_LEVEL" AS "t";
+
+-- EXCLUDE multiple top-level columns (no `t.a` through `t.e`)
+--#[exclude-38]
+SELECT "t"."f" AS "f", "t"."g" AS "g" FROM "default"."T_EXCLUDE_TOP_LEVEL" AS "t";
+
+-- EXCLUDE top-level columns with WHERE
+--#[exclude-39]
+SELECT "t"."c" AS "c", "t"."d" AS "d", "t"."e" AS "e", "t"."f" AS "f", "t"."g" AS "g" FROM "default"."T_EXCLUDE_TOP_LEVEL" AS "t" WHERE "t"."a" AND ("t"."c" = 'remove');
+
+-- EXCLUDE top-level columns with explicit SELECT list
+--#[exclude-40]
+SELECT "t"."c" AS "c", "t"."d" AS "d", "t"."e" AS "e", "t"."f" AS "f", "t"."g" AS "g" FROM "default"."T_EXCLUDE_TOP_LEVEL" AS "t" WHERE "t"."a" AND ("t"."c" = 'remove');
+
+-- EXCLUDE top-level with subquery
+--#[exclude-41]
+SELECT "subq"."a" AS "a", "subq"."b" AS "b", "subq"."c" AS "c", "subq"."d" AS "d", "subq"."e" AS "e", "subq"."f" AS "f", "subq"."g" AS "g" FROM (SELECT "t"."a" AS "a", "t"."b" AS "b", "t"."c" AS "c", "t"."d" AS "d", "t"."e" AS "e", "t"."f" AS "f", "t"."g" AS "g", 'foo' AS "remove_me" FROM "default"."T_EXCLUDE_TOP_LEVEL" AS "t" WHERE "t"."a") AS "subq";
+
+-- EXCLUDE top-level columns with JOIN
+--#[exclude-42]
+SELECT "t1"."b" AS "b", "t1"."d" AS "d", "t1"."f" AS "f", "t2"."a" AS "a", "t2"."c" AS "c", "t2"."e" AS "e", "t2"."g" AS "g" FROM "default"."T_EXCLUDE_TOP_LEVEL" AS "t1" INNER JOIN "default"."T_EXCLUDE_TOP_LEVEL" AS "t2" ON true;
+
+-- EXCLUDE top-level columns with JOIN and WHERE
+--#[exclude-43]
+SELECT "t1"."b" AS "b", "t1"."d" AS "d", "t1"."f" AS "f", "t2"."a" AS "a", "t2"."c" AS "c", "t2"."e" AS "e", "t2"."g" AS "g" FROM "default"."T_EXCLUDE_TOP_LEVEL" AS "t1" INNER JOIN "default"."T_EXCLUDE_TOP_LEVEL" AS "t2" ON true WHERE "t1"."a" AND "t2"."a";
+
+-- EXCLUDE top-level columns with JOIN and WHERE and specified SELECT element
+--#[exclude-44]
+SELECT "t1"."b" AS "b", "t1"."d" AS "d", "t1"."f" AS "f" FROM "default"."T_EXCLUDE_TOP_LEVEL" AS "t1" INNER JOIN "default"."T_EXCLUDE_TOP_LEVEL" AS "t2" ON true WHERE "t1"."a" AND "t2"."a";
+
+-- EXCLUDE top-level columns with JOIN and WHERE and specified SELECT elements
+--#[exclude-45]
+SELECT "t1"."b" AS "b", "t1"."d" AS "d", "t1"."f" AS "f", "t2"."a" AS "special" FROM "default"."T_EXCLUDE_TOP_LEVEL" AS "t1" INNER JOIN "default"."T_EXCLUDE_TOP_LEVEL" AS "t2" ON true WHERE "t1"."a" AND "t2"."a";
+
+-- EXCLUDE top-level columns with multiple JOINs
+--#[exclude-46]
+SELECT
+    "t1"."a" AS "a",
+    "t2"."b" AS "b",
+    "t3"."c" AS "c",
+    "t4"."d" AS "d",
+    "t5"."e" AS "e",
+    "t6"."f" AS "f",
+    "t7"."g" AS "g"
+FROM
+    "default"."T_EXCLUDE_TOP_LEVEL" AS "t1" INNER JOIN
+    "default"."T_EXCLUDE_TOP_LEVEL" AS "t2" ON "t2"."a" LEFT OUTER JOIN
+    "default"."T_EXCLUDE_TOP_LEVEL" AS "t3" ON "t3"."a" INNER JOIN
+    "default"."T_EXCLUDE_TOP_LEVEL" AS "t4" ON "t4"."a" RIGHT OUTER JOIN
+    "default"."T_EXCLUDE_TOP_LEVEL" AS "t5" ON "t5"."a" FULL OUTER JOIN
+    "default"."T_EXCLUDE_TOP_LEVEL" AS "t6" ON "t6"."a" INNER JOIN
+"default"."T_EXCLUDE_TOP_LEVEL" AS "t7" ON true WHERE "t1"."a" AND "t2"."a";

--- a/src/test/resources/outputs/redshift/basics/select.sql
+++ b/src/test/resources/outputs/redshift/basics/select.sql
@@ -2,7 +2,8 @@
 SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c" FROM "default"."T" AS "T";
 
 --#[select-01]
-SELECT "T".* FROM "default"."T" AS "T";
+-- expand out the `SELECT *`
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T";
 
 -- #[select-02]
 -- ERROR, no SELECT VALUE!
@@ -13,7 +14,7 @@ SELECT "T".* FROM "default"."T" AS "T";
 -- SELECT VALUE a FROM "default"."T" AS "T";
 
 --#[select-04]
-SELECT "t1".*, "t2".* FROM "default"."T" AS "t1" INNER JOIN "default"."T" AS "t2" ON true;
+SELECT "t1"."a" AS "a", "t1"."b" AS "b", "t1"."c" AS "c", "t1"."d" AS "d", "t1"."x" AS "x", "t1"."array" AS "array", "t1"."z" AS "z", "t1"."v" AS "v", "t1"."timestamp_1" AS "timestamp_1", "t1"."timestamp_2" AS "timestamp_2", "t2"."a" AS "a", "t2"."b" AS "b", "t2"."c" AS "c", "t2"."d" AS "d", "t2"."x" AS "x", "t2"."array" AS "array", "t2"."z" AS "z", "t2"."v" AS "v", "t2"."timestamp_1" AS "timestamp_1", "t2"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "t1" INNER JOIN "default"."T" AS "t2" ON true;
 
 -- Redshift doesn't support struct wildcard (i.e. <SUPER OBJECT>.*). Rewriting to include every struct field.
 --#[select-05]
@@ -29,7 +30,7 @@ SELECT "T"."d"."e" AS "e", "T"."d"."e" AS "e" FROM "default"."T" AS "T";
 SELECT "T"."d"."e" AS "e" FROM "default"."T" AS "T";
 
 --#[select-09]
-SELECT "T".* FROM "default"."T" AS "T";
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T";
 
 --#[select-10]
 SELECT "T"."c" || CURRENT_USER AS "_1" FROM "default"."T" AS "T";
@@ -47,49 +48,49 @@ SELECT "t"."a" AS "a" FROM "default"."T" AS "t";
 -- SELECT VALUE {z: a} FROM T;
 
 --#[select-14]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" BETWEEN 0 AND 2;
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T" WHERE "T"."b" BETWEEN 0 AND 2;
 
 --#[select-15]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" NOT BETWEEN 0 AND 2;
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T" WHERE "T"."b" NOT BETWEEN 0 AND 2;
 
 --#[select-16]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" NOT BETWEEN 0 AND 2;
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T" WHERE "T"."b" NOT BETWEEN 0 AND 2;
 
 --#[select-17]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" BETWEEN 0 AND 2;
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T" WHERE "T"."b" BETWEEN 0 AND 2;
 
 --#[select-18]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IN (0, 1, 2);
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T" WHERE "T"."b" IN (0, 1, 2);
 
 --#[select-19]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" NOT IN (0, 1, 2);
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T" WHERE "T"."b" NOT IN (0, 1, 2);
 
 --#[select-20]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" NOT IN (0, 1, 2);
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T" WHERE "T"."b" NOT IN (0, 1, 2);
 
 --#[select-21]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IN (0, 1, 2);
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T" WHERE "T"."b" IN (0, 1, 2);
 
 --#[select-22]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IS NULL;
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T" WHERE "T"."b" IS NULL;
 
 --#[select-23]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IS NOT NULL;
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T" WHERE "T"."b" IS NOT NULL;
 
 --#[select-24]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IS NOT NULL;
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T" WHERE "T"."b" IS NOT NULL;
 
 --#[select-25]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IS NULL;
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T" WHERE "T"."b" IS NULL;
 
 --#[select-26]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."c" LIKE 'abc';
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T" WHERE "T"."c" LIKE 'abc';
 
 --#[select-27]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."c" NOT LIKE 'abc';
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T" WHERE "T"."c" NOT LIKE 'abc';
 
 --#[select-28]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."c" NOT LIKE 'abc';
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T" WHERE "T"."c" NOT LIKE 'abc';
 
 --#[select-29]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."c" LIKE 'abc';
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T" WHERE "T"."c" LIKE 'abc';

--- a/src/test/resources/outputs/redshift/operators/in.sql
+++ b/src/test/resources/outputs/redshift/operators/in.sql
@@ -1,17 +1,17 @@
 --#[in-00]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IN (1, 2);
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T" WHERE "T"."b" IN (1, 2);
 
 --#[in-01]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IN (1, 2);
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T" WHERE "T"."b" IN (1, 2);
 
 --#[in-02]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IN (1, 2);
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T" WHERE "T"."b" IN (1, 2);
 
 --#[in-03]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" NOT IN (1, 2);
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T" WHERE "T"."b" NOT IN (1, 2);
 
 --#[in-04]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" NOT IN (1, 2);
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T" WHERE "T"."b" NOT IN (1, 2);
 
 --#[in-05]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" NOT IN (1, 2);
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T" WHERE "T"."b" NOT IN (1, 2);


### PR DESCRIPTION
*Issue #, if available:* None.

*Description of changes:*

This PR adds a new rewrite for `EXCLUDE` transpilation in Redshift when the `EXCLUDE` paths are just top-level columns (e.g. `EXCLUDE tbl1.col1, tbl2.col2`). The newly transpiled query is much simpler and should offer better performance within Redshift.

A comparison of queries:
Input table `EXCLUDE_T_TEST` of three columns, `col1`, `col2`, and `col3`. Let's assume data type for `col3` is a boolean (other columns shouldn't matter in Redshift).

Input:
```
SELECT * EXCLUDE t.col3 FROM EXCLUDE_T_TEST AS t WHERE t.col3
```

Previous Output:
```
SELECT 
	"$__EXCLUDE_ALIAS__"."t"."col1" AS "col1", 
	"$__EXCLUDE_ALIAS__"."t"."col2" AS "col2"
FROM (
	SELECT 
		OBJECT(
			'col1', "t"."col1", 
			'col2', "t"."col2"
) AS "t" 
FROM "default"."EXCLUDE_T_TEST" AS "t" WHERE "t"."col3") AS "$__EXCLUDE_ALIAS__"
```

New Output:
```
SELECT 
	"t"."col1" AS "col1", 
	"t"."col2" AS "col2" 
FROM "default"."EXCLUDE_T_TEST" AS "t" WHERE "t"."col3"
```

Other notes:
- Previous transpilation of `EXCLUDE` with non-top-level columns will yield the same output
- `SELECT *` even without `EXCLUDE` will now be expanded

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
