### PR TITLE
Fix Trino path support for non-delimited identifiers

### DIFF
--- a/src/main/kotlin/org/partiql/scribe/ExcludeBindings.kt
+++ b/src/main/kotlin/org/partiql/scribe/ExcludeBindings.kt
@@ -27,7 +27,7 @@ internal fun excludeBindings(bindings: List<Rel.Binding>, excludePath: Rel.Op.Ex
 }
 
 private fun StaticType.exclude(steps: List<Rel.Op.Exclude.Step>): StaticType =
-    when (val nonNullType = this.asNonNullable()) {
+    when (val nonNullType = this.asNonAbsent()) {
         is StructType -> nonNullType.exclude(steps)
         is CollectionType -> nonNullType.exclude(steps)
         is AnyOfType -> StaticType.unionOf(

--- a/src/main/kotlin/org/partiql/scribe/Extensions.kt
+++ b/src/main/kotlin/org/partiql/scribe/Extensions.kt
@@ -22,13 +22,9 @@ public fun StaticType.asMissable(): StaticType = unionOf(this, MissingType).flat
 public fun StaticType.asAbsent(): StaticType = unionOf(this, NULL, MissingType).flatten()
 
 /**
- *  Returns a non-nullable version of the current [StaticType].
- *
- *  If it already non-nullable, returns the original type.
+ *  Returns a non-null, non-missing version of the current [StaticType].
  *
  *  Note: this extension function will not be needed post PLK 0.15+ with the deprecation of null and missing types.
  */
-public fun StaticType.asNonNullable(): StaticType = when (this.isNullable()) {
-    false -> this
-    true -> unionOf(this.allTypes.filter { it !is NullType }.toSet()).flatten()
-}
+public fun StaticType.asNonAbsent(): StaticType =
+    unionOf(this.allTypes.filter { it !is NullType && it !is MissingType }.toSet()).flatten()

--- a/src/main/kotlin/org/partiql/scribe/RexOpVarTypeRewriter.kt
+++ b/src/main/kotlin/org/partiql/scribe/RexOpVarTypeRewriter.kt
@@ -36,7 +36,7 @@ internal class RexOpVarTypeRewriter(
                 val newPathKey = super.visitRexOp(node.op, ctx) as Rex.Op.Path.Key
                 val newRoot = newPathKey.root
                 val newKeyOp = newPathKey.key.op
-                val t = newRoot.type.asNonNullable()
+                val t = newRoot.type.asNonAbsent()
                 if (t is StructType && newKeyOp is Rex.Op.Lit) {
                     if (newKeyOp.value.type != PartiQLValueType.STRING) {
                         error("Invalid literal along path: $newKeyOp")
@@ -54,7 +54,7 @@ internal class RexOpVarTypeRewriter(
                 val newPathSymbol = super.visitRexOp(node.op, ctx) as Rex.Op.Path.Symbol
                 val newRoot = newPathSymbol.root
                 val fieldName = newPathSymbol.key
-                val t = newRoot.type.asNonNullable()
+                val t = newRoot.type.asNonAbsent()
                 if (t is StructType) {
                     val newType = t.fields.first { it.key.equals(fieldName, ignoreCase = true) }.value
                     node.copy(

--- a/src/main/kotlin/org/partiql/scribe/sql/RexConverter.kt
+++ b/src/main/kotlin/org/partiql/scribe/sql/RexConverter.kt
@@ -29,7 +29,7 @@ import org.partiql.plan.Rel
 import org.partiql.plan.Rex
 import org.partiql.plan.rexOpSelect
 import org.partiql.plan.visitor.PlanBaseVisitor
-import org.partiql.scribe.asNonNullable
+import org.partiql.scribe.asNonAbsent
 import org.partiql.types.BagType
 import org.partiql.types.ListType
 import org.partiql.types.SexpType
@@ -249,7 +249,7 @@ public open class RexConverter(
 
     // Adds the [TupleConstraint.Ordered] for [StructType]s
     private fun StaticType.asOrderedStruct(): StaticType {
-        return when (val type = this.asNonNullable()) {
+        return when (val type = this.asNonAbsent()) {
             is StructType -> type.copy(
                 constraints = type.constraints + setOf(TupleConstraint.Ordered)
             )

--- a/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftExpandStruct.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftExpandStruct.kt
@@ -9,7 +9,7 @@ import org.partiql.plan.rexOpLit
 import org.partiql.plan.rexOpPathKey
 import org.partiql.plan.rexOpStruct
 import org.partiql.plan.rexOpStructField
-import org.partiql.scribe.asNonNullable
+import org.partiql.scribe.asNonAbsent
 import org.partiql.types.StaticType
 import org.partiql.types.StructType
 import org.partiql.types.function.FunctionParameter
@@ -25,7 +25,7 @@ private fun StaticType.expand() = this.metas["EXPAND"] == true
 // 2. the output paths to SET to empty structs
 private fun fieldToRedshiftPaths(field: StructType.Field, prefix: String?): Pair<List<String>, List<String>> {
     val fieldKey = field.key
-    val fieldValue = field.value.asNonNullable()
+    val fieldValue = field.value.asNonAbsent()
     return if (fieldValue is StructType && fieldValue.expand()) {
         if (fieldValue.fields.isEmpty()) {
             // Empty struct (all fields excluded). Add the path to both the keepList and setList.
@@ -153,7 +153,7 @@ internal fun expandStructRedshift(op: Rex.Op, structType: StructType): List<Rex>
             ),
             key = rex(StaticType.STRING, rexOpLit(stringValue(topLevelField.key)))
         )
-        val fieldValue = topLevelField.value.asNonNullable()
+        val fieldValue = topLevelField.value.asNonAbsent()
         // Create using OBJECT_TRANSFORM since the struct has excluded fields and/or nested excluded fields
         if (fieldValue is StructType && fieldValue.expand()) {
             val newOp = rewriteToObjectTransform(pathOp, fieldValue)

--- a/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftRewriter.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftRewriter.kt
@@ -11,7 +11,7 @@ import org.partiql.plan.util.PlanRewriter
 import org.partiql.scribe.ProblemCallback
 import org.partiql.scribe.ScribeProblem
 import org.partiql.scribe.RexOpVarTypeRewriter
-import org.partiql.scribe.asNonNullable
+import org.partiql.scribe.asNonAbsent
 import org.partiql.scribe.excludeBindings
 import org.partiql.types.SingleType
 import org.partiql.types.StructType
@@ -59,7 +59,7 @@ public open class RedshiftRewriter(val onProblem: ProblemCallback) : PlanRewrite
         val newArgs = mutableListOf<Rex>()
         newTupleUnion.args.forEach { arg ->
             val op = arg.op
-            val type = arg.type.asNonNullable()
+            val type = arg.type.asNonAbsent()
             // For now, just support the expansion of variable references and paths
             if (type is StructType && (op is Rex.Op.Var || op is Rex.Op.Path)) {
                 newArgs.addAll(expandStructRedshift(op, type))
@@ -76,7 +76,7 @@ public open class RedshiftRewriter(val onProblem: ProblemCallback) : PlanRewrite
         val struct = super.visitRexOpStruct(node, ctx) as Rex.Op.Struct
         val newStruct = struct.fields.map { field ->
             val op = field.v.op
-            val type = field.v.type.asNonNullable()
+            val type = field.v.type.asNonAbsent()
             val newOp = if (type is StructType && (op is Rex.Op.Var || op is Rex.Op.Path)) {
                 rewriteToObjectTransform(op, type)
             } else {
@@ -95,7 +95,7 @@ public open class RedshiftRewriter(val onProblem: ProblemCallback) : PlanRewrite
     override fun visitRelOpProject(node: Rel.Op.Project, ctx: Rel.Type?): PlanNode {
         // Make sure that the output type is homogeneous
         node.projections.forEachIndexed { index, projection ->
-            val type = projection.type.asNonNullable().flatten()
+            val type = projection.type.asNonAbsent().flatten()
             if (type !is SingleType) {
                 error("Projection item (index $index) is heterogeneous (${type.allTypes.joinToString(",")}) and cannot be coerced to a single type.")
             }

--- a/src/main/kotlin/org/partiql/scribe/targets/spark/SparkExpandStruct.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/spark/SparkExpandStruct.kt
@@ -8,7 +8,7 @@ import org.partiql.plan.rexOpLit
 import org.partiql.plan.rexOpPathKey
 import org.partiql.plan.rexOpStruct
 import org.partiql.plan.rexOpStructField
-import org.partiql.scribe.asNonNullable
+import org.partiql.scribe.asNonAbsent
 import org.partiql.types.CollectionType
 import org.partiql.types.StaticType
 import org.partiql.types.StructType
@@ -25,7 +25,7 @@ internal fun StaticType.toRexSpark(prefixPath: Rex): Rex {
     if (!this.expand()) {
         return prefixPath
     }
-    return when (val nonNullType = this.asNonNullable()) {
+    return when (val nonNullType = this.asNonAbsent()) {
         is StructType -> Rex(
             type = nonNullType,
             op = when (nonNullType.fields.size) {
@@ -123,7 +123,7 @@ internal fun expandStructSpark(op: Rex.Op, structType: StructType): List<Rex> {
             ),
             key = rex(StaticType.STRING, rexOpLit(stringValue(topLevelField.key)))
         )
-        val fieldValue = topLevelField.value.asNonNullable()
+        val fieldValue = topLevelField.value.asNonAbsent()
         if (fieldValue.expand()) {
             val newOp = fieldValue.toRexSpark(
                 prefixPath = Rex(

--- a/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoExpandStruct.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoExpandStruct.kt
@@ -9,7 +9,7 @@ import org.partiql.plan.rexOpLit
 import org.partiql.plan.rexOpPathKey
 import org.partiql.plan.rexOpStruct
 import org.partiql.plan.rexOpStructField
-import org.partiql.scribe.asNonNullable
+import org.partiql.scribe.asNonAbsent
 import org.partiql.types.AnyOfType
 import org.partiql.types.BoolType
 import org.partiql.types.CollectionType
@@ -40,7 +40,7 @@ internal fun StaticType.toRexTrino(prefixPath: Rex): Rex {
     if (!this.expand()) {
         return prefixPath
     }
-    return when (val nonNullType = this.asNonNullable()) {
+    return when (val nonNullType = this.asNonAbsent()) {
         is StructType -> {
             Rex(
                 type = nonNullType,
@@ -268,7 +268,7 @@ internal fun expandStructTrino(op: Rex.Op, structType: StructType): List<Rex> {
             ),
             key = rex(StaticType.STRING, rexOpLit(stringValue(topLevelField.key)))
         )
-        val fieldValue = topLevelField.value.asNonNullable()
+        val fieldValue = topLevelField.value.asNonAbsent()
         if (fieldValue.expand()) {
             val newOp = fieldValue.toRexTrino(
                 prefixPath = Rex(

--- a/src/test/resources/inputs/basics/paths.sql
+++ b/src/test/resources/inputs/basics/paths.sql
@@ -140,3 +140,29 @@ SELECT t.x[0 + 1] AS v FROM t;
 
 --#[paths-sfw-16]
 SELECT t.array[0] AS v FROM t;
+
+-- Additional path exprs
+--#[paths-sfw-17]
+SELECT flds.a AS v FROM EXCLUDE_T AS t;
+
+--#[paths-sfw-18]
+SELECT t.flds.a AS v FROM EXCLUDE_T AS t;
+
+--#[paths-sfw-19]
+SELECT t.flds.a.field_x AS v FROM EXCLUDE_T AS t;
+
+-- qualified path
+--#[paths-sfw-20]
+SELECT "t"."flds"."a"."field_x" AS v FROM EXCLUDE_T AS t;
+
+-- nullable fields
+--#[paths-sfw-21]
+SELECT t.flds.a.field_x AS v FROM EXCLUDE_T_NULLABLE AS t;
+
+-- nullable fields + qualified path
+--#[paths-sfw-22]
+SELECT "t"."flds"."a"."field_x" AS v FROM EXCLUDE_T_NULLABLE AS t;
+
+-- nullable fields + mix of qualified and unqualified path components
+--#[paths-sfw-23]
+SELECT "t".flds."a".field_x AS v FROM EXCLUDE_T_NULLABLE AS t;

--- a/src/test/resources/outputs/trino/basics/paths.sql
+++ b/src/test/resources/outputs/trino/basics/paths.sql
@@ -5,3 +5,29 @@
 --#[paths-sfw-16]
 -- array navigation with literal (1-indexed)
 SELECT "t"."array"[1] AS "v" FROM "default"."T" AS "t";
+
+-- Additional path exprs
+--#[paths-sfw-17]
+SELECT "t"."flds"."a" AS "v" FROM "default"."EXCLUDE_T" AS "t";
+
+--#[paths-sfw-18]
+SELECT "t"."flds"."a" AS "v" FROM "default"."EXCLUDE_T" AS "t";
+
+--#[paths-sfw-19]
+SELECT "t"."flds"."a"."field_x" AS "v" FROM "default"."EXCLUDE_T" AS "t";
+
+-- qualified path
+--#[paths-sfw-20]
+SELECT "t"."flds"."a"."field_x" AS "v" FROM "default"."EXCLUDE_T" AS "t";
+
+-- nullable fields
+--#[paths-sfw-21]
+SELECT "t"."flds".a.field_x AS "v" FROM "default"."EXCLUDE_T_NULLABLE" AS "t";
+
+-- nullable fields + qualified path
+--#[paths-sfw-22]
+SELECT "t"."flds"."a"."field_x" AS "v" FROM "default"."EXCLUDE_T_NULLABLE" AS "t";
+
+-- nullable fields + mix of qualified and unqualified path components
+--#[paths-sfw-23]
+SELECT "t"."flds"."a".field_x AS "v" FROM "default"."EXCLUDE_T_NULLABLE" AS "t";


### PR DESCRIPTION
*Issue #, if available:*
- Resolves https://github.com/partiql/partiql-scribe/issues/41.

*Description of changes:*
Adds support for non-delimited identifiers along path expression. Scribe would previously give an error when transpiling a path expression that would have a non-delimited identifier (e.g. `t.flds.a.field_x`):

```
Trino does not support path expressions on non-variable values
```

### Background on Trino's Support for Paths

Trino has limited support for pathing on structural types such as `ARRAY` and `ROW`s. Alike PartiQL, Trino supports array indexing such as `<some_array>[<int index>]`. Though Trino array indexing is 1-indexed. Scribe already supports transpilation of array indexing:

https://github.com/partiql/partiql-scribe/blob/8bfcb5c85c203d543dfecd14ea9ae2bf25816909/src/test/resources/outputs/trino/basics/paths.sql#L5-L7.

Trino also supports some basic pathing on `ROW`s:

Input table:
```
WITH EXCLUDE_T AS (
	SELECT (
			SELECT (
					SELECT 1 AS field_x,
						'one' AS field_y,
						'1' AS field_z
				) AS a,
				(
					SELECT 2 AS field_x,
						'two' AS field_y,
						'2' AS field_z
				) AS b,
				(
					SELECT 3 AS field_x,
						'three' AS field_y,
						'3' AS field_z
				) AS c
		) AS flds,
		'bar' AS foo
)
```
Non-delimited path query
```
SELECT t.flds.a.field_x
FROM EXCLUDE_T AS t;
```
Outputs:
```
#	field_x
1	1
```

Similarly Trino supports delimited identifier paths:
```
SELECT "t"."flds"."a"."field_x"
FROM EXCLUDE_T AS t;
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
