### PR TITLE
Apply rewrite for EXCLUDE top-level columns in Trino and Spark; apply SELECT * expansion

### DIFF
--- a/src/main/kotlin/org/partiql/scribe/ExpandStruct.kt
+++ b/src/main/kotlin/org/partiql/scribe/ExpandStruct.kt
@@ -1,0 +1,53 @@
+package org.partiql.scribe
+
+import org.partiql.plan.Rex
+import org.partiql.plan.rex
+import org.partiql.plan.rexOpLit
+import org.partiql.plan.rexOpPathKey
+import org.partiql.plan.rexOpStruct
+import org.partiql.plan.rexOpStructField
+import org.partiql.types.StaticType
+import org.partiql.types.StructType
+import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.stringValue
+
+@OptIn(PartiQLValueExperimental::class)
+internal fun expandStruct(op: Rex.Op, structType: StructType): List<Rex> {
+    return structType.fields.map { field ->
+        // Create a new struct for each field
+        Rex(
+            type = StructType(
+                fields = listOf(
+                    StructType.Field(
+                        key = field.key,
+                        value = field.value
+                    )
+                )
+            ),
+            op = rexOpStruct(
+                fields = listOf(
+                    rexOpStructField(
+                        k = Rex(
+                            type = StaticType.STRING,
+                            op = rexOpLit(
+                                stringValue(
+                                    field.key
+                                )
+                            )
+                        ),
+                        v = Rex(
+                            type = field.value,
+                            op = rexOpPathKey(
+                                root = Rex(
+                                    type = field.value,
+                                    op = op
+                                ),
+                                key = rex(StaticType.STRING, rexOpLit(stringValue(field.key)))
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    }
+}

--- a/src/main/kotlin/org/partiql/scribe/sql/RexConverter.kt
+++ b/src/main/kotlin/org/partiql/scribe/sql/RexConverter.kt
@@ -79,6 +79,9 @@ public open class RexConverter(
     }
 
     override fun visitRexOpTupleUnion(node: Rex.Op.TupleUnion, ctx: StaticType): Expr {
+        if (node.args.isEmpty()) {
+            error("TupleUnion $node has no args")
+        }
         val args = node.args.map { arg -> visitRex(arg, ctx) }
         return exprCall(
             identifierSymbol("TUPLEUNION", Identifier.CaseSensitivity.INSENSITIVE), args = args

--- a/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoTarget.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoTarget.kt
@@ -18,12 +18,14 @@ import org.partiql.plan.rexOpPathKey
 import org.partiql.plan.rexOpSelect
 import org.partiql.plan.rexOpStruct
 import org.partiql.plan.rexOpStructField
+import org.partiql.plan.rexOpTupleUnion
 import org.partiql.plan.rexOpVar
 import org.partiql.plan.util.PlanRewriter
 import org.partiql.scribe.VarToPathRewriter
 import org.partiql.scribe.ProblemCallback
 import org.partiql.scribe.ScribeProblem
 import org.partiql.scribe.asNonNullable
+import org.partiql.scribe.expandStruct
 import org.partiql.scribe.sql.SqlCalls
 import org.partiql.scribe.sql.SqlFeatures
 import org.partiql.scribe.sql.SqlTarget
@@ -98,6 +100,27 @@ public open class TrinoTarget : SqlTarget() {
     private class TrinoRewriter(val onProblem: ProblemCallback) : PlanRewriter<Rel.Type?>() {
         private val EXCLUDE_ALIAS = "\$__EXCLUDE_ALIAS__"
 
+        /**
+         * Expand every wildcard including:
+         * - relation wildcards (e.g. SELECT tbl.*) and
+         * - struct/`ROW` wildcards (e.g. `SELECT tbl.foo.*`).
+         */
+        override fun visitRexOpTupleUnion(node: Rex.Op.TupleUnion, ctx: Rel.Type?): PlanNode {
+            val newTupleUnion = super.visitRexOpTupleUnion(node, ctx) as Rex.Op.TupleUnion
+            val newArgs = mutableListOf<Rex>()
+            newTupleUnion.args.forEach { arg ->
+                val op = arg.op
+                val type = arg.type
+                // For now, just support the expansion of variable references and paths
+                if (type is StructType && (op is Rex.Op.Var || op is Rex.Op.Path)) {
+                    newArgs.addAll(expandStruct(op, type))
+                } else {
+                    newArgs.add(arg)
+                }
+            }
+            return rexOpTupleUnion(newArgs)
+        }
+
         override fun visitRelOpProject(node: Rel.Op.Project, ctx: Rel.Type?): PlanNode {
             // Make sure that the output type is homogeneous
             node.projections.forEachIndexed { index, projection ->
@@ -106,9 +129,23 @@ public open class TrinoTarget : SqlTarget() {
                     error("Projection item (index $index) is heterogeneous (${type.allTypes.joinToString(",")}) and cannot be coerced to a single type.")
                 }
             }
-            val project = super.visitRelOpProject(node, ctx) as Rel.Op.Project
-            return if (node.input.op is Rel.Op.Exclude) {
-                // When the Rel.Op.Project's input Rel.Op is Exclude
+            val inputOp = node.input.op
+            val newNode = if (inputOp is Rel.Op.Exclude) {
+                // Check for special case involving just top-level column exclusions (i.e. # of steps is 1)
+                if (inputOp.items.all { it.steps.size == 1 }) {
+                    node.copy(
+                        input = inputOp.input   // get rid of `EXCLUDE` in plan; pass in `EXCLUDE`'s input Rel
+                    )
+                } else {
+                    // `EXCLUDE` node with non-top-level column exclusions; run existing `EXCLUDE` logic
+                    node
+                }
+            } else {
+                node
+            }
+            val project = super.visitRelOpProject(newNode, ctx) as Rel.Op.Project
+            return if (newNode.input.op is Rel.Op.Exclude) {
+                // When the Rel.Op.Project's input Rel.Op is Exclude and has deeper nested `EXCLUDE` paths
                 // 1. Rewrite the Rel's type schema to wrap the existing bindings in a new binding, `$__EXCLUDE_ALIAS__`
                 //    For example if schema was originally
                 //          [ <binding_name_1: type_1>, <binding_name_2: type_2> ]

--- a/src/test/resources/outputs/spark/basics/exclude.sql
+++ b/src/test/resources/outputs/spark/basics/exclude.sql
@@ -1,40 +1,101 @@
 --#[exclude-00]
-SELECT `$__EXCLUDE_ALIAS__`.`t`.* FROM (SELECT STRUCT(STRUCT(STRUCT(`t`.`flds`.`a`.`field_x` AS `field_x`, `t`.`flds`.`a`.`field_y` AS `field_y`) AS `a`, STRUCT(`t`.`flds`.`b`.`field_x` AS `field_x`, `t`.`flds`.`b`.`field_y` AS `field_y`) AS `b`, STRUCT(`t`.`flds`.`c`.`field_x` AS `field_x`, `t`.`flds`.`c`.`field_y` AS `field_y`) AS `c`) AS `flds`) AS `t` FROM `default`.`EXCLUDE_T` AS `t`) AS `$__EXCLUDE_ALIAS__`;
+SELECT `t`.`flds` AS `flds` FROM `default`.`EXCLUDE_T` AS `t`;
 
 --#[exclude-01]
-SELECT `$__EXCLUDE_ALIAS__`.`t`.* FROM (SELECT STRUCT(`t`.`foo` AS `foo`) AS `t` FROM `default`.`EXCLUDE_T` AS `t`) AS `$__EXCLUDE_ALIAS__`;
+SELECT `t`.`foo` AS `foo` FROM `default`.`EXCLUDE_T` AS `t`;
 
 --#[exclude-02]
-SELECT `$__EXCLUDE_ALIAS__`.`t`.* FROM (SELECT STRUCT(STRUCT(STRUCT(`t`.`flds`.`a`.`field_x` AS `field_x`, `t`.`flds`.`a`.`field_y` AS `field_y`) AS `a`, STRUCT(`t`.`flds`.`c`.`field_x` AS `field_x`, `t`.`flds`.`c`.`field_y` AS `field_y`) AS `c`) AS `flds`, `t`.`foo` AS `foo`) AS `t` FROM `default`.`EXCLUDE_T` AS `t`) AS `$__EXCLUDE_ALIAS__`;
+SELECT `$__EXCLUDE_ALIAS__`.`t`.`flds` AS `flds`, `$__EXCLUDE_ALIAS__`.`t`.`foo` AS `foo` FROM (SELECT STRUCT(STRUCT(STRUCT(`t`.`flds`.`a`.`field_x` AS `field_x`, `t`.`flds`.`a`.`field_y` AS `field_y`) AS `a`, STRUCT(`t`.`flds`.`c`.`field_x` AS `field_x`, `t`.`flds`.`c`.`field_y` AS `field_y`) AS `c`) AS `flds`, `t`.`foo` AS `foo`) AS `t` FROM `default`.`EXCLUDE_T` AS `t`) AS `$__EXCLUDE_ALIAS__`;
 
 --#[exclude-03]
-SELECT `$__EXCLUDE_ALIAS__`.`t`.* FROM (SELECT STRUCT(STRUCT(STRUCT(`t`.`flds`.`a`.`field_x` AS `field_x`, `t`.`flds`.`a`.`field_y` AS `field_y`) AS `a`, STRUCT(`t`.`flds`.`b`.`field_x` AS `field_x`, `t`.`flds`.`b`.`field_y` AS `field_y`) AS `b`, STRUCT(`t`.`flds`.`c`.`field_y` AS `field_y`) AS `c`) AS `flds`, `t`.`foo` AS `foo`) AS `t` FROM `default`.`EXCLUDE_T` AS `t`) AS `$__EXCLUDE_ALIAS__`;
+SELECT `$__EXCLUDE_ALIAS__`.`t`.`flds` AS `flds`, `$__EXCLUDE_ALIAS__`.`t`.`foo` AS `foo` FROM (SELECT STRUCT(STRUCT(STRUCT(`t`.`flds`.`a`.`field_x` AS `field_x`, `t`.`flds`.`a`.`field_y` AS `field_y`) AS `a`, STRUCT(`t`.`flds`.`b`.`field_x` AS `field_x`, `t`.`flds`.`b`.`field_y` AS `field_y`) AS `b`, STRUCT(`t`.`flds`.`c`.`field_y` AS `field_y`) AS `c`) AS `flds`, `t`.`foo` AS `foo`) AS `t` FROM `default`.`EXCLUDE_T` AS `t`) AS `$__EXCLUDE_ALIAS__`;
 
 --#[exclude-04]
-SELECT `$__EXCLUDE_ALIAS__`.`t`.* FROM (SELECT STRUCT(STRUCT(STRUCT(`t`.`flds`.`a`.`field_x` AS `field_x`, `t`.`flds`.`a`.`field_y` AS `field_y`) AS `a`, STRUCT(`t`.`flds`.`c`.`field_y` AS `field_y`) AS `c`) AS `flds`, `t`.`foo` AS `foo`) AS `t` FROM `default`.`EXCLUDE_T` AS `t`) AS `$__EXCLUDE_ALIAS__`;
+SELECT `$__EXCLUDE_ALIAS__`.`t`.`flds` AS `flds`, `$__EXCLUDE_ALIAS__`.`t`.`foo` AS `foo` FROM (SELECT STRUCT(STRUCT(STRUCT(`t`.`flds`.`a`.`field_x` AS `field_x`, `t`.`flds`.`a`.`field_y` AS `field_y`) AS `a`, STRUCT(`t`.`flds`.`c`.`field_y` AS `field_y`) AS `c`) AS `flds`, `t`.`foo` AS `foo`) AS `t` FROM `default`.`EXCLUDE_T` AS `t`) AS `$__EXCLUDE_ALIAS__`;
 
 --#[exclude-05]
-SELECT `$__EXCLUDE_ALIAS__`.`t`.* FROM (SELECT STRUCT(STRUCT(STRUCT(`t`.`flds`.`a`.`field_x` AS `field_x`, `t`.`flds`.`a`.`field_y` AS `field_y`) AS `a`, STRUCT(`t`.`flds`.`b`.`field_x` AS `field_x`, `t`.`flds`.`b`.`field_y` AS `field_y`) AS `b`, STRUCT(`t`.`flds`.`c`.`field_x` AS `field_x`) AS `c`) AS `flds`, `t`.`foo` AS `foo`) AS `t` FROM `default`.`EXCLUDE_T` AS `t`) AS `$__EXCLUDE_ALIAS__`;
+SELECT `$__EXCLUDE_ALIAS__`.`t`.`flds` AS `flds`, `$__EXCLUDE_ALIAS__`.`t`.`foo` AS `foo` FROM (SELECT STRUCT(STRUCT(STRUCT(`t`.`flds`.`a`.`field_x` AS `field_x`, `t`.`flds`.`a`.`field_y` AS `field_y`) AS `a`, STRUCT(`t`.`flds`.`b`.`field_x` AS `field_x`, `t`.`flds`.`b`.`field_y` AS `field_y`) AS `b`, STRUCT(`t`.`flds`.`c`.`field_x` AS `field_x`) AS `c`) AS `flds`, `t`.`foo` AS `foo`) AS `t` FROM `default`.`EXCLUDE_T` AS `t`) AS `$__EXCLUDE_ALIAS__`;
 
 --#[exclude-06]
 -- Exclude all the fields of `t.flds.c`
-SELECT `$__EXCLUDE_ALIAS__`.`t`.* FROM (SELECT STRUCT(STRUCT(STRUCT(`t`.`flds`.`a`.`field_x` AS `field_x`, `t`.`flds`.`a`.`field_y` AS `field_y`) AS `a`, STRUCT(`t`.`flds`.`b`.`field_x` AS `field_x`, `t`.`flds`.`b`.`field_y` AS `field_y`) AS `b`, STRUCT() AS `c`) AS `flds`, `t`.`foo` AS `foo`) AS `t` FROM `default`.`EXCLUDE_T` AS `t`) AS `$__EXCLUDE_ALIAS__`;
+SELECT `$__EXCLUDE_ALIAS__`.`t`.`flds` AS `flds`, `$__EXCLUDE_ALIAS__`.`t`.`foo` AS `foo` FROM (SELECT STRUCT(STRUCT(STRUCT(`t`.`flds`.`a`.`field_x` AS `field_x`, `t`.`flds`.`a`.`field_y` AS `field_y`) AS `a`, STRUCT(`t`.`flds`.`b`.`field_x` AS `field_x`, `t`.`flds`.`b`.`field_y` AS `field_y`) AS `b`, STRUCT() AS `c`) AS `flds`, `t`.`foo` AS `foo`) AS `t` FROM `default`.`EXCLUDE_T` AS `t`) AS `$__EXCLUDE_ALIAS__`;
 
 -- START OF EXCLUDE with COLLECTION WILDCARD
 --#[exclude-07]
-SELECT `$__EXCLUDE_ALIAS__`.`t`.* FROM (SELECT STRUCT(`transform`(`t`.`a`, ___coll_wildcard___ -> STRUCT(___coll_wildcard___.`field_y` AS `field_y`)) AS `a`, `t`.`foo` AS `foo`) AS `t` FROM `default`.`EXCLUDE_T_COLL_WILDCARD` AS `t`) AS `$__EXCLUDE_ALIAS__`;
+SELECT `$__EXCLUDE_ALIAS__`.`t`.`a` AS `a`, `$__EXCLUDE_ALIAS__`.`t`.`foo` AS `foo` FROM (SELECT STRUCT(`transform`(`t`.`a`, ___coll_wildcard___ -> STRUCT(___coll_wildcard___.`field_y` AS `field_y`)) AS `a`, `t`.`foo` AS `foo`) AS `t` FROM `default`.`EXCLUDE_T_COLL_WILDCARD` AS `t`) AS `$__EXCLUDE_ALIAS__`;
 
 --#[exclude-08]
-SELECT `$__EXCLUDE_ALIAS__`.`t`.* FROM (SELECT STRUCT(`transform`(`t`.`a`, ___coll_wildcard___ -> STRUCT(___coll_wildcard___.`field_x` AS `field_x`)) AS `a`, `t`.`foo` AS `foo`) AS `t` FROM `default`.`EXCLUDE_T_COLL_WILDCARD` AS `t`) AS `$__EXCLUDE_ALIAS__`;
+SELECT `$__EXCLUDE_ALIAS__`.`t`.`a` AS `a`, `$__EXCLUDE_ALIAS__`.`t`.`foo` AS `foo` FROM (SELECT STRUCT(`transform`(`t`.`a`, ___coll_wildcard___ -> STRUCT(___coll_wildcard___.`field_x` AS `field_x`)) AS `a`, `t`.`foo` AS `foo`) AS `t` FROM `default`.`EXCLUDE_T_COLL_WILDCARD` AS `t`) AS `$__EXCLUDE_ALIAS__`;
 
 --#[exclude-09]
 -- EXCLUDE with JOIN and WHERE clause
-SELECT `$__EXCLUDE_ALIAS__`.`t1`.*, `$__EXCLUDE_ALIAS__`.`t2`.* FROM (SELECT STRUCT(STRUCT(STRUCT(`t1`.`flds`.`a`.`field_x` AS `field_x`, `t1`.`flds`.`a`.`field_y` AS `field_y`) AS `a`, STRUCT(`t1`.`flds`.`b`.`field_x` AS `field_x`, `t1`.`flds`.`b`.`field_y` AS `field_y`) AS `b`, STRUCT(`t1`.`flds`.`c`.`field_x` AS `field_x`, `t1`.`flds`.`c`.`field_y` AS `field_y`) AS `c`) AS `flds`) AS `t1`, STRUCT(STRUCT(STRUCT(`t2`.`flds`.`a`.`field_x` AS `field_x`, `t2`.`flds`.`a`.`field_y` AS `field_y`) AS `a`, STRUCT(`t2`.`flds`.`c`.`field_y` AS `field_y`) AS `c`) AS `flds`, `t2`.`foo` AS `foo`) AS `t2` FROM `default`.`EXCLUDE_T` AS `t1` INNER JOIN `default`.`EXCLUDE_T` AS `t2` ON true WHERE `t1`.`foo` = `t2`.`foo`) AS `$__EXCLUDE_ALIAS__`;
+SELECT `$__EXCLUDE_ALIAS__`.`t1`.`flds` AS `flds`, `$__EXCLUDE_ALIAS__`.`t2`.`flds` AS `flds`, `$__EXCLUDE_ALIAS__`.`t2`.`foo` AS `foo` FROM (SELECT STRUCT(STRUCT(STRUCT(`t1`.`flds`.`a`.`field_x` AS `field_x`, `t1`.`flds`.`a`.`field_y` AS `field_y`) AS `a`, STRUCT(`t1`.`flds`.`b`.`field_x` AS `field_x`, `t1`.`flds`.`b`.`field_y` AS `field_y`) AS `b`, STRUCT(`t1`.`flds`.`c`.`field_x` AS `field_x`, `t1`.`flds`.`c`.`field_y` AS `field_y`) AS `c`) AS `flds`) AS `t1`, STRUCT(STRUCT(STRUCT(`t2`.`flds`.`a`.`field_x` AS `field_x`, `t2`.`flds`.`a`.`field_y` AS `field_y`) AS `a`, STRUCT(`t2`.`flds`.`c`.`field_y` AS `field_y`) AS `c`) AS `flds`, `t2`.`foo` AS `foo`) AS `t2` FROM `default`.`EXCLUDE_T` AS `t1` INNER JOIN `default`.`EXCLUDE_T` AS `t2` ON true WHERE `t1`.`foo` = `t2`.`foo`) AS `$__EXCLUDE_ALIAS__`;
 
 --#[exclude-10]
 -- EXCLUDE with multiple JOIN and WHERE clause
-SELECT `$__EXCLUDE_ALIAS__`.`t1`.*, `$__EXCLUDE_ALIAS__`.`t2`.*, `$__EXCLUDE_ALIAS__`.`t3`.* FROM (SELECT STRUCT(STRUCT(STRUCT(`t1`.`flds`.`b`.`field_x` AS `field_x`, `t1`.`flds`.`b`.`field_y` AS `field_y`) AS `b`, STRUCT(`t1`.`flds`.`c`.`field_x` AS `field_x`, `t1`.`flds`.`c`.`field_y` AS `field_y`) AS `c`) AS `flds`, `t1`.`foo` AS `foo`) AS `t1`, STRUCT(STRUCT(STRUCT(`t2`.`flds`.`a`.`field_x` AS `field_x`, `t2`.`flds`.`a`.`field_y` AS `field_y`) AS `a`, STRUCT(`t2`.`flds`.`c`.`field_x` AS `field_x`, `t2`.`flds`.`c`.`field_y` AS `field_y`) AS `c`) AS `flds`, `t2`.`foo` AS `foo`) AS `t2`, STRUCT(STRUCT(STRUCT(`t3`.`flds`.`a`.`field_x` AS `field_x`, `t3`.`flds`.`a`.`field_y` AS `field_y`) AS `a`, STRUCT(`t3`.`flds`.`b`.`field_x` AS `field_x`, `t3`.`flds`.`b`.`field_y` AS `field_y`) AS `b`) AS `flds`, `t3`.`foo` AS `foo`) AS `t3` FROM `default`.`EXCLUDE_T` AS `t1` INNER JOIN `default`.`EXCLUDE_T` AS `t2` ON true INNER JOIN `default`.`EXCLUDE_T` AS `t3` ON true WHERE (`t1`.`foo` = `t2`.`foo`) AND (`t2`.`foo` = `t3`.`foo`)) AS `$__EXCLUDE_ALIAS__`;
+SELECT `$__EXCLUDE_ALIAS__`.`t1`.`flds` AS `flds`, `$__EXCLUDE_ALIAS__`.`t1`.`foo` AS `foo`, `$__EXCLUDE_ALIAS__`.`t2`.`flds` AS `flds`, `$__EXCLUDE_ALIAS__`.`t2`.`foo` AS `foo`, `$__EXCLUDE_ALIAS__`.`t3`.`flds` AS `flds`, `$__EXCLUDE_ALIAS__`.`t3`.`foo` AS `foo` FROM (SELECT STRUCT(STRUCT(STRUCT(`t1`.`flds`.`b`.`field_x` AS `field_x`, `t1`.`flds`.`b`.`field_y` AS `field_y`) AS `b`, STRUCT(`t1`.`flds`.`c`.`field_x` AS `field_x`, `t1`.`flds`.`c`.`field_y` AS `field_y`) AS `c`) AS `flds`, `t1`.`foo` AS `foo`) AS `t1`, STRUCT(STRUCT(STRUCT(`t2`.`flds`.`a`.`field_x` AS `field_x`, `t2`.`flds`.`a`.`field_y` AS `field_y`) AS `a`, STRUCT(`t2`.`flds`.`c`.`field_x` AS `field_x`, `t2`.`flds`.`c`.`field_y` AS `field_y`) AS `c`) AS `flds`, `t2`.`foo` AS `foo`) AS `t2`, STRUCT(STRUCT(STRUCT(`t3`.`flds`.`a`.`field_x` AS `field_x`, `t3`.`flds`.`a`.`field_y` AS `field_y`) AS `a`, STRUCT(`t3`.`flds`.`b`.`field_x` AS `field_x`, `t3`.`flds`.`b`.`field_y` AS `field_y`) AS `b`) AS `flds`, `t3`.`foo` AS `foo`) AS `t3` FROM `default`.`EXCLUDE_T` AS `t1` INNER JOIN `default`.`EXCLUDE_T` AS `t2` ON true INNER JOIN `default`.`EXCLUDE_T` AS `t3` ON true WHERE (`t1`.`foo` = `t2`.`foo`) AND (`t2`.`foo` = `t3`.`foo`)) AS `$__EXCLUDE_ALIAS__`;
 
 --#[exclude-11]
 -- EXCLUDE with select projection list and multiple JOINs
 SELECT `$__EXCLUDE_ALIAS__`.`t1`.`flds` AS `flds`, `$__EXCLUDE_ALIAS__`.`t2`.`flds` AS `flds`, `$__EXCLUDE_ALIAS__`.`t3`.`flds` AS `flds` FROM (SELECT STRUCT(STRUCT(STRUCT(`t1`.`flds`.`b`.`field_x` AS `field_x`, `t1`.`flds`.`b`.`field_y` AS `field_y`) AS `b`, STRUCT(`t1`.`flds`.`c`.`field_x` AS `field_x`, `t1`.`flds`.`c`.`field_y` AS `field_y`) AS `c`) AS `flds`, `t1`.`foo` AS `foo`) AS `t1`, STRUCT(STRUCT(STRUCT(`t2`.`flds`.`a`.`field_x` AS `field_x`, `t2`.`flds`.`a`.`field_y` AS `field_y`) AS `a`, STRUCT(`t2`.`flds`.`c`.`field_x` AS `field_x`, `t2`.`flds`.`c`.`field_y` AS `field_y`) AS `c`) AS `flds`, `t2`.`foo` AS `foo`) AS `t2`, STRUCT(STRUCT(STRUCT(`t3`.`flds`.`a`.`field_x` AS `field_x`, `t3`.`flds`.`a`.`field_y` AS `field_y`) AS `a`, STRUCT(`t3`.`flds`.`b`.`field_x` AS `field_x`, `t3`.`flds`.`b`.`field_y` AS `field_y`) AS `b`) AS `flds`, `t3`.`foo` AS `foo`) AS `t3` FROM `default`.`EXCLUDE_T` AS `t1` INNER JOIN `default`.`EXCLUDE_T` AS `t2` ON true INNER JOIN `default`.`EXCLUDE_T` AS `t3` ON true WHERE (`t1`.`foo` = `t2`.`foo`) AND (`t2`.`foo` = `t3`.`foo`)) AS `$__EXCLUDE_ALIAS__`;
+
+-- Tests for EXCLUDE on top-level columns only --
+-- Baseline query without `EXCLUDE`
+--#[exclude-36]
+SELECT `t`.`a` AS `a`, `t`.`b` AS `b`, `t`.`c` AS `c`, `t`.`d` AS `d`, `t`.`e` AS `e`, `t`.`f` AS `f`, `t`.`g` AS `g` FROM `default`.`T_EXCLUDE_TOP_LEVEL` AS `t`;
+
+-- EXCLUDE single top-level column (no `t.a`)
+--#[exclude-37]
+SELECT `t`.`b` AS `b`, `t`.`c` AS `c`, `t`.`d` AS `d`, `t`.`e` AS `e`, `t`.`f` AS `f`, `t`.`g` AS `g` FROM `default`.`T_EXCLUDE_TOP_LEVEL` AS `t`;
+
+-- EXCLUDE multiple top-level columns (no `t.a` through `t.e`)
+--#[exclude-38]
+SELECT `t`.`f` AS `f`, `t`.`g` AS `g` FROM `default`.`T_EXCLUDE_TOP_LEVEL` AS `t`;
+
+-- EXCLUDE top-level columns with WHERE
+--#[exclude-39]
+SELECT `t`.`c` AS `c`, `t`.`d` AS `d`, `t`.`e` AS `e`, `t`.`f` AS `f`, `t`.`g` AS `g` FROM `default`.`T_EXCLUDE_TOP_LEVEL` AS `t` WHERE `t`.`a` AND (`t`.`c` = 'remove');
+
+-- EXCLUDE top-level columns with explicit SELECT list
+--#[exclude-40]
+SELECT `t`.`c` AS `c`, `t`.`d` AS `d`, `t`.`e` AS `e`, `t`.`f` AS `f`, `t`.`g` AS `g` FROM `default`.`T_EXCLUDE_TOP_LEVEL` AS `t` WHERE `t`.`a` AND (`t`.`c` = 'remove');
+
+-- EXCLUDE top-level with subquery
+--#[exclude-41]
+SELECT `subq`.`a` AS `a`, `subq`.`b` AS `b`, `subq`.`c` AS `c`, `subq`.`d` AS `d`, `subq`.`e` AS `e`, `subq`.`f` AS `f`, `subq`.`g` AS `g` FROM (SELECT `t`.`a` AS `a`, `t`.`b` AS `b`, `t`.`c` AS `c`, `t`.`d` AS `d`, `t`.`e` AS `e`, `t`.`f` AS `f`, `t`.`g` AS `g`, 'foo' AS `remove_me` FROM `default`.`T_EXCLUDE_TOP_LEVEL` AS `t` WHERE `t`.`a`) AS `subq`;
+
+-- EXCLUDE top-level columns with JOIN
+--#[exclude-42]
+SELECT `t1`.`b` AS `b`, `t1`.`d` AS `d`, `t1`.`f` AS `f`, `t2`.`a` AS `a`, `t2`.`c` AS `c`, `t2`.`e` AS `e`, `t2`.`g` AS `g` FROM `default`.`T_EXCLUDE_TOP_LEVEL` AS `t1` INNER JOIN `default`.`T_EXCLUDE_TOP_LEVEL` AS `t2` ON true;
+
+-- EXCLUDE top-level columns with JOIN and WHERE
+--#[exclude-43]
+SELECT `t1`.`b` AS `b`, `t1`.`d` AS `d`, `t1`.`f` AS `f`, `t2`.`a` AS `a`, `t2`.`c` AS `c`, `t2`.`e` AS `e`, `t2`.`g` AS `g` FROM `default`.`T_EXCLUDE_TOP_LEVEL` AS `t1` INNER JOIN `default`.`T_EXCLUDE_TOP_LEVEL` AS `t2` ON true WHERE `t1`.`a` AND `t2`.`a`;
+
+-- EXCLUDE top-level columns with JOIN and WHERE and specified SELECT element
+--#[exclude-44]
+SELECT `t1`.`b` AS `b`, `t1`.`d` AS `d`, `t1`.`f` AS `f` FROM `default`.`T_EXCLUDE_TOP_LEVEL` AS `t1` INNER JOIN `default`.`T_EXCLUDE_TOP_LEVEL` AS `t2` ON true WHERE `t1`.`a` AND `t2`.`a`;
+
+-- EXCLUDE top-level columns with JOIN and WHERE and specified SELECT elements
+--#[exclude-45]
+SELECT `t1`.`b` AS `b`, `t1`.`d` AS `d`, `t1`.`f` AS `f`, `t2`.`a` AS `special` FROM `default`.`T_EXCLUDE_TOP_LEVEL` AS `t1` INNER JOIN `default`.`T_EXCLUDE_TOP_LEVEL` AS `t2` ON true WHERE `t1`.`a` AND `t2`.`a`;
+
+-- EXCLUDE top-level columns with multiple JOINs
+--#[exclude-46]
+SELECT
+    `t1`.`a` AS `a`,
+    `t2`.`b` AS `b`,
+    `t3`.`c` AS `c`,
+    `t4`.`d` AS `d`,
+    `t5`.`e` AS `e`,
+    `t6`.`f` AS `f`,
+    `t7`.`g` AS `g`
+FROM
+    `default`.`T_EXCLUDE_TOP_LEVEL` AS `t1` INNER JOIN
+    `default`.`T_EXCLUDE_TOP_LEVEL` AS `t2` ON `t2`.`a` LEFT OUTER JOIN
+    `default`.`T_EXCLUDE_TOP_LEVEL` AS `t3` ON `t3`.`a` INNER JOIN
+    `default`.`T_EXCLUDE_TOP_LEVEL` AS `t4` ON `t4`.`a` RIGHT OUTER JOIN
+    `default`.`T_EXCLUDE_TOP_LEVEL` AS `t5` ON `t5`.`a` FULL OUTER JOIN
+    `default`.`T_EXCLUDE_TOP_LEVEL` AS `t6` ON `t6`.`a` INNER JOIN
+    `default`.`T_EXCLUDE_TOP_LEVEL` AS `t7` ON true
+WHERE `t1`.`a` AND `t2`.`a`;

--- a/src/test/resources/outputs/spark/basics/select.sql
+++ b/src/test/resources/outputs/spark/basics/select.sql
@@ -2,7 +2,7 @@
 SELECT `T`.`a` AS `a`, `T`.`b` AS `b`, `T`.`c` AS `c` FROM `default`.`T` AS `T`;
 
 --#[select-01]
-SELECT `T`.* FROM `default`.`T` AS `T`;
+SELECT `T`.`a` AS `a`, `T`.`b` AS `b`, `T`.`c` AS `c`, `T`.`d` AS `d`, `T`.`x` AS `x`, `T`.`array` AS `array`, `T`.`z` AS `z`, `T`.`v` AS `v`, `T`.`timestamp_1` AS `timestamp_1`, `T`.`timestamp_2` AS `timestamp_2` FROM `default`.`T` AS `T`;
 
 -- #[select-02]
 -- ERROR, no SELECT VALUE!
@@ -13,22 +13,22 @@ SELECT `T`.* FROM `default`.`T` AS `T`;
 -- SELECT VALUE a FROM default.T AS T;
 
 --#[select-04]
-SELECT `t1`.*, `t2`.* FROM `default`.`T` AS `t1` INNER JOIN `default`.`T` AS `t2` ON true;
+SELECT `t1`.`a` AS `a`, `t1`.`b` AS `b`, `t1`.`c` AS `c`, `t1`.`d` AS `d`, `t1`.`x` AS `x`, `t1`.`array` AS `array`, `t1`.`z` AS `z`, `t1`.`v` AS `v`, `t1`.`timestamp_1` AS `timestamp_1`, `t1`.`timestamp_2` AS `timestamp_2`, `t2`.`a` AS `a`, `t2`.`b` AS `b`, `t2`.`c` AS `c`, `t2`.`d` AS `d`, `t2`.`x` AS `x`, `t2`.`array` AS `array`, `t2`.`z` AS `z`, `t2`.`v` AS `v`, `t2`.`timestamp_1` AS `timestamp_1`, `t2`.`timestamp_2` AS `timestamp_2` FROM `default`.`T` AS `t1` INNER JOIN `default`.`T` AS `t2` ON true;
 
 --#[select-05]
-SELECT `T`.`d`.* FROM `default`.`T` AS `T`;
+SELECT `T`.`d`.`e` AS `e` FROM `default`.`T` AS `T`;
 
 --#[select-06]
-SELECT `T` AS `t`, `T`.`d`.* FROM `default`.`T` AS `T`;
+SELECT `T` AS `t`, `T`.`d`.`e` AS `e` FROM `default`.`T` AS `T`;
 
 --#[select-07]
-SELECT `T`.`d`.*, `T`.`d`.* FROM `default`.`T` AS `T`;
+SELECT `T`.`d`.`e` AS `e`, `T`.`d`.`e` AS `e` FROM `default`.`T` AS `T`;
 
 --#[select-08]
-SELECT `T`.`d`.* FROM `default`.`T` AS `T`;
+SELECT `T`.`d`.`e` AS `e` FROM `default`.`T` AS `T`;
 
 --#[select-09]
-SELECT `T`.* FROM `default`.`T` AS `T`;
+SELECT `T`.`a` AS `a`, `T`.`b` AS `b`, `T`.`c` AS `c`, `T`.`d` AS `d`, `T`.`x` AS `x`, `T`.`array` AS `array`, `T`.`z` AS `z`, `T`.`v` AS `v`, `T`.`timestamp_1` AS `timestamp_1`, `T`.`timestamp_2` AS `timestamp_2` FROM `default`.`T` AS `T`;
 
 --#[select-10]
 SELECT `T`.`c` || `current_user`() AS `_1` FROM `default`.`T` AS `T`;

--- a/src/test/resources/outputs/spark/operators/in.sql
+++ b/src/test/resources/outputs/spark/operators/in.sql
@@ -1,17 +1,17 @@
 --#[in-00]
-SELECT `T`.* FROM `default`.`T` AS `T` WHERE `T`.`b` IN (1, 2);
+SELECT `T`.`a` AS `a`, `T`.`b` AS `b`, `T`.`c` AS `c`, `T`.`d` AS `d`, `T`.`x` AS `x`, `T`.`array` AS `array`, `T`.`z` AS `z`, `T`.`v` AS `v`, `T`.`timestamp_1` AS `timestamp_1`, `T`.`timestamp_2` AS `timestamp_2` FROM `default`.`T` AS `T` WHERE `T`.`b` IN (1, 2);
 
 --#[in-01]
-SELECT `T`.* FROM `default`.`T` AS `T` WHERE `T`.`b` IN (1, 2);
+SELECT `T`.`a` AS `a`, `T`.`b` AS `b`, `T`.`c` AS `c`, `T`.`d` AS `d`, `T`.`x` AS `x`, `T`.`array` AS `array`, `T`.`z` AS `z`, `T`.`v` AS `v`, `T`.`timestamp_1` AS `timestamp_1`, `T`.`timestamp_2` AS `timestamp_2` FROM `default`.`T` AS `T` WHERE `T`.`b` IN (1, 2);
 
 --#[in-02]
-SELECT `T`.* FROM `default`.`T` AS `T` WHERE `T`.`b` IN (1, 2);
+SELECT `T`.`a` AS `a`, `T`.`b` AS `b`, `T`.`c` AS `c`, `T`.`d` AS `d`, `T`.`x` AS `x`, `T`.`array` AS `array`, `T`.`z` AS `z`, `T`.`v` AS `v`, `T`.`timestamp_1` AS `timestamp_1`, `T`.`timestamp_2` AS `timestamp_2` FROM `default`.`T` AS `T` WHERE `T`.`b` IN (1, 2);
 
 --#[in-03]
-SELECT `T`.* FROM `default`.`T` AS `T` WHERE `T`.`b` NOT IN (1, 2);
+SELECT `T`.`a` AS `a`, `T`.`b` AS `b`, `T`.`c` AS `c`, `T`.`d` AS `d`, `T`.`x` AS `x`, `T`.`array` AS `array`, `T`.`z` AS `z`, `T`.`v` AS `v`, `T`.`timestamp_1` AS `timestamp_1`, `T`.`timestamp_2` AS `timestamp_2` FROM `default`.`T` AS `T` WHERE `T`.`b` NOT IN (1, 2);
 
 --#[in-04]
-SELECT `T`.* FROM `default`.`T` AS `T` WHERE `T`.`b` NOT IN (1, 2);
+SELECT `T`.`a` AS `a`, `T`.`b` AS `b`, `T`.`c` AS `c`, `T`.`d` AS `d`, `T`.`x` AS `x`, `T`.`array` AS `array`, `T`.`z` AS `z`, `T`.`v` AS `v`, `T`.`timestamp_1` AS `timestamp_1`, `T`.`timestamp_2` AS `timestamp_2` FROM `default`.`T` AS `T` WHERE `T`.`b` NOT IN (1, 2);
 
 --#[in-05]
-SELECT `T`.* FROM `default`.`T` AS `T` WHERE `T`.`b` NOT IN (1, 2);
+SELECT `T`.`a` AS `a`, `T`.`b` AS `b`, `T`.`c` AS `c`, `T`.`d` AS `d`, `T`.`x` AS `x`, `T`.`array` AS `array`, `T`.`z` AS `z`, `T`.`v` AS `v`, `T`.`timestamp_1` AS `timestamp_1`, `T`.`timestamp_2` AS `timestamp_2` FROM `default`.`T` AS `T` WHERE `T`.`b` NOT IN (1, 2);

--- a/src/test/resources/outputs/trino/basics/exclude.sql
+++ b/src/test/resources/outputs/trino/basics/exclude.sql
@@ -1,20 +1,20 @@
 --#[exclude-00]
-SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT CAST(ROW((SELECT (SELECT "t"."flds"."a"."field_x" AS field_x, "t"."flds"."a"."field_y" AS field_y) AS a, (SELECT "t"."flds"."b"."field_x" AS field_x, "t"."flds"."b"."field_y" AS field_y) AS b, (SELECT "t"."flds"."c"."field_x" AS field_x, "t"."flds"."c"."field_y" AS field_y) AS c)) AS ROW(flds ROW(a ROW(field_x INTEGER, field_y VARCHAR), b ROW(field_x INTEGER, field_y VARCHAR), c ROW(field_x INTEGER, field_y VARCHAR)))) AS "t" FROM "default"."EXCLUDE_T" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "t"."flds" AS "flds" FROM "default"."EXCLUDE_T" AS "t";
 
 --#[exclude-01]
-SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT CAST(ROW("t"."foo") AS ROW(foo VARCHAR)) AS "t" FROM "default"."EXCLUDE_T" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "t"."foo" AS "foo" FROM "default"."EXCLUDE_T" AS "t";
 
 --#[exclude-02]
-SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT (SELECT (SELECT (SELECT "t"."flds"."a"."field_x" AS field_x, "t"."flds"."a"."field_y" AS field_y) AS a, (SELECT "t"."flds"."c"."field_x" AS field_x, "t"."flds"."c"."field_y" AS field_y) AS c) AS flds, "t"."foo" AS foo) AS "t" FROM "default"."EXCLUDE_T" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "$__EXCLUDE_ALIAS__"."t"."flds" AS "flds", "$__EXCLUDE_ALIAS__"."t"."foo" AS "foo" FROM (SELECT (SELECT (SELECT (SELECT "t"."flds"."a"."field_x" AS field_x, "t"."flds"."a"."field_y" AS field_y) AS a, (SELECT "t"."flds"."c"."field_x" AS field_x, "t"."flds"."c"."field_y" AS field_y) AS c) AS flds, "t"."foo" AS foo) AS "t" FROM "default"."EXCLUDE_T" AS "t") AS "$__EXCLUDE_ALIAS__";
 
 --#[exclude-03]
-SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT (SELECT (SELECT (SELECT "t"."flds"."a"."field_x" AS field_x, "t"."flds"."a"."field_y" AS field_y) AS a, (SELECT "t"."flds"."b"."field_x" AS field_x, "t"."flds"."b"."field_y" AS field_y) AS b, CAST(ROW("t"."flds"."c"."field_y") AS ROW(field_y VARCHAR)) AS c) AS flds, "t"."foo" AS foo) AS "t" FROM "default"."EXCLUDE_T" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "$__EXCLUDE_ALIAS__"."t"."flds" AS "flds", "$__EXCLUDE_ALIAS__"."t"."foo" AS "foo" FROM (SELECT (SELECT (SELECT (SELECT "t"."flds"."a"."field_x" AS field_x, "t"."flds"."a"."field_y" AS field_y) AS a, (SELECT "t"."flds"."b"."field_x" AS field_x, "t"."flds"."b"."field_y" AS field_y) AS b, CAST(ROW("t"."flds"."c"."field_y") AS ROW(field_y VARCHAR)) AS c) AS flds, "t"."foo" AS foo) AS "t" FROM "default"."EXCLUDE_T" AS "t") AS "$__EXCLUDE_ALIAS__";
 
 --#[exclude-04]
-SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT (SELECT (SELECT (SELECT "t"."flds"."a"."field_x" AS field_x, "t"."flds"."a"."field_y" AS field_y) AS a, CAST(ROW("t"."flds"."c"."field_y") AS ROW(field_y VARCHAR)) AS c) AS flds, "t"."foo" AS foo) AS "t" FROM "default"."EXCLUDE_T" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "$__EXCLUDE_ALIAS__"."t"."flds" AS "flds", "$__EXCLUDE_ALIAS__"."t"."foo" AS "foo" FROM (SELECT (SELECT (SELECT (SELECT "t"."flds"."a"."field_x" AS field_x, "t"."flds"."a"."field_y" AS field_y) AS a, CAST(ROW("t"."flds"."c"."field_y") AS ROW(field_y VARCHAR)) AS c) AS flds, "t"."foo" AS foo) AS "t" FROM "default"."EXCLUDE_T" AS "t") AS "$__EXCLUDE_ALIAS__";
 
 --#[exclude-05]
-SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT (SELECT (SELECT (SELECT "t"."flds"."a"."field_x" AS field_x, "t"."flds"."a"."field_y" AS field_y) AS a, (SELECT "t"."flds"."b"."field_x" AS field_x, "t"."flds"."b"."field_y" AS field_y) AS b, CAST(ROW("t"."flds"."c"."field_x") AS ROW(field_x INTEGER)) AS c) AS flds, "t"."foo" AS foo) AS "t" FROM "default"."EXCLUDE_T" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "$__EXCLUDE_ALIAS__"."t"."flds" AS "flds", "$__EXCLUDE_ALIAS__"."t"."foo" AS "foo" FROM (SELECT (SELECT (SELECT (SELECT "t"."flds"."a"."field_x" AS field_x, "t"."flds"."a"."field_y" AS field_y) AS a, (SELECT "t"."flds"."b"."field_x" AS field_x, "t"."flds"."b"."field_y" AS field_y) AS b, CAST(ROW("t"."flds"."c"."field_x") AS ROW(field_x INTEGER)) AS c) AS flds, "t"."foo" AS foo) AS "t" FROM "default"."EXCLUDE_T" AS "t") AS "$__EXCLUDE_ALIAS__";
 
 -- --#[exclude-06]
 -- Exclude all the fields of `t.flds.c`; unsure if Trino supports ROWs with no fields. Asked a question in discussion to see if feasible https://github.com/trinodb/trino/discussions/20558
@@ -23,17 +23,17 @@ SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT (SELECT (SELECT (SELECT "t"."flds
 
 -- START OF EXCLUDE with COLLECTION WILDCARD
 --#[exclude-07]
-SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT (SELECT transform("t"."a", ___coll_wildcard___ -> CAST(ROW(___coll_wildcard___."field_y") AS ROW(field_y VARCHAR))) AS a, "t"."foo" AS foo) AS "t" FROM "default"."EXCLUDE_T_COLL_WILDCARD" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "$__EXCLUDE_ALIAS__"."t"."a" AS "a", "$__EXCLUDE_ALIAS__"."t"."foo" AS "foo" FROM (SELECT (SELECT transform("t"."a", ___coll_wildcard___ -> CAST(ROW(___coll_wildcard___."field_y") AS ROW(field_y VARCHAR))) AS a, "t"."foo" AS foo) AS "t" FROM "default"."EXCLUDE_T_COLL_WILDCARD" AS "t") AS "$__EXCLUDE_ALIAS__";
 
 --#[exclude-08]
-SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT (SELECT transform("t"."a", ___coll_wildcard___ -> CAST(ROW(___coll_wildcard___."field_x") AS ROW(field_x INTEGER))) AS a, "t"."foo" AS foo) AS "t" FROM "default"."EXCLUDE_T_COLL_WILDCARD" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "$__EXCLUDE_ALIAS__"."t"."a" AS "a", "$__EXCLUDE_ALIAS__"."t"."foo" AS "foo" FROM (SELECT (SELECT transform("t"."a", ___coll_wildcard___ -> CAST(ROW(___coll_wildcard___."field_x") AS ROW(field_x INTEGER))) AS a, "t"."foo" AS foo) AS "t" FROM "default"."EXCLUDE_T_COLL_WILDCARD" AS "t") AS "$__EXCLUDE_ALIAS__";
 
 --#[exclude-09]
-SELECT "$__EXCLUDE_ALIAS__"."t1".*, "$__EXCLUDE_ALIAS__"."t2".* FROM (SELECT CAST(ROW((SELECT (SELECT "t1"."flds"."a"."field_x" AS field_x, "t1"."flds"."a"."field_y" AS field_y) AS a, (SELECT "t1"."flds"."b"."field_x" AS field_x, "t1"."flds"."b"."field_y" AS field_y) AS b, (SELECT "t1"."flds"."c"."field_x" AS field_x, "t1"."flds"."c"."field_y" AS field_y) AS c)) AS ROW(flds ROW(a ROW(field_x INTEGER, field_y VARCHAR), b ROW(field_x INTEGER, field_y VARCHAR), c ROW(field_x INTEGER, field_y VARCHAR)))) AS "t1", (SELECT (SELECT (SELECT "t2"."flds"."a"."field_x" AS field_x, "t2"."flds"."a"."field_y" AS field_y) AS a, CAST(ROW("t2"."flds"."c"."field_y") AS ROW(field_y VARCHAR)) AS c) AS flds, "t2"."foo" AS foo) AS "t2" FROM "default"."EXCLUDE_T" AS "t1" INNER JOIN "default"."EXCLUDE_T" AS "t2" ON true WHERE "t1"."foo" = "t2"."foo") AS "$__EXCLUDE_ALIAS__";
+SELECT "$__EXCLUDE_ALIAS__"."t1"."flds" AS "flds", "$__EXCLUDE_ALIAS__"."t2"."flds" AS "flds", "$__EXCLUDE_ALIAS__"."t2"."foo" AS "foo" FROM (SELECT CAST(ROW((SELECT (SELECT "t1"."flds"."a"."field_x" AS field_x, "t1"."flds"."a"."field_y" AS field_y) AS a, (SELECT "t1"."flds"."b"."field_x" AS field_x, "t1"."flds"."b"."field_y" AS field_y) AS b, (SELECT "t1"."flds"."c"."field_x" AS field_x, "t1"."flds"."c"."field_y" AS field_y) AS c)) AS ROW(flds ROW(a ROW(field_x INTEGER, field_y VARCHAR), b ROW(field_x INTEGER, field_y VARCHAR), c ROW(field_x INTEGER, field_y VARCHAR)))) AS "t1", (SELECT (SELECT (SELECT "t2"."flds"."a"."field_x" AS field_x, "t2"."flds"."a"."field_y" AS field_y) AS a, CAST(ROW("t2"."flds"."c"."field_y") AS ROW(field_y VARCHAR)) AS c) AS flds, "t2"."foo" AS foo) AS "t2" FROM "default"."EXCLUDE_T" AS "t1" INNER JOIN "default"."EXCLUDE_T" AS "t2" ON true WHERE "t1"."foo" = "t2"."foo") AS "$__EXCLUDE_ALIAS__";
 
 --#[exclude-10]
 -- EXCLUDE with multiple JOIN and WHERE clause
-SELECT "$__EXCLUDE_ALIAS__"."t1".*, "$__EXCLUDE_ALIAS__"."t2".*, "$__EXCLUDE_ALIAS__"."t3".* FROM (SELECT (SELECT (SELECT (SELECT "t1"."flds"."b"."field_x" AS field_x, "t1"."flds"."b"."field_y" AS field_y) AS b, (SELECT "t1"."flds"."c"."field_x" AS field_x, "t1"."flds"."c"."field_y" AS field_y) AS c) AS flds, "t1"."foo" AS foo) AS "t1", (SELECT (SELECT (SELECT "t2"."flds"."a"."field_x" AS field_x, "t2"."flds"."a"."field_y" AS field_y) AS a, (SELECT "t2"."flds"."c"."field_x" AS field_x, "t2"."flds"."c"."field_y" AS field_y) AS c) AS flds, "t2"."foo" AS foo) AS "t2", (SELECT (SELECT (SELECT "t3"."flds"."a"."field_x" AS field_x, "t3"."flds"."a"."field_y" AS field_y) AS a, (SELECT "t3"."flds"."b"."field_x" AS field_x, "t3"."flds"."b"."field_y" AS field_y) AS b) AS flds, "t3"."foo" AS foo) AS "t3" FROM "default"."EXCLUDE_T" AS "t1" INNER JOIN "default"."EXCLUDE_T" AS "t2" ON true INNER JOIN "default"."EXCLUDE_T" AS "t3" ON true WHERE ("t1"."foo" = "t2"."foo") AND ("t2"."foo" = "t3"."foo")) AS "$__EXCLUDE_ALIAS__";
+SELECT "$__EXCLUDE_ALIAS__"."t1"."flds" AS "flds", "$__EXCLUDE_ALIAS__"."t1"."foo" AS "foo", "$__EXCLUDE_ALIAS__"."t2"."flds" AS "flds", "$__EXCLUDE_ALIAS__"."t2"."foo" AS "foo", "$__EXCLUDE_ALIAS__"."t3"."flds" AS "flds", "$__EXCLUDE_ALIAS__"."t3"."foo" AS "foo" FROM (SELECT (SELECT (SELECT (SELECT "t1"."flds"."b"."field_x" AS field_x, "t1"."flds"."b"."field_y" AS field_y) AS b, (SELECT "t1"."flds"."c"."field_x" AS field_x, "t1"."flds"."c"."field_y" AS field_y) AS c) AS flds, "t1"."foo" AS foo) AS "t1", (SELECT (SELECT (SELECT "t2"."flds"."a"."field_x" AS field_x, "t2"."flds"."a"."field_y" AS field_y) AS a, (SELECT "t2"."flds"."c"."field_x" AS field_x, "t2"."flds"."c"."field_y" AS field_y) AS c) AS flds, "t2"."foo" AS foo) AS "t2", (SELECT (SELECT (SELECT "t3"."flds"."a"."field_x" AS field_x, "t3"."flds"."a"."field_y" AS field_y) AS a, (SELECT "t3"."flds"."b"."field_x" AS field_x, "t3"."flds"."b"."field_y" AS field_y) AS b) AS flds, "t3"."foo" AS foo) AS "t3" FROM "default"."EXCLUDE_T" AS "t1" INNER JOIN "default"."EXCLUDE_T" AS "t2" ON true INNER JOIN "default"."EXCLUDE_T" AS "t3" ON true WHERE ("t1"."foo" = "t2"."foo") AND ("t2"."foo" = "t3"."foo")) AS "$__EXCLUDE_ALIAS__";
 
 --#[exclude-11]
 -- EXCLUDE with select projection list and multiple JOINs
@@ -42,19 +42,19 @@ SELECT "$__EXCLUDE_ALIAS__"."t1"."flds" AS "flds", "$__EXCLUDE_ALIAS__"."t2"."fl
 -- EXCLUDE with different types
 -- bool
 --#[exclude-12]
-SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep BOOLEAN))) AS ROW(foo ROW(keep BOOLEAN))) AS "t" FROM "default"."datatypes"."T_BOOL" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "$__EXCLUDE_ALIAS__"."t"."foo" AS "foo" FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep BOOLEAN))) AS ROW(foo ROW(keep BOOLEAN))) AS "t" FROM "default"."datatypes"."T_BOOL" AS "t") AS "$__EXCLUDE_ALIAS__";
 
 -- int16
 --#[exclude-13]
-SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep SMALLINT))) AS ROW(foo ROW(keep SMALLINT))) AS "t" FROM "default"."datatypes"."T_INT16" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "$__EXCLUDE_ALIAS__"."t"."foo" AS "foo" FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep SMALLINT))) AS ROW(foo ROW(keep SMALLINT))) AS "t" FROM "default"."datatypes"."T_INT16" AS "t") AS "$__EXCLUDE_ALIAS__";
 
 -- int32
 --#[exclude-14]
-SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep INTEGER))) AS ROW(foo ROW(keep INTEGER))) AS "t" FROM "default"."datatypes"."T_INT32" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "$__EXCLUDE_ALIAS__"."t"."foo" AS "foo" FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep INTEGER))) AS ROW(foo ROW(keep INTEGER))) AS "t" FROM "default"."datatypes"."T_INT32" AS "t") AS "$__EXCLUDE_ALIAS__";
 
 -- int64
 --#[exclude-15]
-SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep BIGINT))) AS ROW(foo ROW(keep BIGINT))) AS "t" FROM "default"."datatypes"."T_INT64" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "$__EXCLUDE_ALIAS__"."t"."foo" AS "foo" FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep BIGINT))) AS ROW(foo ROW(keep BIGINT))) AS "t" FROM "default"."datatypes"."T_INT64" AS "t") AS "$__EXCLUDE_ALIAS__";
 
 -- int (unconstrained)
 -- Trino does not support unconstrained int; error or give result of BIGINT
@@ -68,72 +68,133 @@ SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep
 
 -- float32
 --#[exclude-18]
-SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep DOUBLE))) AS ROW(foo ROW(keep DOUBLE))) AS "t" FROM "default"."datatypes"."T_FLOAT32" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "$__EXCLUDE_ALIAS__"."t"."foo" AS "foo" FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep DOUBLE))) AS ROW(foo ROW(keep DOUBLE))) AS "t" FROM "default"."datatypes"."T_FLOAT32" AS "t") AS "$__EXCLUDE_ALIAS__";
 
 -- float64
 --#[exclude-19]
-SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep DOUBLE))) AS ROW(foo ROW(keep DOUBLE))) AS "t" FROM "default"."datatypes"."T_FLOAT64" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "$__EXCLUDE_ALIAS__"."t"."foo" AS "foo" FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep DOUBLE))) AS ROW(foo ROW(keep DOUBLE))) AS "t" FROM "default"."datatypes"."T_FLOAT64" AS "t") AS "$__EXCLUDE_ALIAS__";
 
 -- string
 --#[exclude-20]
-SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep VARCHAR))) AS ROW(foo ROW(keep VARCHAR))) AS "t" FROM "default"."datatypes"."T_STRING" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "$__EXCLUDE_ALIAS__"."t"."foo" AS "foo" FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep VARCHAR))) AS ROW(foo ROW(keep VARCHAR))) AS "t" FROM "default"."datatypes"."T_STRING" AS "t") AS "$__EXCLUDE_ALIAS__";
 
 -- date
 --#[exclude-21]
-SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep DATE))) AS ROW(foo ROW(keep DATE))) AS "t" FROM "default"."datatypes"."T_DATE" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "$__EXCLUDE_ALIAS__"."t"."foo" AS "foo" FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep DATE))) AS ROW(foo ROW(keep DATE))) AS "t" FROM "default"."datatypes"."T_DATE" AS "t") AS "$__EXCLUDE_ALIAS__";
 
 -- time
 --#[exclude-22]
-SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep TIME))) AS ROW(foo ROW(keep TIME))) AS "t" FROM "default"."datatypes"."T_TIME" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "$__EXCLUDE_ALIAS__"."t"."foo" AS "foo" FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep TIME))) AS ROW(foo ROW(keep TIME))) AS "t" FROM "default"."datatypes"."T_TIME" AS "t") AS "$__EXCLUDE_ALIAS__";
 
 -- timestamp
 --#[exclude-23]
-SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep TIMESTAMP))) AS ROW(foo ROW(keep TIMESTAMP))) AS "t" FROM "default"."datatypes"."T_TIMESTAMP" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "$__EXCLUDE_ALIAS__"."t"."foo" AS "foo" FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep TIMESTAMP))) AS ROW(foo ROW(keep TIMESTAMP))) AS "t" FROM "default"."datatypes"."T_TIMESTAMP" AS "t") AS "$__EXCLUDE_ALIAS__";
 
 -- null
 --#[exclude-24]
-SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep NULL))) AS ROW(foo ROW(keep NULL))) AS "t" FROM "default"."datatypes"."T_NULL" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "$__EXCLUDE_ALIAS__"."t"."foo" AS "foo" FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep NULL))) AS ROW(foo ROW(keep NULL))) AS "t" FROM "default"."datatypes"."T_NULL" AS "t") AS "$__EXCLUDE_ALIAS__";
 
 -- struct
 --#[exclude-25]
-SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT CAST(ROW(CAST(ROW((SELECT "t"."foo"."keep"."keep1" AS keep1, "t"."foo"."keep"."keep2" AS keep2)) AS ROW(keep ROW(keep1 INTEGER, keep2 VARCHAR)))) AS ROW(foo ROW(keep ROW(keep1 INTEGER, keep2 VARCHAR)))) AS "t" FROM "default"."datatypes"."T_STRUCT" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "$__EXCLUDE_ALIAS__"."t"."foo" AS "foo" FROM (SELECT CAST(ROW(CAST(ROW((SELECT "t"."foo"."keep"."keep1" AS keep1, "t"."foo"."keep"."keep2" AS keep2)) AS ROW(keep ROW(keep1 INTEGER, keep2 VARCHAR)))) AS ROW(foo ROW(keep ROW(keep1 INTEGER, keep2 VARCHAR)))) AS "t" FROM "default"."datatypes"."T_STRUCT" AS "t") AS "$__EXCLUDE_ALIAS__";
 
 -- list
 --#[exclude-26]
-SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT CAST(ROW(CAST(ROW(transform("t"."foo"."keep", ___coll_wildcard___ -> ___coll_wildcard___)) AS ROW(keep ARRAY<INTEGER>))) AS ROW(foo ROW(keep ARRAY<INTEGER>))) AS "t" FROM "default"."datatypes"."T_LIST" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "$__EXCLUDE_ALIAS__"."t"."foo" AS "foo" FROM (SELECT CAST(ROW(CAST(ROW(transform("t"."foo"."keep", ___coll_wildcard___ -> ___coll_wildcard___)) AS ROW(keep ARRAY<INTEGER>))) AS ROW(foo ROW(keep ARRAY<INTEGER>))) AS "t" FROM "default"."datatypes"."T_LIST" AS "t") AS "$__EXCLUDE_ALIAS__";
 
 -- decimal(5, 2)
 --#[exclude-27]
-SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep DECIMAL(5, 2)))) AS ROW(foo ROW(keep DECIMAL(5, 2)))) AS "t" FROM "default"."datatypes"."T_DECIMAL_5_2" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "$__EXCLUDE_ALIAS__"."t"."foo" AS "foo" FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep DECIMAL(5, 2)))) AS ROW(foo ROW(keep DECIMAL(5, 2)))) AS "t" FROM "default"."datatypes"."T_DECIMAL_5_2" AS "t") AS "$__EXCLUDE_ALIAS__";
 
 -- varchar(16)
 --#[exclude-28]
-SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep VARCHAR(16)))) AS ROW(foo ROW(keep VARCHAR(16)))) AS "t" FROM "default"."datatypes"."T_STRING_16" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "$__EXCLUDE_ALIAS__"."t"."foo" AS "foo" FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep VARCHAR(16)))) AS ROW(foo ROW(keep VARCHAR(16)))) AS "t" FROM "default"."datatypes"."T_STRING_16" AS "t") AS "$__EXCLUDE_ALIAS__";
 
 -- char(16)
 --#[exclude-29]
-SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep CHAR(16)))) AS ROW(foo ROW(keep CHAR(16)))) AS "t" FROM "default"."datatypes"."T_CHAR_16" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "$__EXCLUDE_ALIAS__"."t"."foo" AS "foo" FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep CHAR(16)))) AS ROW(foo ROW(keep CHAR(16)))) AS "t" FROM "default"."datatypes"."T_CHAR_16" AS "t") AS "$__EXCLUDE_ALIAS__";
 
 -- time(6)
 --#[exclude-30]
-SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep TIME(6)))) AS ROW(foo ROW(keep TIME(6)))) AS "t" FROM "default"."datatypes"."T_TIME_6" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "$__EXCLUDE_ALIAS__"."t"."foo" AS "foo" FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep TIME(6)))) AS ROW(foo ROW(keep TIME(6)))) AS "t" FROM "default"."datatypes"."T_TIME_6" AS "t") AS "$__EXCLUDE_ALIAS__";
 
 -- timestamp(6)
 --#[exclude-31]
-SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep TIMESTAMP(6)))) AS ROW(foo ROW(keep TIMESTAMP(6)))) AS "t" FROM "default"."datatypes"."T_TIMESTAMP_6" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "$__EXCLUDE_ALIAS__"."t"."foo" AS "foo" FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep TIMESTAMP(6)))) AS ROW(foo ROW(keep TIMESTAMP(6)))) AS "t" FROM "default"."datatypes"."T_TIMESTAMP_6" AS "t") AS "$__EXCLUDE_ALIAS__";
 
 -- union(string, null)
 --#[exclude-32]
-SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep VARCHAR))) AS ROW(foo ROW(keep VARCHAR))) AS "t" FROM "default"."datatypes"."T_STRING_NULL" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "$__EXCLUDE_ALIAS__"."t"."foo" AS "foo" FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep VARCHAR))) AS ROW(foo ROW(keep VARCHAR))) AS "t" FROM "default"."datatypes"."T_STRING_NULL" AS "t") AS "$__EXCLUDE_ALIAS__";
 
 -- union(int32, null)
 --#[exclude-33]
-SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep INTEGER))) AS ROW(foo ROW(keep INTEGER))) AS "t" FROM "default"."datatypes"."T_INT32_NULL" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "$__EXCLUDE_ALIAS__"."t"."foo" AS "foo" FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep INTEGER))) AS ROW(foo ROW(keep INTEGER))) AS "t" FROM "default"."datatypes"."T_INT32_NULL" AS "t") AS "$__EXCLUDE_ALIAS__";
 
 -- union(varchar(16), null)
 --#[exclude-34]
-SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep VARCHAR(16)))) AS ROW(foo ROW(keep VARCHAR(16)))) AS "t" FROM "default"."datatypes"."T_STRING_16_NULL" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "$__EXCLUDE_ALIAS__"."t"."foo" AS "foo" FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep VARCHAR(16)))) AS ROW(foo ROW(keep VARCHAR(16)))) AS "t" FROM "default"."datatypes"."T_STRING_16_NULL" AS "t") AS "$__EXCLUDE_ALIAS__";
 
 -- union(char(16), null)
 --#[exclude-35]
