### PR TITLE
Support nested EXCLUDE on nullable paths

### DIFF
--- a/src/main/kotlin/org/partiql/scribe/Extensions.kt
+++ b/src/main/kotlin/org/partiql/scribe/Extensions.kt
@@ -25,6 +25,8 @@ public fun StaticType.asAbsent(): StaticType = unionOf(this, NULL, MissingType).
  *  Returns a non-nullable version of the current [StaticType].
  *
  *  If it already non-nullable, returns the original type.
+ *
+ *  Note: this extension function will not be needed post PLK 0.15+ with the deprecation of null and missing types.
  */
 public fun StaticType.asNonNullable(): StaticType = when (this.isNullable()) {
     false -> this

--- a/src/main/kotlin/org/partiql/scribe/RexOpVarTypeRewriter.kt
+++ b/src/main/kotlin/org/partiql/scribe/RexOpVarTypeRewriter.kt
@@ -36,7 +36,7 @@ internal class RexOpVarTypeRewriter(
                 val newPathKey = super.visitRexOp(node.op, ctx) as Rex.Op.Path.Key
                 val newRoot = newPathKey.root
                 val newKeyOp = newPathKey.key.op
-                val t = newRoot.type
+                val t = newRoot.type.asNonNullable()
                 if (t is StructType && newKeyOp is Rex.Op.Lit) {
                     if (newKeyOp.value.type != PartiQLValueType.STRING) {
                         error("Invalid literal along path: $newKeyOp")
@@ -54,7 +54,7 @@ internal class RexOpVarTypeRewriter(
                 val newPathSymbol = super.visitRexOp(node.op, ctx) as Rex.Op.Path.Symbol
                 val newRoot = newPathSymbol.root
                 val fieldName = newPathSymbol.key
-                val t = newRoot.type
+                val t = newRoot.type.asNonNullable()
                 if (t is StructType) {
                     val newType = t.fields.first { it.key.equals(fieldName, ignoreCase = true) }.value
                     node.copy(

--- a/src/main/kotlin/org/partiql/scribe/sql/RexConverter.kt
+++ b/src/main/kotlin/org/partiql/scribe/sql/RexConverter.kt
@@ -29,6 +29,7 @@ import org.partiql.plan.Rel
 import org.partiql.plan.Rex
 import org.partiql.plan.rexOpSelect
 import org.partiql.plan.visitor.PlanBaseVisitor
+import org.partiql.scribe.asNonNullable
 import org.partiql.types.BagType
 import org.partiql.types.ListType
 import org.partiql.types.SexpType
@@ -248,9 +249,9 @@ public open class RexConverter(
 
     // Adds the [TupleConstraint.Ordered] for [StructType]s
     private fun StaticType.asOrderedStruct(): StaticType {
-        return when (this) {
-            is StructType -> this.copy(
-                constraints = this.constraints + setOf(TupleConstraint.Ordered)
+        return when (val type = this.asNonNullable()) {
+            is StructType -> type.copy(
+                constraints = type.constraints + setOf(TupleConstraint.Ordered)
             )
             else -> this
         }

--- a/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftExpandStruct.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftExpandStruct.kt
@@ -9,6 +9,7 @@ import org.partiql.plan.rexOpLit
 import org.partiql.plan.rexOpPathKey
 import org.partiql.plan.rexOpStruct
 import org.partiql.plan.rexOpStructField
+import org.partiql.scribe.asNonNullable
 import org.partiql.types.StaticType
 import org.partiql.types.StructType
 import org.partiql.types.function.FunctionParameter
@@ -24,7 +25,7 @@ private fun StaticType.shouldExpand() = this.metas["EXPAND"] == true
 // 2. the output paths to SET to empty structs
 private fun fieldToRedshiftPaths(field: StructType.Field, prefix: String?): Pair<List<String>, List<String>> {
     val fieldKey = field.key
-    val fieldValue = field.value
+    val fieldValue = field.value.asNonNullable()
     return if (fieldValue is StructType && fieldValue.shouldExpand()) {
         if (fieldValue.fields.isEmpty()) {
             // Empty struct (all fields excluded). Add the path to both the keepList and setList.
@@ -156,7 +157,7 @@ internal fun expandStruct(op: Rex.Op, structType: StructType): List<Rex> {
             ),
             key = rex(StaticType.STRING, rexOpLit(stringValue(topLevelField.key)))
         )
-        val fieldValue = topLevelField.value
+        val fieldValue = topLevelField.value.asNonNullable()
         // Create using OBJECT_TRANSFORM since the struct has excluded fields and/or nested excluded fields
         if (fieldValue is StructType && fieldValue.shouldExpand()) {
             val newOp = rewriteToObjectTransform(pathOp, fieldValue)

--- a/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftRewriter.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftRewriter.kt
@@ -196,11 +196,11 @@ public open class RedshiftRewriter(val onProblem: ProblemCallback) : PlanRewrite
     }
 
     private fun StaticType.exclude(steps: List<Rel.Op.Exclude.Step>): StaticType =
-        when (this) {
-            is StructType -> this.exclude(steps)
-            is CollectionType -> this.exclude(steps)
+        when (val nonNullType = this.asNonNullable()) {
+            is StructType -> nonNullType.exclude(steps)
+            is CollectionType -> nonNullType.exclude(steps)
             is AnyOfType -> StaticType.unionOf(
-                this.types.map { it.exclude(steps) }.toSet()
+                nonNullType.types.map { it.exclude(steps) }.toSet()
             )
             else -> this
         }.flatten()

--- a/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftRewriter.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftRewriter.kt
@@ -65,7 +65,7 @@ public open class RedshiftRewriter(val onProblem: ProblemCallback) : PlanRewrite
         val newArgs = mutableListOf<Rex>()
         newTupleUnion.args.forEach { arg ->
             val op = arg.op
-            val type = arg.type
+            val type = arg.type.asNonNullable()
             // For now, just support the expansion of variable references and paths
             if (type is StructType && (op is Rex.Op.Var || op is Rex.Op.Path)) {
                 newArgs.addAll(expandStruct(op, type))
@@ -82,7 +82,7 @@ public open class RedshiftRewriter(val onProblem: ProblemCallback) : PlanRewrite
         val struct = super.visitRexOpStruct(node, ctx) as Rex.Op.Struct
         val newStruct = struct.fields.map { field ->
             val op = field.v.op
-            val type = field.v.type
+            val type = field.v.type.asNonNullable()
             val newOp = if (type is StructType && (op is Rex.Op.Var || op is Rex.Op.Path)) {
                 rewriteToObjectTransform(op, type)
             } else {

--- a/src/main/kotlin/org/partiql/scribe/targets/spark/SparkRewriter.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/spark/SparkRewriter.kt
@@ -55,7 +55,7 @@ public open class SparkRewriter(val onProblem: ProblemCallback) : PlanRewriter<R
         val newArgs = mutableListOf<Rex>()
         newTupleUnion.args.forEach { arg ->
             val op = arg.op
-            val type = arg.type
+            val type = arg.type.asNonNullable()
             // For now, just support the expansion of variable references and paths
             if (type is StructType && (op is Rex.Op.Var || op is Rex.Op.Path)) {
                 newArgs.addAll(expandStruct(op, type))
@@ -74,7 +74,7 @@ public open class SparkRewriter(val onProblem: ProblemCallback) : PlanRewriter<R
     }
 
     override fun visitRexOpSelect(node: Rex.Op.Select, ctx: Rel.Type?): PlanNode {
-        when (val type = node.constructor.type) {
+        when (val type = node.constructor.type.asNonNullable()) {
             is StructType -> {
                 val open = !(type.contentClosed && type.constraints.contains(TupleConstraint.Open(false)))
                 val unordered = !type.constraints.contains(TupleConstraint.Ordered)

--- a/src/main/kotlin/org/partiql/scribe/targets/spark/SparkRewriter.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/spark/SparkRewriter.kt
@@ -24,6 +24,7 @@ import org.partiql.plan.util.PlanRewriter
 import org.partiql.scribe.ProblemCallback
 import org.partiql.scribe.ScribeProblem
 import org.partiql.scribe.VarToPathRewriter
+import org.partiql.scribe.asNonNullable
 import org.partiql.scribe.expandStruct
 import org.partiql.types.CollectionType
 import org.partiql.types.StaticType
@@ -266,14 +267,14 @@ public open class SparkRewriter(val onProblem: ProblemCallback) : PlanRewriter<R
     }
 
     private fun StaticType.toRex(prefixPath: Rex): Rex {
-        return when (this) {
+        return when (val nonNullType = this.asNonNullable()) {
             is StructType -> Rex(
-                type = this,
-                op = this.toRexStruct(prefixPath),
+                type = nonNullType,
+                op = nonNullType.toRexStruct(prefixPath),
             )
             is CollectionType -> Rex(
-                type = this,
-                op = this.toRexCallTransform(prefixPath),
+                type = nonNullType,
+                op = nonNullType.toRexCallTransform(prefixPath),
             )
             else -> prefixPath
         }

--- a/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoRewriter.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoRewriter.kt
@@ -74,7 +74,7 @@ public open class TrinoRewriter(val onProblem: ProblemCallback) : PlanRewriter<R
         val newArgs = mutableListOf<Rex>()
         newTupleUnion.args.forEach { arg ->
             val op = arg.op
-            val type = arg.type
+            val type = arg.type.asNonNullable()
             // For now, just support the expansion of variable references and paths
             if (type is StructType && (op is Rex.Op.Var || op is Rex.Op.Path)) {
                 newArgs.addAll(expandStruct(op, type))
@@ -152,7 +152,7 @@ public open class TrinoRewriter(val onProblem: ProblemCallback) : PlanRewriter<R
     }
 
     override fun visitRexOpSelect(node: Rex.Op.Select, ctx: Rel.Type?): PlanNode {
-        when (val type = node.constructor.type) {
+        when (val type = node.constructor.type.asNonNullable()) {
             is StructType -> {
                 val open = !(type.contentClosed && type.constraints.contains(TupleConstraint.Open(false)))
                 val unordered = !type.constraints.contains(TupleConstraint.Ordered)

--- a/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoRewriter.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoRewriter.kt
@@ -385,20 +385,20 @@ public open class TrinoRewriter(val onProblem: ProblemCallback) : PlanRewriter<R
     }
 
     private fun StaticType.toRex(prefixPath: Rex): Rex {
-        return when (this) {
+        return when (val nonNullType = this.asNonNullable()) {
             is StructType -> {
                 Rex(
-                    type = this,
-                    op = when (this.fields.size) {
+                    type = nonNullType,
+                    op = when (nonNullType.fields.size) {
                         0 -> kotlin.error("Currently Trino does not allow empty ROWs. Consider `EXCLUDE` on the outer struct")
-                        1 -> this.toRexCastRow(prefixPath)
-                        else -> this.toRexStruct(prefixPath)
+                        1 -> nonNullType.toRexCastRow(prefixPath)
+                        else -> nonNullType.toRexStruct(prefixPath)
                     },
                 )
             }
             is CollectionType -> Rex(
-                type = this,
-                op = this.toRexCallTransform(prefixPath),
+                type = nonNullType,
+                op = nonNullType.toRexCallTransform(prefixPath),
             )
             else -> prefixPath
         }

--- a/src/test/resources/catalogs/default/EXCLUDE_T_NULLABLE.ion
+++ b/src/test/resources/catalogs/default/EXCLUDE_T_NULLABLE.ion
@@ -1,0 +1,86 @@
+// Same as `EXCLUDE_T` but every struct and field is nullable
+{
+  type: "bag",
+  items: {
+    type: "struct",
+    constraints: [ closed, ordered, unique ],
+    fields: [
+      {
+        name: "flds",
+        type: [
+          {
+            type: "struct",
+            constraints: [ closed, ordered, unique ],
+            fields: [
+              {
+                name: "a",
+                type: [
+                  {
+                    type: "struct",
+                    constraints: [ closed, ordered, unique ],
+                    fields: [
+                      {
+                        name: "field_x",
+                        type: ["int32", "null"],
+                      },
+                      {
+                        name: "field_y",
+                        type: ["string", "null"],
+                      }
+                    ]
+                  },
+                  "null"
+                ]
+              },
+              {
+                name: "b",
+                type: [
+                  {
+                    type: "struct",
+                    constraints: [ closed, ordered, unique ],
+                    fields: [
+                      {
+                        name: "field_x",
+                        type: ["int32", "null"],
+                      },
+                      {
+                        name: "field_y",
+                        type: ["string", "null"],
+                      }
+                    ]
+                  },
+                  "null"
+                ]
+              },
+              {
+                name: "c",
+                type: [
+                  {
+                    type: "struct",
+                    constraints: [ closed, ordered, unique ],
+                    fields: [
+                      {
+                        name: "field_x",
+                        type: ["int32", "null"],
+                      },
+                      {
+                        name: "field_y",
+                        type: ["string", "null"],
+                      }
+                    ]
+                  },
+                  "null"
+                ]
+              },
+            ]
+          },
+          "null"
+        ]
+      },
+      {
+        name: "foo",
+        type: ["string", "null"],
+      }
+    ]
+  }
+}

--- a/src/test/resources/inputs/basics/exclude.sql
+++ b/src/test/resources/inputs/basics/exclude.sql
@@ -210,3 +210,6 @@ SELECT * EXCLUDE t.flds.a.field_x, t.flds.a.field_y, t.flds.b.field_x, t.flds.b.
 --#[exclude-48]
 SELECT * EXCLUDE t.flds.a, t.flds.b, t.flds.c FROM EXCLUDE_T AS t;
 
+--#[exclude-49]
+-- Exclude two nested fields; same transpiled query (other than table name) as #[exclude-04]
+SELECT * EXCLUDE t.flds.b, t.flds.c.field_x FROM EXCLUDE_T_NULLABLE AS t;

--- a/src/test/resources/outputs/redshift/basics/exclude.sql
+++ b/src/test/resources/outputs/redshift/basics/exclude.sql
@@ -109,3 +109,7 @@ SELECT OBJECT_TRANSFORM("t"."flds" KEEP '"a"', '"b"', '"c"' SET '"a"', OBJECT(),
 -- EXCLUDE all fields of a top-level struct column
 --#[exclude-48]
 SELECT OBJECT() AS "flds", "t"."foo" AS "foo" FROM "default"."EXCLUDE_T" AS "t";
+
+--#[exclude-49]
+-- Exclude two nested fields; same transpiled query (other than table name) as #[exclude-04]
+SELECT OBJECT_TRANSFORM("t"."flds" KEEP '"a"', '"c"."field_y"') AS "flds", "t"."foo" AS "foo" FROM "default"."EXCLUDE_T_NULLABLE" AS "t";

--- a/src/test/resources/outputs/spark/basics/exclude.sql
+++ b/src/test/resources/outputs/spark/basics/exclude.sql
@@ -99,3 +99,7 @@ FROM
     `default`.`T_EXCLUDE_TOP_LEVEL` AS `t6` ON `t6`.`a` INNER JOIN
     `default`.`T_EXCLUDE_TOP_LEVEL` AS `t7` ON true
 WHERE `t1`.`a` AND `t2`.`a`;
+
+--#[exclude-49]
+-- Exclude two nested fields; same transpiled query (other than table name) as #[exclude-04]
+SELECT `$__EXCLUDE_ALIAS__`.`t`.`flds` AS `flds`, `$__EXCLUDE_ALIAS__`.`t`.`foo` AS `foo` FROM (SELECT STRUCT(STRUCT(STRUCT(`t`.`flds`.`a`.`field_x` AS `field_x`, `t`.`flds`.`a`.`field_y` AS `field_y`) AS `a`, STRUCT(`t`.`flds`.`c`.`field_y` AS `field_y`) AS `c`) AS `flds`, `t`.`foo` AS `foo`) AS `t` FROM `default`.`EXCLUDE_T_NULLABLE` AS `t`) AS `$__EXCLUDE_ALIAS__`;

--- a/src/test/resources/outputs/trino/basics/exclude.sql
+++ b/src/test/resources/outputs/trino/basics/exclude.sql
@@ -198,3 +198,7 @@ FROM
         "default"."T_EXCLUDE_TOP_LEVEL" AS "t6" ON "t6"."a" INNER JOIN
         "default"."T_EXCLUDE_TOP_LEVEL" AS "t7" ON true
 WHERE "t1"."a" AND "t2"."a";
+
+--#[exclude-49]
+-- Exclude two nested fields; same transpiled query (other than table name) as #[exclude-04]
+SELECT "$__EXCLUDE_ALIAS__"."t"."flds" AS "flds", "$__EXCLUDE_ALIAS__"."t"."foo" AS "foo" FROM (SELECT (SELECT (SELECT (SELECT "t"."flds"."a"."field_x" AS field_x, "t"."flds"."a"."field_y" AS field_y) AS a, CAST(ROW("t"."flds"."c"."field_y") AS ROW(field_y VARCHAR)) AS c) AS flds, "t"."foo" AS foo) AS "t" FROM "default"."EXCLUDE_T_NULLABLE" AS "t") AS "$__EXCLUDE_ALIAS__";


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Adds support for nested `EXCLUDE` paths where structs along the paths can be nullable.

This change shouldn't be necessary once we remove absent types from the typing system in PLK 0.15 onwards.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
