### PR TITLE
Redshift add explicit casts for datetime paths and varrefs

### DIFF
--- a/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftRexConverter.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftRexConverter.kt
@@ -1,0 +1,80 @@
+package org.partiql.scribe.targets.redshift
+
+import org.partiql.ast.Expr
+import org.partiql.ast.exprCase
+import org.partiql.ast.exprCaseBranch
+import org.partiql.ast.exprCast
+import org.partiql.ast.exprNullIf
+import org.partiql.ast.typeDate
+import org.partiql.ast.typeTime
+import org.partiql.ast.typeTimestamp
+import org.partiql.plan.Rex
+import org.partiql.scribe.asNonAbsent
+import org.partiql.scribe.sql.Locals
+import org.partiql.scribe.sql.RexConverter
+import org.partiql.scribe.sql.SqlArg
+import org.partiql.scribe.sql.SqlTransform
+import org.partiql.types.StaticType
+
+/**
+ * Redshift-specific [Rex] plan node to [Expr] ast node converter.
+ *
+ * Major differences include
+ * - wrapping [Rex.Op.Call]s, [Rex.Op.Nullif], and [Rex.Op.Case] using datetime paths and variable references with
+ * explicit casts
+ */
+public open class RedshiftRexConverter(
+    private val transform: SqlTransform,
+    private val locals: Locals
+): RexConverter(transform, locals) {
+    override fun visitRexOpCall(node: Rex.Op.Call, ctx: StaticType): Expr {
+        val (name, args) = when (node) {
+            is Rex.Op.Call.Static -> {
+                val name = node.fn.signature.name
+                val args = node.args.map { SqlArg(wrapInDatetimeCast(it), it.type) }
+                name to args
+            }
+            is Rex.Op.Call.Dynamic -> {
+                val name = node.candidates.first().fn.signature.name
+                val args = node.args.map { SqlArg(wrapInDatetimeCast(it), it.type) }
+                name to args
+            }
+        }
+        return transform.getFunction(name, args)
+    }
+
+    override fun visitRexOpNullif(node: Rex.Op.Nullif, ctx: StaticType): Expr {
+        val v1 = wrapInDatetimeCast(node.value)
+        val v2 = wrapInDatetimeCast(node.nullifier)
+        return exprNullIf(v1, v2)
+    }
+
+    override fun visitRexOpCase(node: Rex.Op.Case, ctx: StaticType): Expr {
+        val default = wrapInDatetimeCast(node.default)
+        val branches = node.branches.map {
+            val condition = wrapInDatetimeCast(it.condition)
+            val result = wrapInDatetimeCast(it.rex)
+            exprCaseBranch(condition, result)
+        }
+        return when (branches.isEmpty()) {
+            true -> default
+            false -> exprCase(expr = null, branches = branches, default = default)
+        }
+    }
+
+    private fun wrapInDatetimeCast(rex: Rex): Expr {
+        val op = rex.op
+        val expr = visitRex(rex, StaticType.ANY)
+        val type = rex.type.asNonAbsent()
+        return if (op is Rex.Op.Path || op is Rex.Op.Var) {
+            return when (type) {
+                StaticType.DATE -> exprCast(expr, typeDate())
+                StaticType.TIME -> exprCast(expr, typeTime(null))
+                StaticType.TIMESTAMP -> exprCast(expr, typeTimestamp(null))
+                else -> expr
+            }
+        } else {
+            expr
+        }
+    }
+}

--- a/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftSqlTransform.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftSqlTransform.kt
@@ -1,0 +1,16 @@
+package org.partiql.scribe.targets.redshift
+
+import org.partiql.plan.Catalog
+import org.partiql.scribe.ProblemCallback
+import org.partiql.scribe.sql.Locals
+import org.partiql.scribe.sql.RexConverter
+import org.partiql.scribe.sql.SqlCalls
+import org.partiql.scribe.sql.SqlTransform
+
+public open class RedshiftSqlTransform(
+    catalogs: List<Catalog>,
+    calls: SqlCalls,
+    onProblem: ProblemCallback
+): SqlTransform(catalogs, calls, onProblem) {
+    override fun getRexConverter(locals: Locals): RexConverter = RedshiftRexConverter(this, locals)
+}

--- a/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftTarget.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftTarget.kt
@@ -1,11 +1,13 @@
 package org.partiql.scribe.targets.redshift
 
+import org.partiql.ast.AstNode
 import org.partiql.plan.PartiQLPlan
 import org.partiql.scribe.ProblemCallback
 import org.partiql.scribe.sql.SqlCalls
 import org.partiql.scribe.sql.SqlDialect
 import org.partiql.scribe.sql.SqlFeatures
 import org.partiql.scribe.sql.SqlTarget