-SELECT "$__EXCLUDE_ALIAS__"."t".* FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep CHAR(16)))) AS ROW(foo ROW(keep CHAR(16)))) AS "t" FROM "default"."datatypes"."T_CHAR_16_NULL" AS "t") AS "$__EXCLUDE_ALIAS__";
+SELECT "$__EXCLUDE_ALIAS__"."t"."foo" AS "foo" FROM (SELECT CAST(ROW(CAST(ROW("t"."foo"."keep") AS ROW(keep CHAR(16)))) AS ROW(foo ROW(keep CHAR(16)))) AS "t" FROM "default"."datatypes"."T_CHAR_16_NULL" AS "t") AS "$__EXCLUDE_ALIAS__";
+
+-- Tests for EXCLUDE on top-level columns only --
+-- Baseline query without `EXCLUDE`
+--#[exclude-36]
+SELECT "t"."a" AS "a", "t"."b" AS "b", "t"."c" AS "c", "t"."d" AS "d", "t"."e" AS "e", "t"."f" AS "f", "t"."g" AS "g" FROM "default"."T_EXCLUDE_TOP_LEVEL" AS "t";
+
+-- EXCLUDE single top-level column (no `t.a`)
+--#[exclude-37]
+SELECT "t"."b" AS "b", "t"."c" AS "c", "t"."d" AS "d", "t"."e" AS "e", "t"."f" AS "f", "t"."g" AS "g" FROM "default"."T_EXCLUDE_TOP_LEVEL" AS "t";
+
+-- EXCLUDE multiple top-level columns (no `t.a` through `t.e`)
+--#[exclude-38]
+SELECT "t"."f" AS "f", "t"."g" AS "g" FROM "default"."T_EXCLUDE_TOP_LEVEL" AS "t";
+
+-- EXCLUDE top-level columns with WHERE
+--#[exclude-39]
+SELECT "t"."c" AS "c", "t"."d" AS "d", "t"."e" AS "e", "t"."f" AS "f", "t"."g" AS "g" FROM "default"."T_EXCLUDE_TOP_LEVEL" AS "t" WHERE "t"."a" AND ("t"."c" = 'remove');
+
+-- EXCLUDE top-level columns with explicit SELECT list
+--#[exclude-40]
+SELECT "t"."c" AS "c", "t"."d" AS "d", "t"."e" AS "e", "t"."f" AS "f", "t"."g" AS "g" FROM "default"."T_EXCLUDE_TOP_LEVEL" AS "t" WHERE "t"."a" AND ("t"."c" = 'remove');
+
+-- EXCLUDE top-level with subquery
+--#[exclude-41]
+SELECT "subq"."a" AS "a", "subq"."b" AS "b", "subq"."c" AS "c", "subq"."d" AS "d", "subq"."e" AS "e", "subq"."f" AS "f", "subq"."g" AS "g" FROM (SELECT "t"."a" AS "a", "t"."b" AS "b", "t"."c" AS "c", "t"."d" AS "d", "t"."e" AS "e", "t"."f" AS "f", "t"."g" AS "g", 'foo' AS "remove_me" FROM "default"."T_EXCLUDE_TOP_LEVEL" AS "t" WHERE "t"."a") AS "subq";
+
+-- EXCLUDE top-level columns with JOIN
+--#[exclude-42]
+SELECT "t1"."b" AS "b", "t1"."d" AS "d", "t1"."f" AS "f", "t2"."a" AS "a", "t2"."c" AS "c", "t2"."e" AS "e", "t2"."g" AS "g" FROM "default"."T_EXCLUDE_TOP_LEVEL" AS "t1" INNER JOIN "default"."T_EXCLUDE_TOP_LEVEL" AS "t2" ON true;
+
+-- EXCLUDE top-level columns with JOIN and WHERE
+--#[exclude-43]
+SELECT "t1"."b" AS "b", "t1"."d" AS "d", "t1"."f" AS "f", "t2"."a" AS "a", "t2"."c" AS "c", "t2"."e" AS "e", "t2"."g" AS "g" FROM "default"."T_EXCLUDE_TOP_LEVEL" AS "t1" INNER JOIN "default"."T_EXCLUDE_TOP_LEVEL" AS "t2" ON true WHERE "t1"."a" AND "t2"."a";
+
+-- EXCLUDE top-level columns with JOIN and WHERE and specified SELECT element
+--#[exclude-44]
+SELECT "t1"."b" AS "b", "t1"."d" AS "d", "t1"."f" AS "f" FROM "default"."T_EXCLUDE_TOP_LEVEL" AS "t1" INNER JOIN "default"."T_EXCLUDE_TOP_LEVEL" AS "t2" ON true WHERE "t1"."a" AND "t2"."a";
+
+-- EXCLUDE top-level columns with JOIN and WHERE and specified SELECT elements
+--#[exclude-45]
+SELECT "t1"."b" AS "b", "t1"."d" AS "d", "t1"."f" AS "f", "t2"."a" AS "special" FROM "default"."T_EXCLUDE_TOP_LEVEL" AS "t1" INNER JOIN "default"."T_EXCLUDE_TOP_LEVEL" AS "t2" ON true WHERE "t1"."a" AND "t2"."a";
+
+-- EXCLUDE top-level columns with multiple JOINs
+--#[exclude-46]
+SELECT
+    "t1"."a" AS "a",
+    "t2"."b" AS "b",
+    "t3"."c" AS "c",
+    "t4"."d" AS "d",
+    "t5"."e" AS "e",
+    "t6"."f" AS "f",
+    "t7"."g" AS "g"
+FROM
+    "default"."T_EXCLUDE_TOP_LEVEL" AS "t1" INNER JOIN
+        "default"."T_EXCLUDE_TOP_LEVEL" AS "t2" ON "t2"."a" LEFT OUTER JOIN
+        "default"."T_EXCLUDE_TOP_LEVEL" AS "t3" ON "t3"."a" INNER JOIN
+        "default"."T_EXCLUDE_TOP_LEVEL" AS "t4" ON "t4"."a" RIGHT OUTER JOIN
+        "default"."T_EXCLUDE_TOP_LEVEL" AS "t5" ON "t5"."a" FULL OUTER JOIN
+        "default"."T_EXCLUDE_TOP_LEVEL" AS "t6" ON "t6"."a" INNER JOIN
+        "default"."T_EXCLUDE_TOP_LEVEL" AS "t7" ON true
+WHERE "t1"."a" AND "t2"."a";

--- a/src/test/resources/outputs/trino/basics/select.sql
+++ b/src/test/resources/outputs/trino/basics/select.sql
@@ -2,7 +2,7 @@
 SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c" FROM "default"."T" AS "T";
 
 --#[select-01]
-SELECT "T".* FROM "default"."T" AS "T";
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T";
 
 --#[select-02]
 SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c" FROM "default"."T" AS "T";
@@ -12,7 +12,7 @@ SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c" FROM "default"."T" AS "T";
 -- SELECT VALUE a FROM T;
 
 --#[select-04]
-SELECT "t1".*, "t2".* FROM "default"."T" AS "t1" INNER JOIN "default"."T" AS "t2" ON true;
+SELECT "t1"."a" AS "a", "t1"."b" AS "b", "t1"."c" AS "c", "t1"."d" AS "d", "t1"."x" AS "x", "t1"."array" AS "array", "t1"."z" AS "z", "t1"."v" AS "v", "t1"."timestamp_1" AS "timestamp_1", "t1"."timestamp_2" AS "timestamp_2", "t2"."a" AS "a", "t2"."b" AS "b", "t2"."c" AS "c", "t2"."d" AS "d", "t2"."x" AS "x", "t2"."array" AS "array", "t2"."z" AS "z", "t2"."v" AS "v", "t2"."timestamp_1" AS "timestamp_1", "t2"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "t1" INNER JOIN "default"."T" AS "t2" ON true;
 
 -- #[select-05]
 -- ERR! Trino doesn't have path expressions
@@ -31,7 +31,7 @@ SELECT "t1".*, "t2".* FROM "default"."T" AS "t1" INNER JOIN "default"."T" AS "t2
 -- SELECT "T"."d".* FROM "default"."T" AS "T";
 
 --#[select-09]
-SELECT "T".* FROM "default"."T" AS "T";
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T";
 
 --#[select-10]
 SELECT "T"."c" || current_user AS "_1" FROM "default"."T" AS "T";

--- a/src/test/resources/outputs/trino/operators/in.sql
+++ b/src/test/resources/outputs/trino/operators/in.sql
@@ -1,17 +1,17 @@
 --#[in-00]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IN (1, 2);
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T" WHERE "T"."b" IN (1, 2);
 
 --#[in-01]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IN (1, 2);
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T" WHERE "T"."b" IN (1, 2);
 
 --#[in-02]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" IN (1, 2);
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T" WHERE "T"."b" IN (1, 2);
 
 --#[in-03]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" NOT IN (1, 2);
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T" WHERE "T"."b" NOT IN (1, 2);
 
 --#[in-04]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" NOT IN (1, 2);
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T" WHERE "T"."b" NOT IN (1, 2);
 
 --#[in-05]
-SELECT "T".* FROM "default"."T" AS "T" WHERE "T"."b" NOT IN (1, 2);
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T" WHERE "T"."b" NOT IN (1, 2);


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*

Applies the same changes from https://github.com/partiql/partiql-scribe/pull/49 to Trino and Spark.
- Simplifies the `EXCLUDE` rewrite for top-level columns
- Expands all `SELECT tbl.*` and `SELECT tbl.struct.*`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
