### PR TITLE
build: set up PLK git submodule

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,6 +22,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: recursive
     - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
@@ -55,6 +57,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: recursive
     - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "partiql-lang-kotlin"]
+	path = partiql-lang-kotlin
+	url = https://github.com/partiql/partiql-lang-kotlin.git

--- a/README.adoc
+++ b/README.adoc
@@ -4,23 +4,15 @@
 Scribe is a compiler framework for the PartiQL SQL dialect.
 It is considered experimental and is under active development.
 
-=== Upgrading PartiQL
+=== Local Build
 
-Scribe will depend on a PartiQL major-version, but for now we shadow partiql-lang-kotlin to a single dependency.
+This project uses a https://git-scm.com/book/en/v2/Git-Tools-Submodules[git-submodule] to pull in
+https://github.com/partiql/partiql-lang-kotlin[partiql-lang-kotlin]. The easiest way to pull everything in is to clone the
+repository recursively:
 
 [source,shell]
 ----
-# From partiql-lang-kotlin produce a JAR
-
-./gradlew :partiql-lang:shadowJar
-
-cp ./partiql-lang/build/libs/partiql-lang-kotlin-version.jar ./path/to/Scribe/libs
-
-# Also copy the local plugin (we should consider bundling with SPI)
-
-./gradlew :plugins:partiql-local:installDist
-
-cp ./plugins/partiql-local/build/libs/partiql-local-version.jar ./path/to/Scribe/libs
+git clone --recursive https://github.com/partiql/partiql-scribe.git
 ----
 
 == Terms

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ object Versions {
 
     // Deps
     const val JUNIT_5 = "5.9.3"
-    const val PARTIQL = "1.2.1"
+    const val PARTIQL = "1.2.2-SNAPSHOT"
 }
 
 object Deps {
@@ -40,7 +40,7 @@ repositories {
 }
 
 dependencies {
-    api(Deps.PARTIQL)
+    implementation(Deps.PARTIQL)
     // Test
     testImplementation(Deps.KOTLIN_TEST)
     testImplementation(Deps.KOTLIN_TEST_JUNIT)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,3 @@
 rootProject.name = "Scribe"
+
+includeBuild("partiql-lang-kotlin")


### PR DESCRIPTION
*Issue #, if available:*
None.

*Description of changes:*
Initializes a Git submodule of partiql-lang-kotlin to make it easier to test local changes of partiql-lang-kotlin in Scribe without needing to do a full Maven release. This is done using a gradle feature called [composite builds](https://docs.gradle.org/current/userguide/composite_builds.html).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