+import org.partiql.scribe.sql.SqlTransform
 
 /**
  * Experimental Redshift SQL target.
@@ -39,4 +41,10 @@ public open class RedshiftTarget : SqlTarget() {
      */
     override fun rewrite(plan: PartiQLPlan, onProblem: ProblemCallback) =
         RedshiftRewriter(onProblem).visitPartiQLPlan(plan, null) as PartiQLPlan
+
+    override fun unplan(plan: PartiQLPlan, onProblem: ProblemCallback): AstNode {
+        val transform = RedshiftSqlTransform(plan.catalogs, getCalls(onProblem), onProblem)
+        val statement = transform.apply(plan.statement)
+        return statement
+    }
 }

--- a/src/test/resources/inputs/builtins/datetime.sql
+++ b/src/test/resources/inputs/builtins/datetime.sql
@@ -70,3 +70,60 @@ SELECT DATE_DIFF(SECOND, TIMESTAMP '2017-01-02T03:04:05.006', TIMESTAMP '2017-01
 -- Check UTCNOW()
 --#[datetime-23]
 SELECT UTCNOW() FROM T;
+
+-- Explicit casts for comparison/equality with a datetime path
+--#[datetime-24]
+SELECT * FROM datatypes.T_TIMESTAMP AS t WHERE t.foo.keep > TIMESTAMP '2023-10-19 12:34:56';
+
+--#[datetime-25]
+SELECT * FROM datatypes.T_DATE AS t WHERE DATE '2023-10-19' < t.foo.keep;
+
+--#[datetime-26]
+SELECT * FROM datatypes.T_TIME AS t WHERE t.foo.keep <= TIME '12:34:56';
+
+--#[datetime-27]
+SELECT * FROM datatypes.T_TIMESTAMP AS t WHERE t.foo.keep = TIMESTAMP '2023-10-19 12:34:56';
+
+--#[datetime-28]
+SELECT * FROM datatypes.T_TIMESTAMP AS t WHERE t.foo.keep <> TIMESTAMP '2023-10-19 12:34:56';
+
+-- Explicit casts for EXTRACT with a datetime path
+--#[datetime-29]
+SELECT EXTRACT(YEAR FROM t.foo.keep) FROM datatypes.T_TIMESTAMP AS t;
+
+--#[datetime-30]
+SELECT EXTRACT(YEAR FROM t.foo.keep) FROM datatypes.T_DATE AS t;
+
+--#[datetime-31]
+SELECT EXTRACT(HOUR FROM t.foo.keep) FROM datatypes.T_TIME AS t;
+
+-- Explicit casts for BETWEEN with a datetime path
+--#[datetime-32]
+SELECT * FROM datatypes.T_TIMESTAMP AS t WHERE t.foo.keep BETWEEN TIMESTAMP '2023-10-19 12:34:56' AND TIMESTAMP '2024-10-19 12:34:56';
+
+--#[datetime-33]
+SELECT * FROM datatypes.T_TIMESTAMP AS t WHERE TIMESTAMP '2023-10-19 12:34:56' BETWEEN t.foo.keep AND TIMESTAMP '2024-10-19 12:34:56';
+
+--#[datetime-34]
+SELECT * FROM datatypes.T_TIMESTAMP AS t WHERE TIMESTAMP '2023-12-19 12:34:56' BETWEEN TIMESTAMP '2023-10-19 12:34:56' AND t.foo.keep;
+
+-- Explicit casts for NULLIF with a datetime path
+--#[datetime-35]
+SELECT NULLIF(t.foo.keep, TIMESTAMP '2023-12-19 12:34:56') FROM datatypes.T_TIMESTAMP AS t;
+
+--#[datetime-36]
+SELECT NULLIF(TIMESTAMP '2023-12-19 12:34:56', t.foo.keep) FROM datatypes.T_TIMESTAMP AS t;
+
+-- Explicit casts for CASE-WHEN with a datetime path
+--#[datetime-37]
+SELECT CASE t.foo.keep WHEN TIMESTAMP '2023-12-19 12:34:56' THEN t.foo.keep ELSE UTCNOW() END AS result FROM datatypes.T_TIMESTAMP AS t;
+
+--#[datetime-38]
+SELECT CASE t.foo.keep WHEN TIMESTAMP '2023-12-19 12:34:56' THEN TIMESTAMP '2023-12-19 12:34:56' ELSE t.foo.keep END AS result FROM datatypes.T_TIMESTAMP AS t;
+
+--#[datetime-39]
+SELECT CASE WHEN TIMESTAMP '2023-12-19 12:34:56' = t.foo.keep THEN TIMESTAMP '2023-12-19 12:34:56' ELSE t.foo.keep END AS result FROM datatypes.T_TIMESTAMP AS t;
+
+-- Explicit cast for top-level timestamp in comparison
+--#[datetime-40]
+SELECT timestamp_2, timestamp_1 < timestamp_2 AS result FROM T WHERE timestamp_1 > TIMESTAMP '2023-12-19 12:34:56';

--- a/src/test/resources/outputs/redshift/builtins/datetime.sql
+++ b/src/test/resources/outputs/redshift/builtins/datetime.sql
@@ -22,25 +22,83 @@ SELECT DATEADD(MONTH, 5, CURRENT_DATE) AS "_1" FROM "default"."T" AS "T";
 SELECT DATEADD(YEAR, 5, CURRENT_DATE) AS "_1" FROM "default"."T" AS "T";
 
 --#[datetime-15]
-SELECT DATEDIFF(YEAR, "T"."timestamp_1", "T"."timestamp_2") AS "_1" FROM "default"."T" AS "T";
+SELECT DATEDIFF(YEAR, CAST("T"."timestamp_1" AS TIMESTAMP), CAST("T"."timestamp_2" AS TIMESTAMP)) AS "_1" FROM "default"."T" AS "T"
 
 --#[datetime-16]
-SELECT DATEDIFF(MONTH, "T"."timestamp_1", "T"."timestamp_2") AS "_1" FROM "default"."T" AS "T";
+SELECT DATEDIFF(MONTH, CAST("T"."timestamp_1" AS TIMESTAMP), CAST("T"."timestamp_2" AS TIMESTAMP)) AS "_1" FROM "default"."T" AS "T"
 
 --#[datetime-17]
-SELECT DATEDIFF(DAY, "T"."timestamp_1", "T"."timestamp_2") AS "_1" FROM "default"."T" AS "T";
+SELECT DATEDIFF(DAY, CAST("T"."timestamp_1" AS TIMESTAMP), CAST("T"."timestamp_2" AS TIMESTAMP)) AS "_1" FROM "default"."T" AS "T"
 
 --#[datetime-18]
-SELECT DATEDIFF(HOUR, "T"."timestamp_1", "T"."timestamp_2") AS "_1" FROM "default"."T" AS "T";
+SELECT DATEDIFF(HOUR, CAST("T"."timestamp_1" AS TIMESTAMP), CAST("T"."timestamp_2" AS TIMESTAMP)) AS "_1" FROM "default"."T" AS "T"
 
 --#[datetime-19]
-SELECT DATEDIFF(MINUTE, "T"."timestamp_1", "T"."timestamp_2") AS "_1" FROM "default"."T" AS "T";
+SELECT DATEDIFF(MINUTE, CAST("T"."timestamp_1" AS TIMESTAMP), CAST("T"."timestamp_2" AS TIMESTAMP)) AS "_1" FROM "default"."T" AS "T"
 
 --#[datetime-20]
-SELECT DATEDIFF(SECOND, "T"."timestamp_1", "T"."timestamp_2") AS "_1" FROM "default"."T" AS "T";
+SELECT DATEDIFF(SECOND, CAST("T"."timestamp_1" AS TIMESTAMP), CAST("T"."timestamp_2" AS TIMESTAMP)) AS "_1" FROM "default"."T" AS "T"
 
 --#[datetime-21]
 SELECT DATEADD(SECOND, 1, TIMESTAMP '2017-01-02 03:04:05.006') AS "_1" FROM "default"."T" AS "T";
 
 --#[datetime-22]
 SELECT DATEDIFF(SECOND, TIMESTAMP '2017-01-02 03:04:05.006', TIMESTAMP '2017-01-02 03:04:20.006') AS "_1" FROM "default"."T" AS "T";
+
+-- Explicit casts for comparison/equality with a datetime path
+--#[datetime-24]
+SELECT "t"."foo" FROM "default"."datatypes"."T_TIMESTAMP" AS "t" WHERE CAST("t"."foo"."keep" AS TIMESTAMP) > TIMESTAMP '2023-10-19 12:34:56';
+
+--#[datetime-25]
+SELECT "t"."foo" FROM "default"."datatypes"."T_DATE" AS "t" WHERE DATE '2023-10-19' < CAST("t"."foo"."keep" AS DATE);
+
+--#[datetime-26]
+SELECT "t"."foo" FROM "default"."datatypes"."T_TIME" AS "t" WHERE CAST("t"."foo"."keep" AS TIME) <= TIME '12:34:56';
+
+--#[datetime-27]
+SELECT "t"."foo" FROM "default"."datatypes"."T_TIMESTAMP" AS "t" WHERE CAST("t"."foo"."keep" AS TIMESTAMP) = TIMESTAMP '2023-10-19 12:34:56';
+
+--#[datetime-28]
+SELECT "t"."foo" FROM "default"."datatypes"."T_TIMESTAMP" AS "t" WHERE CAST("t"."foo"."keep" AS TIMESTAMP) <> TIMESTAMP '2023-10-19 12:34:56';
+
+-- Explicit casts for EXTRACT with a datetime path
+-- TODO EXTRACT not yet supported in AST->PLAN conversion in v0.14.9
+-- --#[datetime-29]
+-- SELECT EXTRACT(YEAR FROM t.foo.keep) FROM datatypes.T_TIMESTAMP AS t;
+--
+-- --#[datetime-30]
+-- SELECT EXTRACT(YEAR FROM t.foo.keep) FROM datatypes.T_DATE AS t;
+--
+-- --#[datetime-31]
+-- SELECT EXTRACT(HOUR FROM t.foo.keep) FROM datatypes.T_TIME AS t;
+
+-- Explicit casts for BETWEEN with a datetime path
+--#[datetime-32]
+SELECT "t"."foo" FROM "default"."datatypes"."T_TIMESTAMP" AS "t" WHERE CAST("t"."foo"."keep" AS TIMESTAMP) BETWEEN TIMESTAMP '2023-10-19 12:34:56' AND TIMESTAMP '2024-10-19 12:34:56';
+
+--#[datetime-33]
+SELECT "t"."foo" FROM "default"."datatypes"."T_TIMESTAMP" AS "t" WHERE TIMESTAMP '2023-10-19 12:34:56' BETWEEN CAST("t"."foo"."keep" AS TIMESTAMP) AND TIMESTAMP '2024-10-19 12:34:56';
+
+--#[datetime-34]
+SELECT "t"."foo" FROM "default"."datatypes"."T_TIMESTAMP" AS "t" WHERE TIMESTAMP '2023-12-19 12:34:56' BETWEEN TIMESTAMP '2023-10-19 12:34:56' AND CAST("t"."foo"."keep" AS TIMESTAMP);
+
+-- Explicit casts for NULLIF with a datetime path
+--#[datetime-35]
+SELECT NULLIF(CAST("t"."foo"."keep" AS TIMESTAMP), TIMESTAMP '2023-12-19 12:34:56') AS "_1" FROM "default"."datatypes"."T_TIMESTAMP" AS "t";
+
+--#[datetime-36]
+SELECT NULLIF(TIMESTAMP '2023-12-19 12:34:56', CAST("t"."foo"."keep" AS TIMESTAMP)) AS "_1" FROM "default"."datatypes"."T_TIMESTAMP" AS "t";
+
+-- Explicit casts for CASE-WHEN with a datetime path
+--#[datetime-37]
+SELECT CASE WHEN CAST("t"."foo"."keep" AS TIMESTAMP) = TIMESTAMP '2023-12-19 12:34:56' THEN CAST("t"."foo"."keep" AS TIMESTAMP) ELSE sysdate END AS "result" FROM "default"."datatypes"."T_TIMESTAMP" AS "t";
+
+--#[datetime-38]
+SELECT CASE WHEN CAST("t"."foo"."keep" AS TIMESTAMP) = TIMESTAMP '2023-12-19 12:34:56' THEN TIMESTAMP '2023-12-19 12:34:56' ELSE CAST("t"."foo"."keep" AS TIMESTAMP) END AS "result" FROM "default"."datatypes"."T_TIMESTAMP" AS "t";
+
+--#[datetime-39]
+SELECT CASE WHEN TIMESTAMP '2023-12-19 12:34:56' = CAST("t"."foo"."keep" AS TIMESTAMP) THEN TIMESTAMP '2023-12-19 12:34:56' ELSE CAST("t"."foo"."keep" AS TIMESTAMP) END AS "result" FROM "default"."datatypes"."T_TIMESTAMP" AS "t";
+
+-- Explicit cast for top-level timestamp in comparison
+--#[datetime-40]
+SELECT "T"."timestamp_2", CAST("T"."timestamp_1" AS TIMESTAMP) < CAST("T"."timestamp_2" AS TIMESTAMP) AS "result" FROM "default"."T" AS "T" WHERE CAST("T"."timestamp_1" AS TIMESTAMP) > TIMESTAMP '2023-12-19 12:34:56';


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Redshift add explicit casts for datetime paths and varrefs used in certain exprs (function calls, nullif, case when).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
