### PR TITLE
Removes decimal coercions

### DIFF
--- a/src/main/kotlin/org/partiql/scribe/sql/SqlCalls.kt
+++ b/src/main/kotlin/org/partiql/scribe/sql/SqlCalls.kt
@@ -107,6 +107,7 @@ public abstract class SqlCalls {
         "cast_int64" to { args -> rewriteCast(PartiQLValueType.INT64, args) },
         "cast_int" to { args -> rewriteCast(PartiQLValueType.INT, args) },
         "cast_decimal" to { args -> rewriteCast(PartiQLValueType.DECIMAL, args) },
+        "cast_decimal_arbitrary" to ::removeDecimalArbitraryCoercion,
         "cast_float32" to { args -> rewriteCast(PartiQLValueType.FLOAT32, args) },
         "cast_float64" to { args -> rewriteCast(PartiQLValueType.FLOAT64, args) },
         "cast_char" to { args -> rewriteCast(PartiQLValueType.CHAR, args) },
@@ -202,6 +203,7 @@ public abstract class SqlCalls {
     }
 
     public open fun unary(op: Expr.Unary.Op, args: SqlArgs): Expr {
+        Long.MAX_VALUE
         assert(args.size == 1) { "Unary operator $op requires exactly 1 argument" }
         return exprUnary(op, args[0].expr)
     }
@@ -300,6 +302,11 @@ public abstract class SqlCalls {
     public open fun inCollection(args: SqlArgs) : Expr = exprInCollection(args[0].expr, args[1].expr, false)
 
     public open fun between(args: SqlArgs) : Expr = exprBetween(args[0].expr, args[1].expr, args[2].expr, false)
+
+    private fun removeDecimalArbitraryCoercion(args: SqlArgs): Expr {
+        assert(args.size == 1) { "cast_decimal_arbitrary should only have one argument" }
+        return args[0].expr
+    }
 
     public open fun like(args: SqlArgs, escape: Boolean): Expr {
         val arg0 = args[0].expr

--- a/src/main/kotlin/org/partiql/scribe/sql/SqlCalls.kt
+++ b/src/main/kotlin/org/partiql/scribe/sql/SqlCalls.kt
@@ -203,7 +203,6 @@ public abstract class SqlCalls {
     }
 
     public open fun unary(op: Expr.Unary.Op, args: SqlArgs): Expr {
-        Long.MAX_VALUE
         assert(args.size == 1) { "Unary operator $op requires exactly 1 argument" }
         return exprUnary(op, args[0].expr)
     }

--- a/src/test/resources/catalogs/default/T_DECIMALS.ion
+++ b/src/test/resources/catalogs/default/T_DECIMALS.ion
@@ -1,0 +1,21 @@
+{
+  type: "bag",
+  items: {
+    type: "struct",
+    constraints: [ closed, ordered, unique ],
+    fields: [
+      {
+        name: "da", // decimal arbitrary
+        type: "decimal",
+      },
+      {
+        name: "de", // decimal exact
+        type: {
+          type: "decimal",
+          precision: 10,
+          scale: 0,
+        },
+      },
+    ]
+  }
+}

--- a/src/test/resources/inputs/operators/between.sql
+++ b/src/test/resources/inputs/operators/between.sql
@@ -1,0 +1,23 @@
+--#[between-00]
+-- between(decimal, int32, int32)
+SELECT da FROM T_DECIMALS WHERE da BETWEEN -1 AND 1;
+
+--#[between-01]
+-- between(decimal, int64, int64)
+SELECT da FROM T_DECIMALS WHERE da BETWEEN -2147483649 AND 2147483648;
+
+--#[between-02]
+-- between(decimal, decimal, decimal)
+SELECT da FROM T_DECIMALS WHERE da BETWEEN -9223372036854775809 AND 9223372036854775808;
+
+--#[between-04]
+-- between(decimal(p,s), int32, int32)
+SELECT de FROM T_DECIMALS WHERE de BETWEEN -1 AND 1;
+
+--#[between-05]
+-- between(decimal(p,s), int64, int64)
+SELECT de FROM T_DECIMALS WHERE de BETWEEN -2147483649 AND 2147483648;
+
+--#[between-06]
+-- between(decimal(p,s), decimal, decimal)
+SELECT de FROM T_DECIMALS WHERE de BETWEEN -9223372036854775809 AND 9223372036854775808;

--- a/src/test/resources/outputs/partiql/operators/between.sql
+++ b/src/test/resources/outputs/partiql/operators/between.sql
@@ -1,0 +1,23 @@
+--#[between-00]
+-- between(decimal, int32, int32)
+SELECT "T_DECIMALS"['da'] AS "da" FROM "default"."T_DECIMALS" AS "T_DECIMALS" WHERE "T_DECIMALS"['da'] BETWEEN -(1) AND 1
+
+--#[between-01]
+-- between(decimal, int64, int64)
+SELECT "T_DECIMALS"['da'] AS "da" FROM "default"."T_DECIMALS" AS "T_DECIMALS" WHERE "T_DECIMALS"['da'] BETWEEN -(2147483649) AND 2147483648
+
+--#[between-02]
+-- between(decimal, decimal, decimal)
+SELECT "T_DECIMALS"['da'] AS "da" FROM "default"."T_DECIMALS" AS "T_DECIMALS" WHERE "T_DECIMALS"['da'] BETWEEN -(9223372036854775809) AND 9223372036854775808
+
+--#[between-04]
+-- between(decimal(p,s), int32, int32)
+SELECT "T_DECIMALS"['de'] AS "de" FROM "default"."T_DECIMALS" AS "T_DECIMALS" WHERE "T_DECIMALS"['de'] BETWEEN -(1) AND 1
+
+--#[between-05]
+-- between(decimal(p,s), int64, int64)
+SELECT "T_DECIMALS"['de'] AS "de" FROM "default"."T_DECIMALS" AS "T_DECIMALS" WHERE "T_DECIMALS"['de'] BETWEEN -(2147483649) AND 2147483648
+
+--#[between-06]
+-- between(decimal(p,s), decimal, decimal)
+SELECT "T_DECIMALS"['de'] AS "de" FROM "default"."T_DECIMALS" AS "T_DECIMALS" WHERE "T_DECIMALS"['de'] BETWEEN -(9223372036854775809) AND 9223372036854775808

--- a/src/test/resources/outputs/redshift/operators/between.sql
+++ b/src/test/resources/outputs/redshift/operators/between.sql
@@ -1,0 +1,23 @@
+--#[between-00]
+-- between(decimal, int32, int32)
+SELECT "T_DECIMALS"."da" AS "da" FROM "default"."T_DECIMALS" AS "T_DECIMALS" WHERE "T_DECIMALS"."da" BETWEEN -1 AND 1;
+
+--#[between-01]
+-- between(decimal, int64, int64)
+SELECT "T_DECIMALS"."da" AS "da" FROM "default"."T_DECIMALS" AS "T_DECIMALS" WHERE "T_DECIMALS"."da" BETWEEN -2147483649 AND 2147483648;
+
+--#[between-02]
+-- between(decimal, decimal, decimal)
+SELECT "T_DECIMALS"."da" AS "da" FROM "default"."T_DECIMALS" AS "T_DECIMALS" WHERE "T_DECIMALS"."da" BETWEEN -9223372036854775809 AND 9223372036854775808;
+
+--#[between-04]
+-- between(decimal(p,s), int32, int32)
+SELECT "T_DECIMALS"."de" AS "de" FROM "default"."T_DECIMALS" AS "T_DECIMALS" WHERE "T_DECIMALS"."de" BETWEEN -1 AND 1;
+
+--#[between-05]
+-- between(decimal(p,s), int64, int64)
+SELECT "T_DECIMALS"."de" AS "de" FROM "default"."T_DECIMALS" AS "T_DECIMALS" WHERE "T_DECIMALS"."de" BETWEEN -2147483649 AND 2147483648;
+
+--#[between-06]
+-- between(decimal(p,s), decimal, decimal)
+SELECT "T_DECIMALS"."de" AS "de" FROM "default"."T_DECIMALS" AS "T_DECIMALS" WHERE "T_DECIMALS"."de" BETWEEN -9223372036854775809 AND 9223372036854775808;

--- a/src/test/resources/outputs/spark/operators/between.sql
+++ b/src/test/resources/outputs/spark/operators/between.sql
@@ -1,0 +1,23 @@
+--#[between-00]
+-- between(decimal, int32, int32)
+SELECT `T_DECIMALS`.`da` AS `da` FROM `default`.`T_DECIMALS` AS `T_DECIMALS` WHERE `T_DECIMALS`.`da` BETWEEN -1 AND 1;
+
+--#[between-01]
+-- between(decimal, int64, int64)
+SELECT `T_DECIMALS`.`da` AS `da` FROM `default`.`T_DECIMALS` AS `T_DECIMALS` WHERE `T_DECIMALS`.`da` BETWEEN -2147483649 AND 2147483648;
+
+--#[between-02]
+-- between(decimal, decimal, decimal)
+SELECT `T_DECIMALS`.`da` AS `da` FROM `default`.`T_DECIMALS` AS `T_DECIMALS` WHERE `T_DECIMALS`.`da` BETWEEN -9223372036854775809 AND 9223372036854775808;
+
+--#[between-04]
+-- between(decimal(p,s), int32, int32)
+SELECT `T_DECIMALS`.`de` AS `de` FROM `default`.`T_DECIMALS` AS `T_DECIMALS` WHERE `T_DECIMALS`.`de` BETWEEN -1 AND 1;
+
+--#[between-05]
+-- between(decimal(p,s), int64, int64)
+SELECT `T_DECIMALS`.`de` AS `de` FROM `default`.`T_DECIMALS` AS `T_DECIMALS` WHERE `T_DECIMALS`.`de` BETWEEN -2147483649 AND 2147483648;
+
+--#[between-06]
+-- between(decimal(p,s), decimal, decimal)
+SELECT `T_DECIMALS`.`de` AS `de` FROM `default`.`T_DECIMALS` AS `T_DECIMALS` WHERE `T_DECIMALS`.`de` BETWEEN -9223372036854775809 AND 9223372036854775808;

--- a/src/test/resources/outputs/trino/operators/between.sql
+++ b/src/test/resources/outputs/trino/operators/between.sql
@@ -1,0 +1,23 @@
+--#[between-00]
+-- between(decimal, int32, int32)
+SELECT "T_DECIMALS"."da" AS "da" FROM "default"."T_DECIMALS" AS "T_DECIMALS" WHERE "T_DECIMALS"."da" BETWEEN -1 AND 1;
+
+--#[between-01]
+-- between(decimal, int64, int64)
+SELECT "T_DECIMALS"."da" AS "da" FROM "default"."T_DECIMALS" AS "T_DECIMALS" WHERE "T_DECIMALS"."da" BETWEEN -2147483649 AND 2147483648;
+
+--#[between-02]
+-- between(decimal, decimal, decimal)
+SELECT "T_DECIMALS"."da" AS "da" FROM "default"."T_DECIMALS" AS "T_DECIMALS" WHERE "T_DECIMALS"."da" BETWEEN -CAST('9223372036854775809' AS DECIMAL(38,0)) AND CAST('9223372036854775808' AS DECIMAL(38,0));
+
+--#[between-04]
+-- between(decimal(p,s), int32, int32)
+SELECT "T_DECIMALS"."de" AS "de" FROM "default"."T_DECIMALS" AS "T_DECIMALS" WHERE "T_DECIMALS"."de" BETWEEN -1 AND 1;
+
+--#[between-05]
+-- between(decimal(p,s), int64, int64)
+SELECT "T_DECIMALS"."de" AS "de" FROM "default"."T_DECIMALS" AS "T_DECIMALS" WHERE "T_DECIMALS"."de" BETWEEN -2147483649 AND 2147483648;
+
+--#[between-06]
+-- between(decimal(p,s), decimal, decimal)
+SELECT "T_DECIMALS"."de" AS "de" FROM "default"."T_DECIMALS" AS "T_DECIMALS" WHERE "T_DECIMALS"."de" BETWEEN -CAST('9223372036854775809' AS DECIMAL(38,0)) AND CAST('9223372036854775808' AS DECIMAL(38,0));


### PR DESCRIPTION
*Description of changes:*

The partiql-lang-kotlin implementation inserts a `cast_decimal_arbitrary` in the plan to make coercions explicit, but these explicit casts are not needed when translating to the other dialects — because these are implicit coercions and can be omitted. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
