### PR TITLE
Qualify Trino `CAST(ROW())` field names

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ object Versions {
     const val jline = "3.21.0"
     const val junit5 = "5.9.3"
     const val picoCli = "4.7.0"
-    const val partiql = "0.14.6"
+    const val partiql = "0.14.9"
 }
 
 object Deps {

--- a/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoExpandStruct.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoExpandStruct.kt
@@ -177,7 +177,8 @@ private fun StaticType.toTrinoString(): String {
         is StructType -> {
             val head = "ROW("
             val fieldsAsString = this.fields.foldIndexed("") { index, acc, field ->
-                val fieldStr = acc + field.key + " " + field.value.toTrinoString()
+                // wrap `field.key` in double-quotes since the field name could be a reserved keyword
+                val fieldStr = acc + "\"${field.key}\"" + " " + field.value.toTrinoString()
                 if (index < fields.size - 1) {
                     "$fieldStr, "
                 } else {

--- a/src/test/resources/catalogs/default/EXCLUDE_T_RESERVED_KEYWORDS.ion
+++ b/src/test/resources/catalogs/default/EXCLUDE_T_RESERVED_KEYWORDS.ion
@@ -1,0 +1,56 @@
+{
+  type: "bag",
+  items: {
+    type: "struct",
+    constraints: [ closed, ordered, unique ],
+    fields: [
+      {
+        name: "flds",
+        type: {
+          type: "struct",
+          constraints: [ closed, ordered, unique ],
+          fields: [
+            {
+              name: "select",
+              type: {
+                type: "struct",
+                constraints: [ closed, ordered, unique ],
+                fields: [
+                  {
+                    name: "field_x",
+                    type: "int32",
+                  },
+                  {
+                    name: "field_y",
+                    type: "string",
+                  }
+                ]
+              },
+            },
+            {
+              name: "order",
+              type: {
+                type: "struct",
+                constraints: [ closed, ordered, unique ],
+                fields: [
+                  {
+                    name: "field_x",
+                    type: "int32",
+                  },
+                  {
+                    name: "field_y",
+                    type: "string",
+                  }
+                ]
+              },
+            },
+          ]
+        }
+      },
+      {
+        name: "foo",
+        type: "string",
+      }
+    ]
+  }
+}

--- a/src/test/resources/inputs/basics/exclude.sql
+++ b/src/test/resources/inputs/basics/exclude.sql
@@ -225,3 +225,6 @@ SELECT * EXCLUDE t.a[*].field_z FROM EXCLUDE_T_NESTED_LIST AS t;
 
 --#[exclude-53]
 SELECT * EXCLUDE t.a[*].nested_list FROM EXCLUDE_T_NESTED_LIST AS t;
+
+--#[exclude-54]
+SELECT * EXCLUDE t.flds."select".field_x FROM EXCLUDE_T_RESERVED_KEYWORDS AS t;

--- a/src/test/resources/outputs/trino/basics/exclude.sql
+++ b/src/test/resources/outputs/trino/basics/exclude.sql
@@ -5,16 +5,16 @@ SELECT "t"."flds" AS "flds" FROM "default"."EXCLUDE_T" AS "t";
 SELECT "t"."foo" AS "foo" FROM "default"."EXCLUDE_T" AS "t";
 
 --#[exclude-02]
-SELECT CAST(ROW("t"."flds"."a", "t"."flds"."c") AS ROW(a ROW(field_x INTEGER, field_y VARCHAR), c ROW(field_x INTEGER, field_y VARCHAR))) AS "flds", "t"."foo" AS "foo" FROM "default"."EXCLUDE_T" AS "t";
+SELECT CAST(ROW("t"."flds"."a", "t"."flds"."c") AS ROW("a" ROW("field_x" INTEGER, "field_y" VARCHAR), "c" ROW("field_x" INTEGER, "field_y" VARCHAR))) AS "flds", "t"."foo" AS "foo" FROM "default"."EXCLUDE_T" AS "t";
 
 --#[exclude-03]
-SELECT CAST(ROW("t"."flds"."a", "t"."flds"."b", CAST(ROW("t"."flds"."c"."field_y") AS ROW(field_y VARCHAR))) AS ROW(a ROW(field_x INTEGER, field_y VARCHAR), b ROW(field_x INTEGER, field_y VARCHAR), c ROW(field_y VARCHAR))) AS "flds", "t"."foo" AS "foo" FROM "default"."EXCLUDE_T" AS "t";
+SELECT CAST(ROW("t"."flds"."a", "t"."flds"."b", CAST(ROW("t"."flds"."c"."field_y") AS ROW("field_y" VARCHAR))) AS ROW("a" ROW("field_x" INTEGER, "field_y" VARCHAR), "b" ROW("field_x" INTEGER, "field_y" VARCHAR), "c" ROW("field_y" VARCHAR))) AS "flds", "t"."foo" AS "foo" FROM "default"."EXCLUDE_T" AS "t";
 
 --#[exclude-04]
-SELECT CAST(ROW("t"."flds"."a", CAST(ROW("t"."flds"."c"."field_y") AS ROW(field_y VARCHAR))) AS ROW(a ROW(field_x INTEGER, field_y VARCHAR), c ROW(field_y VARCHAR))) AS "flds", "t"."foo" AS "foo" FROM "default"."EXCLUDE_T" AS "t";
+SELECT CAST(ROW("t"."flds"."a", CAST(ROW("t"."flds"."c"."field_y") AS ROW("field_y" VARCHAR))) AS ROW("a" ROW("field_x" INTEGER, "field_y" VARCHAR), "c" ROW("field_y" VARCHAR))) AS "flds", "t"."foo" AS "foo" FROM "default"."EXCLUDE_T" AS "t";
 
 --#[exclude-05]
-SELECT CAST(ROW("t"."flds"."a", "t"."flds"."b", CAST(ROW("t"."flds"."c"."field_x") AS ROW(field_x INTEGER))) AS ROW(a ROW(field_x INTEGER, field_y VARCHAR), b ROW(field_x INTEGER, field_y VARCHAR), c ROW(field_x INTEGER))) AS "flds", "t"."foo" AS "foo" FROM "default"."EXCLUDE_T" AS "t";
+SELECT CAST(ROW("t"."flds"."a", "t"."flds"."b", CAST(ROW("t"."flds"."c"."field_x") AS ROW("field_x" INTEGER))) AS ROW("a" ROW("field_x" INTEGER, "field_y" VARCHAR), "b" ROW("field_x" INTEGER, "field_y" VARCHAR), "c" ROW("field_x" INTEGER))) AS "flds", "t"."foo" AS "foo" FROM "default"."EXCLUDE_T" AS "t";
 
 -- --#[exclude-06]
 -- Exclude all the fields of `t.flds.c`; unsure if Trino supports ROWs with no fields. Asked a question in discussion to see if feasible https://github.com/trinodb/trino/discussions/20558
@@ -23,38 +23,38 @@ SELECT CAST(ROW("t"."flds"."a", "t"."flds"."b", CAST(ROW("t"."flds"."c"."field_x
 
 -- START OF EXCLUDE with COLLECTION WILDCARD
 --#[exclude-07]
-SELECT transform("t"."a", ___coll_wildcard___ -> CAST(ROW(___coll_wildcard___."field_y") AS ROW(field_y VARCHAR))) AS "a", "t"."foo" AS "foo" FROM "default"."EXCLUDE_T_COLL_WILDCARD" AS "t";
+SELECT transform("t"."a", ___coll_wildcard___ -> CAST(ROW(___coll_wildcard___."field_y") AS ROW("field_y" VARCHAR))) AS "a", "t"."foo" AS "foo" FROM "default"."EXCLUDE_T_COLL_WILDCARD" AS "t";
 
 --#[exclude-08]
-SELECT transform("t"."a", ___coll_wildcard___ -> CAST(ROW(___coll_wildcard___."field_x") AS ROW(field_x INTEGER))) AS "a", "t"."foo" AS "foo" FROM "default"."EXCLUDE_T_COLL_WILDCARD" AS "t";
+SELECT transform("t"."a", ___coll_wildcard___ -> CAST(ROW(___coll_wildcard___."field_x") AS ROW("field_x" INTEGER))) AS "a", "t"."foo" AS "foo" FROM "default"."EXCLUDE_T_COLL_WILDCARD" AS "t";
 
 --#[exclude-09]
-SELECT "t1"."flds" AS "flds", CAST(ROW("t2"."flds"."a", CAST(ROW("t2"."flds"."c"."field_y") AS ROW(field_y VARCHAR))) AS ROW(a ROW(field_x INTEGER, field_y VARCHAR), c ROW(field_y VARCHAR))) AS "flds", "t2"."foo" AS "foo" FROM "default"."EXCLUDE_T" AS "t1" INNER JOIN "default"."EXCLUDE_T" AS "t2" ON true WHERE "t1"."foo" = "t2"."foo";
+SELECT "t1"."flds" AS "flds", CAST(ROW("t2"."flds"."a", CAST(ROW("t2"."flds"."c"."field_y") AS ROW("field_y" VARCHAR))) AS ROW("a" ROW("field_x" INTEGER, "field_y" VARCHAR), "c" ROW("field_y" VARCHAR))) AS "flds", "t2"."foo" AS "foo" FROM "default"."EXCLUDE_T" AS "t1" INNER JOIN "default"."EXCLUDE_T" AS "t2" ON true WHERE "t1"."foo" = "t2"."foo";
 
 --#[exclude-10]
 -- EXCLUDE with multiple JOIN and WHERE clause
-SELECT CAST(ROW("t1"."flds"."b", "t1"."flds"."c") AS ROW(b ROW(field_x INTEGER, field_y VARCHAR), c ROW(field_x INTEGER, field_y VARCHAR))) AS "flds", "t1"."foo" AS "foo", CAST(ROW("t2"."flds"."a", "t2"."flds"."c") AS ROW(a ROW(field_x INTEGER, field_y VARCHAR), c ROW(field_x INTEGER, field_y VARCHAR))) AS "flds", "t2"."foo" AS "foo", CAST(ROW("t3"."flds"."a", "t3"."flds"."b") AS ROW(a ROW(field_x INTEGER, field_y VARCHAR), b ROW(field_x INTEGER, field_y VARCHAR))) AS "flds", "t3"."foo" AS "foo" FROM "default"."EXCLUDE_T" AS "t1" INNER JOIN "default"."EXCLUDE_T" AS "t2" ON true INNER JOIN "default"."EXCLUDE_T" AS "t3" ON true WHERE ("t1"."foo" = "t2"."foo") AND ("t2"."foo" = "t3"."foo");
+SELECT CAST(ROW("t1"."flds"."b", "t1"."flds"."c") AS ROW("b" ROW("field_x" INTEGER, "field_y" VARCHAR), "c" ROW("field_x" INTEGER, "field_y" VARCHAR))) AS "flds", "t1"."foo" AS "foo", CAST(ROW("t2"."flds"."a", "t2"."flds"."c") AS ROW("a" ROW("field_x" INTEGER, "field_y" VARCHAR), "c" ROW("field_x" INTEGER, "field_y" VARCHAR))) AS "flds", "t2"."foo" AS "foo", CAST(ROW("t3"."flds"."a", "t3"."flds"."b") AS ROW("a" ROW("field_x" INTEGER, "field_y" VARCHAR), "b" ROW("field_x" INTEGER, "field_y" VARCHAR))) AS "flds", "t3"."foo" AS "foo" FROM "default"."EXCLUDE_T" AS "t1" INNER JOIN "default"."EXCLUDE_T" AS "t2" ON true INNER JOIN "default"."EXCLUDE_T" AS "t3" ON true WHERE ("t1"."foo" = "t2"."foo") AND ("t2"."foo" = "t3"."foo");
 
 --#[exclude-11]
 -- EXCLUDE with select projection list and multiple JOINs
-SELECT CAST(ROW("t1"."flds"."b", "t1"."flds"."c") AS ROW(b ROW(field_x INTEGER, field_y VARCHAR), c ROW(field_x INTEGER, field_y VARCHAR))) AS "flds", CAST(ROW("t2"."flds"."a", "t2"."flds"."c") AS ROW(a ROW(field_x INTEGER, field_y VARCHAR), c ROW(field_x INTEGER, field_y VARCHAR))) AS "flds", CAST(ROW("t3"."flds"."a", "t3"."flds"."b") AS ROW(a ROW(field_x INTEGER, field_y VARCHAR), b ROW(field_x INTEGER, field_y VARCHAR))) AS "flds" FROM "default"."EXCLUDE_T" AS "t1" INNER JOIN "default"."EXCLUDE_T" AS "t2" ON true INNER JOIN "default"."EXCLUDE_T" AS "t3" ON true WHERE ("t1"."foo" = "t2"."foo") AND ("t2"."foo" = "t3"."foo");
+SELECT CAST(ROW("t1"."flds"."b", "t1"."flds"."c") AS ROW("b" ROW("field_x" INTEGER, "field_y" VARCHAR), "c" ROW("field_x" INTEGER, "field_y" VARCHAR))) AS "flds", CAST(ROW("t2"."flds"."a", "t2"."flds"."c") AS ROW("a" ROW("field_x" INTEGER, "field_y" VARCHAR), "c" ROW("field_x" INTEGER, "field_y" VARCHAR))) AS "flds", CAST(ROW("t3"."flds"."a", "t3"."flds"."b") AS ROW("a" ROW("field_x" INTEGER, "field_y" VARCHAR), "b" ROW("field_x" INTEGER, "field_y" VARCHAR))) AS "flds" FROM "default"."EXCLUDE_T" AS "t1" INNER JOIN "default"."EXCLUDE_T" AS "t2" ON true INNER JOIN "default"."EXCLUDE_T" AS "t3" ON true WHERE ("t1"."foo" = "t2"."foo") AND ("t2"."foo" = "t3"."foo");
 
 -- EXCLUDE with different types
 -- bool
 --#[exclude-12]
-SELECT CAST(ROW("t"."foo"."keep") AS ROW(keep BOOLEAN)) AS "foo" FROM "default"."datatypes"."T_BOOL" AS "t";
+SELECT CAST(ROW("t"."foo"."keep") AS ROW("keep" BOOLEAN)) AS "foo" FROM "default"."datatypes"."T_BOOL" AS "t"
 
 -- int16
 --#[exclude-13]
-SELECT CAST(ROW("t"."foo"."keep") AS ROW(keep SMALLINT)) AS "foo" FROM "default"."datatypes"."T_INT16" AS "t";
+SELECT CAST(ROW("t"."foo"."keep") AS ROW("keep" SMALLINT)) AS "foo" FROM "default"."datatypes"."T_INT16" AS "t";
 
 -- int32
 --#[exclude-14]
-SELECT CAST(ROW("t"."foo"."keep") AS ROW(keep INTEGER)) AS "foo" FROM "default"."datatypes"."T_INT32" AS "t";
+SELECT CAST(ROW("t"."foo"."keep") AS ROW("keep" INTEGER)) AS "foo" FROM "default"."datatypes"."T_INT32" AS "t";
 
 -- int64
 --#[exclude-15]
-SELECT CAST(ROW("t"."foo"."keep") AS ROW(keep BIGINT)) AS "foo" FROM "default"."datatypes"."T_INT64" AS "t";
+SELECT CAST(ROW("t"."foo"."keep") AS ROW("keep" BIGINT)) AS "foo" FROM "default"."datatypes"."T_INT64" AS "t";
 
 -- int (unconstrained)
 -- Trino does not support unconstrained int; error or give result of BIGINT
@@ -68,75 +68,75 @@ SELECT CAST(ROW("t"."foo"."keep") AS ROW(keep BIGINT)) AS "foo" FROM "default"."
 
 -- float32
 --#[exclude-18]
-SELECT CAST(ROW("t"."foo"."keep") AS ROW(keep DOUBLE)) AS "foo" FROM "default"."datatypes"."T_FLOAT32" AS "t";
+SELECT CAST(ROW("t"."foo"."keep") AS ROW("keep" DOUBLE)) AS "foo" FROM "default"."datatypes"."T_FLOAT32" AS "t";
 
 -- float64
 --#[exclude-19]
-SELECT CAST(ROW("t"."foo"."keep") AS ROW(keep DOUBLE)) AS "foo" FROM "default"."datatypes"."T_FLOAT64" AS "t";
+SELECT CAST(ROW("t"."foo"."keep") AS ROW("keep" DOUBLE)) AS "foo" FROM "default"."datatypes"."T_FLOAT64" AS "t";
 
 -- string
 --#[exclude-20]
-SELECT CAST(ROW("t"."foo"."keep") AS ROW(keep VARCHAR)) AS "foo" FROM "default"."datatypes"."T_STRING" AS "t";
+SELECT CAST(ROW("t"."foo"."keep") AS ROW("keep" VARCHAR)) AS "foo" FROM "default"."datatypes"."T_STRING" AS "t";
 
 -- date
 --#[exclude-21]
-SELECT CAST(ROW("t"."foo"."keep") AS ROW(keep DATE)) AS "foo" FROM "default"."datatypes"."T_DATE" AS "t";
+SELECT CAST(ROW("t"."foo"."keep") AS ROW("keep" DATE)) AS "foo" FROM "default"."datatypes"."T_DATE" AS "t";
 
 -- time
 --#[exclude-22]
-SELECT CAST(ROW("t"."foo"."keep") AS ROW(keep TIME)) AS "foo" FROM "default"."datatypes"."T_TIME" AS "t";
+SELECT CAST(ROW("t"."foo"."keep") AS ROW("keep" TIME)) AS "foo" FROM "default"."datatypes"."T_TIME" AS "t";
 
 -- timestamp
 --#[exclude-23]
-SELECT CAST(ROW("t"."foo"."keep") AS ROW(keep TIMESTAMP)) AS "foo" FROM "default"."datatypes"."T_TIMESTAMP" AS "t";
+SELECT CAST(ROW("t"."foo"."keep") AS ROW("keep" TIMESTAMP)) AS "foo" FROM "default"."datatypes"."T_TIMESTAMP" AS "t";
 
 -- null
 --#[exclude-24]
-SELECT CAST(ROW("t"."foo"."keep") AS ROW(keep NULL)) AS "foo" FROM "default"."datatypes"."T_NULL" AS "t";
+SELECT CAST(ROW("t"."foo"."keep") AS ROW("keep" NULL)) AS "foo" FROM "default"."datatypes"."T_NULL" AS "t";
 
 -- struct
 --#[exclude-25]
-SELECT CAST(ROW("t"."foo"."keep") AS ROW(keep ROW(keep1 INTEGER, keep2 VARCHAR))) AS "foo" FROM "default"."datatypes"."T_STRUCT" AS "t";
+SELECT CAST(ROW("t"."foo"."keep") AS ROW("keep" ROW("keep1" INTEGER, "keep2" VARCHAR))) AS "foo" FROM "default"."datatypes"."T_STRUCT" AS "t";
 
 -- list
 --#[exclude-26]
-SELECT CAST(ROW("t"."foo"."keep") AS ROW(keep ARRAY<INTEGER>)) AS "foo" FROM "default"."datatypes"."T_LIST" AS "t";
+SELECT CAST(ROW("t"."foo"."keep") AS ROW("keep" ARRAY<INTEGER>)) AS "foo" FROM "default"."datatypes"."T_LIST" AS "t";
 
 -- decimal(5, 2)
 --#[exclude-27]
-SELECT CAST(ROW("t"."foo"."keep") AS ROW(keep DECIMAL(5, 2))) AS "foo" FROM "default"."datatypes"."T_DECIMAL_5_2" AS "t";
+SELECT CAST(ROW("t"."foo"."keep") AS ROW("keep" DECIMAL(5, 2))) AS "foo" FROM "default"."datatypes"."T_DECIMAL_5_2" AS "t";
 
 -- varchar(16)
 --#[exclude-28]
-SELECT CAST(ROW("t"."foo"."keep") AS ROW(keep VARCHAR(16))) AS "foo" FROM "default"."datatypes"."T_STRING_16" AS "t";
+SELECT CAST(ROW("t"."foo"."keep") AS ROW("keep" VARCHAR(16))) AS "foo" FROM "default"."datatypes"."T_STRING_16" AS "t";
 
 -- char(16)
 --#[exclude-29]
-SELECT CAST(ROW("t"."foo"."keep") AS ROW(keep CHAR(16))) AS "foo" FROM "default"."datatypes"."T_CHAR_16" AS "t";
+SELECT CAST(ROW("t"."foo"."keep") AS ROW("keep" CHAR(16))) AS "foo" FROM "default"."datatypes"."T_CHAR_16" AS "t";
 
 -- time(6)
 --#[exclude-30]
-SELECT CAST(ROW("t"."foo"."keep") AS ROW(keep TIME(6))) AS "foo" FROM "default"."datatypes"."T_TIME_6" AS "t";
+SELECT CAST(ROW("t"."foo"."keep") AS ROW("keep" TIME(6))) AS "foo" FROM "default"."datatypes"."T_TIME_6" AS "t";
 
 -- timestamp(6)
 --#[exclude-31]
-SELECT CAST(ROW("t"."foo"."keep") AS ROW(keep TIMESTAMP(6))) AS "foo" FROM "default"."datatypes"."T_TIMESTAMP_6" AS "t";
+SELECT CAST(ROW("t"."foo"."keep") AS ROW("keep" TIMESTAMP(6))) AS "foo" FROM "default"."datatypes"."T_TIMESTAMP_6" AS "t";
 
 -- union(string, null)
 --#[exclude-32]
-SELECT CAST(ROW("t"."foo"."keep") AS ROW(keep VARCHAR)) AS "foo" FROM "default"."datatypes"."T_STRING_NULL" AS "t";
+SELECT CAST(ROW("t"."foo"."keep") AS ROW("keep" VARCHAR)) AS "foo" FROM "default"."datatypes"."T_STRING_NULL" AS "t";
 
 -- union(int32, null)
 --#[exclude-33]
-SELECT CAST(ROW("t"."foo"."keep") AS ROW(keep INTEGER)) AS "foo" FROM "default"."datatypes"."T_INT32_NULL" AS "t";
+SELECT CAST(ROW("t"."foo"."keep") AS ROW("keep" INTEGER)) AS "foo" FROM "default"."datatypes"."T_INT32_NULL" AS "t";
 
 -- union(varchar(16), null)
 --#[exclude-34]
-SELECT CAST(ROW("t"."foo"."keep") AS ROW(keep VARCHAR(16))) AS "foo" FROM "default"."datatypes"."T_STRING_16_NULL" AS "t";
+SELECT CAST(ROW("t"."foo"."keep") AS ROW("keep" VARCHAR(16))) AS "foo" FROM "default"."datatypes"."T_STRING_16_NULL" AS "t";
 
 -- union(char(16), null)
 --#[exclude-35]
-SELECT CAST(ROW("t"."foo"."keep") AS ROW(keep CHAR(16))) AS "foo" FROM "default"."datatypes"."T_CHAR_16_NULL" AS "t";
+SELECT CAST(ROW("t"."foo"."keep") AS ROW("keep" CHAR(16))) AS "foo" FROM "default"."datatypes"."T_CHAR_16_NULL" AS "t";
 
 -- Tests for EXCLUDE on top-level columns only --
 -- Baseline query without `EXCLUDE`
@@ -201,16 +201,19 @@ WHERE "t1"."a" AND "t2"."a";
 
 --#[exclude-49]
 -- Exclude two nested fields; same transpiled query (other than table name) as #[exclude-04]
-SELECT CAST(ROW("t"."flds"."a", CAST(ROW("t"."flds"."c"."field_y") AS ROW(field_y VARCHAR))) AS ROW(a ROW(field_x INTEGER, field_y VARCHAR), c ROW(field_y VARCHAR))) AS "flds", "t"."foo" AS "foo" FROM "default"."EXCLUDE_T_NULLABLE" AS "t";
+SELECT CAST(ROW("t"."flds"."a", CAST(ROW("t"."flds"."c"."field_y") AS ROW("field_y" VARCHAR))) AS ROW("a" ROW("field_x" INTEGER, "field_y" VARCHAR), "c" ROW("field_y" VARCHAR))) AS "flds", "t"."foo" AS "foo" FROM "default"."EXCLUDE_T_NULLABLE" AS "t";
 
 --#[exclude-50]
-SELECT transform("t"."a", ___coll_wildcard___ -> CAST(ROW(___coll_wildcard___."field_y", ___coll_wildcard___."field_z", ___coll_wildcard___."nested_list") AS ROW(field_y VARCHAR, field_z VARCHAR, nested_list ARRAY<INTEGER>))) AS "a", "t"."foo" AS "foo" FROM "default"."EXCLUDE_T_NESTED_LIST" AS "t";
+SELECT transform("t"."a", ___coll_wildcard___ -> CAST(ROW(___coll_wildcard___."field_y", ___coll_wildcard___."field_z", ___coll_wildcard___."nested_list") AS ROW("field_y" VARCHAR, "field_z" VARCHAR, "nested_list" ARRAY<INTEGER>))) AS "a", "t"."foo" AS "foo" FROM "default"."EXCLUDE_T_NESTED_LIST" AS "t";
 
 --#[exclude-51]
-SELECT transform("t"."a", ___coll_wildcard___ -> CAST(ROW(___coll_wildcard___."field_x", ___coll_wildcard___."field_z", ___coll_wildcard___."nested_list") AS ROW(field_x INTEGER, field_z VARCHAR, nested_list ARRAY<INTEGER>))) AS "a", "t"."foo" AS "foo" FROM "default"."EXCLUDE_T_NESTED_LIST" AS "t";
+SELECT transform("t"."a", ___coll_wildcard___ -> CAST(ROW(___coll_wildcard___."field_x", ___coll_wildcard___."field_z", ___coll_wildcard___."nested_list") AS ROW("field_x" INTEGER, "field_z" VARCHAR, "nested_list" ARRAY<INTEGER>))) AS "a", "t"."foo" AS "foo" FROM "default"."EXCLUDE_T_NESTED_LIST" AS "t";
 
 --#[exclude-52]
-SELECT transform("t"."a", ___coll_wildcard___ -> CAST(ROW(___coll_wildcard___."field_x", ___coll_wildcard___."field_y", ___coll_wildcard___."nested_list") AS ROW(field_x INTEGER, field_y VARCHAR, nested_list ARRAY<INTEGER>))) AS "a", "t"."foo" AS "foo" FROM "default"."EXCLUDE_T_NESTED_LIST" AS "t";
+SELECT transform("t"."a", ___coll_wildcard___ -> CAST(ROW(___coll_wildcard___."field_x", ___coll_wildcard___."field_y", ___coll_wildcard___."nested_list") AS ROW("field_x" INTEGER, "field_y" VARCHAR, "nested_list" ARRAY<INTEGER>))) AS "a", "t"."foo" AS "foo" FROM "default"."EXCLUDE_T_NESTED_LIST" AS "t";
 
 --#[exclude-53]
-SELECT transform("t"."a", ___coll_wildcard___ -> CAST(ROW(___coll_wildcard___."field_x", ___coll_wildcard___."field_y", ___coll_wildcard___."field_z") AS ROW(field_x INTEGER, field_y VARCHAR, field_z VARCHAR))) AS "a", "t"."foo" AS "foo" FROM "default"."EXCLUDE_T_NESTED_LIST" AS "t";
+SELECT transform("t"."a", ___coll_wildcard___ -> CAST(ROW(___coll_wildcard___."field_x", ___coll_wildcard___."field_y", ___coll_wildcard___."field_z") AS ROW("field_x" INTEGER, "field_y" VARCHAR, "field_z" VARCHAR))) AS "a", "t"."foo" AS "foo" FROM "default"."EXCLUDE_T_NESTED_LIST" AS "t";
+
+--#[exclude-54]
+SELECT CAST(ROW(CAST(ROW("t"."flds"."select"."field_y") AS ROW("field_y" VARCHAR)), "t"."flds"."order") AS ROW("select" ROW("field_y" VARCHAR), "order" ROW("field_x" INTEGER, "field_y" VARCHAR))) AS "flds", "t"."foo" AS "foo" FROM "default"."EXCLUDE_T_RESERVED_KEYWORDS" AS "t";


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Qualifies the field name in `CAST(ROW(...) AS ROW(<field name> <field type>))` expressions. This will allow for reconstructing `ROW`s that use a reserved keyword as a field name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
