### PR TITLE
Adds printing of real and double precision

### DIFF
--- a/src/main/kotlin/org/partiql/scribe/sql/SqlDialect.kt
+++ b/src/main/kotlin/org/partiql/scribe/sql/SqlDialect.kt
@@ -173,7 +173,7 @@ abstract class SqlDialect : AstBaseVisitor<SqlBlock, SqlBlock>() {
 
     override fun visitTypeReal(node: Type.Real, tail: SqlBlock): SqlBlock = tail concat "REAL"
 
-    override fun visitTypeFloat32(node: Type.Float32, tail: SqlBlock): SqlBlock = tail concat "FLOAT32"
+    override fun visitTypeFloat32(node: Type.Float32, tail: SqlBlock): SqlBlock = tail concat "REAL"
 
     override fun visitTypeFloat64(node: Type.Float64, tail: SqlBlock): SqlBlock = tail concat "DOUBLE PRECISION"
 
@@ -232,8 +232,8 @@ abstract class SqlDialect : AstBaseVisitor<SqlBlock, SqlBlock>() {
     override fun visitTypeInterval(node: Type.Interval, tail: SqlBlock): SqlBlock =
         tail concat type("INTERVAL", node.precision)
 
-    // unsupported
-    override fun visitTypeCustom(node: Type.Custom, tail: SqlBlock): SqlBlock = defaultReturn(node, tail)
+    // insert custom type as-is
+    override fun visitTypeCustom(node: Type.Custom, tail: SqlBlock): SqlBlock = tail concat node.name
 
     // Expressions
 

--- a/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftCalls.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftCalls.kt
@@ -3,18 +3,17 @@ package org.partiql.scribe.targets.redshift
 import org.partiql.ast.DatetimeField
 import org.partiql.ast.Expr
 import org.partiql.ast.Identifier
-import org.partiql.ast.exprBetween
 import org.partiql.ast.exprCall
 import org.partiql.ast.exprCast
 import org.partiql.ast.exprCollection
 import org.partiql.ast.exprInCollection
-import org.partiql.ast.exprIsType
-import org.partiql.ast.exprLike
 import org.partiql.ast.exprLit
 import org.partiql.ast.exprVar
 import org.partiql.ast.identifierSymbol
 import org.partiql.ast.typeCustom
 import org.partiql.ast.typeDecimal
+import org.partiql.ast.typeFloat32
+import org.partiql.ast.typeFloat64
 import org.partiql.scribe.ProblemCallback
 import org.partiql.scribe.error
 import org.partiql.scribe.info
@@ -145,8 +144,8 @@ public open class RedshiftCalls(private val log: ProblemCallback) : SqlCalls() {
                 super.rewriteCast(type, args)
             }
             // using the customer type to rename type
-            PartiQLValueType.FLOAT32 -> exprCast(args[0].expr, typeCustom("FLOAT4"))
-            PartiQLValueType.FLOAT64 -> exprCast(args[0].expr, typeCustom("FLOAT8"))
+            PartiQLValueType.FLOAT32 -> exprCast(args[0].expr, typeFloat32())
+            PartiQLValueType.FLOAT64 -> exprCast(args[0].expr, typeFloat64())
             PartiQLValueType.BINARY -> exprCast(args[0].expr, typeCustom("VARBYTE"))
             PartiQLValueType.BYTE -> TODO("Mapping to VARBYTE(1), do this after supporting parameterized type")
             else -> super.rewriteCast(type, args)

--- a/src/main/kotlin/org/partiql/scribe/targets/spark/SparkDialect.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/spark/SparkDialect.kt
@@ -103,6 +103,8 @@ public open class SparkDialect : SqlDialect() {
 
     override fun visitTypeInt8(node: Type.Int8, tail: SqlBlock): SqlBlock = tail concat "BIGINT"
 
+    override fun visitTypeFloat64(node: Type.Float64, tail: SqlBlock): SqlBlock = tail concat "DOUBLE"
+
     override fun visitExprCollection(node: Expr.Collection, tail: SqlBlock): SqlBlock {
         val (start, end) = when (node.type) {
             Expr.Collection.Type.ARRAY -> "array(" to ")"

--- a/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoDialect.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoDialect.kt
@@ -125,6 +125,8 @@ public open class TrinoDialect : SqlDialect() {
 
     override fun visitTypeInt8(node: Type.Int8, tail: SqlBlock): SqlBlock = tail concat "BIGINT"
 
+    override fun visitTypeFloat64(node: Type.Float64, tail: SqlBlock): SqlBlock = tail concat "DOUBLE"
+
     override fun visitTypeString(node: Type.String, tail: SqlBlock): SqlBlock = tail concat "VARCHAR"
 
     override fun visitExprCollection(node: Expr.Collection, tail: SqlBlock): SqlBlock {

--- a/src/test/resources/inputs/operators/cast.sql
+++ b/src/test/resources/inputs/operators/cast.sql
@@ -1,11 +1,23 @@
+-- tests translations of type names across dialects.
+
+-- exact numeric
+
 --#[cast-00]
-CAST('1' AS INT);
+SELECT CAST('1' AS INT) FROM T;
 
 --#[cast-01]
-CAST('1' AS INT4);
+SELECT CAST('1' AS INT4) FROM T;
 
 --#[cast-02]
-CAST('1' AS INT8);
+SELECT CAST('1' AS INT8) FROM T;
 
 --#[cast-03]
-CAST('1' AS BIGINT);
+SELECT CAST('1' AS BIGINT) FROM T;
+
+-- approximate numeric
+
+-- #[cast-04]
+-- SELECT CAST(1 AS REAL) FROM T;
+
+--#[cast-05]
+SELECT CAST(1 AS DOUBLE PRECISION) FROM T;

--- a/src/test/resources/outputs/partiql/operators/cast.sql
+++ b/src/test/resources/outputs/partiql/operators/cast.sql
@@ -1,11 +1,17 @@
 --#[cast-00]
-CAST('1' AS INT);
+SELECT CAST('1' AS INT) AS "_1" FROM "default"."T" AS "T";
 
 --#[cast-01]
-CAST('1' AS INT);
+SELECT CAST('1' AS INT) AS "_1" FROM "default"."T" AS "T";
 
 --#[cast-02]
-CAST('1' AS BIGINT);
+SELECT CAST('1' AS BIGINT) AS "_1" FROM "default"."T" AS "T";
 
 --#[cast-03]
-CAST('1' AS BIGINT);
+SELECT CAST('1' AS BIGINT) AS "_1" FROM "default"."T" AS "T";
+
+-- #[cast-04]
+-- SELECT CAST(1 AS REAL) AS "_1" FROM "default"."T" AS "T";
+
+--#[cast-05]
+SELECT CAST(1 AS DOUBLE PRECISION) AS "_1" FROM "default"."T" AS "T";

--- a/src/test/resources/outputs/redshift/operators/cast.sql
+++ b/src/test/resources/outputs/redshift/operators/cast.sql
@@ -1,11 +1,17 @@
 --#[cast-00]
-CAST('1' AS INT);
+SELECT CAST('1' AS INT) AS "_1" FROM "default"."T" AS "T";
 
 --#[cast-01]
-CAST('1' AS INT);
+SELECT CAST('1' AS INT) AS "_1" FROM "default"."T" AS "T";
 
 --#[cast-02]
-CAST('1' AS BIGINT);
+SELECT CAST('1' AS BIGINT) AS "_1" FROM "default"."T" AS "T";
 
 --#[cast-03]
-CAST('1' AS BIGINT);
+SELECT CAST('1' AS BIGINT) AS "_1" FROM "default"."T" AS "T";
+
+-- #[cast-04]
+-- SELECT CAST(1 AS REAL) AS "_1" FROM "default"."T" AS "T";
+
+--#[cast-05]
+SELECT CAST(1 AS DOUBLE PRECISION) AS "_1" FROM "default"."T" AS "T";

--- a/src/test/resources/outputs/spark/operators/cast.sql
+++ b/src/test/resources/outputs/spark/operators/cast.sql
@@ -1,11 +1,17 @@
--- #[cast-00]
--- SELECT CAST('1' AS INT);
+--#[cast-00]
+SELECT CAST('1' AS INT) AS `_1` FROM `default`.`T` AS `T`;
 
--- #[cast-01]
--- SELECT CAST('1' AS INT);
+--#[cast-01]
+SELECT CAST('1' AS INT) AS `_1` FROM `default`.`T` AS `T`;
 
--- #[cast-02]
--- SELECT CAST('1' AS BIGINT);
+--#[cast-02]
+SELECT CAST('1' AS BIGINT) AS `_1` FROM `default`.`T` AS `T`;
 
--- #[cast-03]
--- SELECT CAST('1' AS BIGINT);
+--#[cast-03]
+SELECT CAST('1' AS BIGINT) AS `_1` FROM `default`.`T` AS `T`;
+
+-- #[cast-04]
+-- SELECT CAST(1 AS REAL) AS `_1` FROM `default`.`T` AS `T`;
+
+--#[cast-05]
+SELECT CAST(1 AS DOUBLE) AS `_1` FROM `default`.`T` AS `T`;

--- a/src/test/resources/outputs/trino/operators/cast.sql
+++ b/src/test/resources/outputs/trino/operators/cast.sql
@@ -1,11 +1,17 @@
 --#[cast-00]
-CAST('1' AS INT);
+SELECT CAST('1' AS INT) AS "_1" FROM "default"."T" AS "T";
 
 --#[cast-01]
-CAST('1' AS INT);
+SELECT CAST('1' AS INT) AS "_1" FROM "default"."T" AS "T";
 
 --#[cast-02]
-CAST('1' AS BIGINT);
+SELECT CAST('1' AS BIGINT) AS "_1" FROM "default"."T" AS "T";
 
 --#[cast-03]
-CAST('1' AS BIGINT);
+SELECT CAST('1' AS BIGINT) AS "_1" FROM "default"."T" AS "T";
+
+-- #[cast-04]
+-- SELECT CAST(1 AS REAL) AS "_1" FROM "default"."T" AS "T";
+
+--#[cast-05]
+SELECT CAST(1 AS DOUBLE) AS "_1" FROM "default"."T" AS "T";


### PR DESCRIPTION
*Description of changes:*

We should be printing float8 as such

    Redshift — DOUBLE PRECISION / FLOAT / FLOAT8
    Trino — DOUBLE
    Spark — DOUBLE

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
