### PR TITLE
[wip] feat: INTERVAL data type support for Trino

### DIFF
--- a/api/Scribe.api
+++ b/api/Scribe.api
@@ -531,12 +531,20 @@ public class org/partiql/scribe/targets/trino/TrinoAstToSql : org/partiql/scribe
 	public fun visitExprBag (Lorg/partiql/ast/expr/ExprBag;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExprCall (Lorg/partiql/ast/expr/ExprCall;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprCall (Lorg/partiql/ast/expr/ExprCall;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
+	public synthetic fun visitExprCast (Lorg/partiql/ast/expr/ExprCast;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitExprCast (Lorg/partiql/ast/expr/ExprCast;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExprLit (Lorg/partiql/ast/expr/ExprLit;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprLit (Lorg/partiql/ast/expr/ExprLit;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExprQuerySet (Lorg/partiql/ast/expr/ExprQuerySet;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprQuerySet (Lorg/partiql/ast/expr/ExprQuerySet;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExprSessionAttribute (Lorg/partiql/ast/expr/ExprSessionAttribute;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprSessionAttribute (Lorg/partiql/ast/expr/ExprSessionAttribute;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
+	public synthetic fun visitIntervalQualifier (Lorg/partiql/ast/IntervalQualifier;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitIntervalQualifier (Lorg/partiql/ast/IntervalQualifier;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
+	public synthetic fun visitIntervalQualifierRange (Lorg/partiql/ast/IntervalQualifier$Range;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitIntervalQualifierRange (Lorg/partiql/ast/IntervalQualifier$Range;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
+	public synthetic fun visitIntervalQualifierSingle (Lorg/partiql/ast/IntervalQualifier$Single;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitIntervalQualifierSingle (Lorg/partiql/ast/IntervalQualifier$Single;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitPathStepElement (Lorg/partiql/ast/expr/PathStep$Element;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitPathStepElement (Lorg/partiql/ast/expr/PathStep$Element;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 }

--- a/src/test/resources/outputs/trino/basics/interval.sql
+++ b/src/test/resources/outputs/trino/basics/interval.sql
@@ -1,0 +1,199 @@
+-- INTERVAL <interval string> <single datetime field>
+--#[interval-00]
+SELECT INTERVAL '10' YEAR AS "i" FROM "default"."T" AS "T";
+
+--#[interval-01]
+SELECT INTERVAL '-10' YEAR AS "i" FROM "default"."T" AS "T";
+
+--#[interval-02]
+SELECT INTERVAL '10' YEAR AS "i" FROM "default"."T" AS "T";
+
+--#[interval-03]
+SELECT INTERVAL '-10' YEAR AS "i" FROM "default"."T" AS "T";
+
+--#[interval-04]
+SELECT INTERVAL '10' MONTH AS "i" FROM "default"."T" AS "T";
+
+--#[interval-05]
+SELECT INTERVAL '-10' MONTH AS "i" FROM "default"."T" AS "T";
+
+--#[interval-06]
+SELECT INTERVAL '10' MONTH AS "i" FROM "default"."T" AS "T";
+
+--#[interval-07]
+SELECT INTERVAL '-10' MONTH AS "i" FROM "default"."T" AS "T";
+
+--#[interval-08]
+SELECT INTERVAL '10' DAY AS "i" FROM "default"."T" AS "T";
+
+--#[interval-09]
+SELECT INTERVAL '-10' DAY AS "i" FROM "default"."T" AS "T";
+
+--#[interval-10]
+SELECT INTERVAL '10' DAY AS "i" FROM "default"."T" AS "T";
+
+--#[interval-11]
+SELECT INTERVAL '-10' DAY AS "i" FROM "default"."T" AS "T";
+
+--#[interval-12]
+SELECT INTERVAL '10' HOUR AS "i" FROM "default"."T" AS "T";
+
+--#[interval-13]
+SELECT INTERVAL '-10' HOUR AS "i" FROM "default"."T" AS "T";
+
+--#[interval-14]
+SELECT INTERVAL '10' HOUR AS "i" FROM "default"."T" AS "T";
+
+--#[interval-15]
+SELECT INTERVAL '-10' HOUR AS "i" FROM "default"."T" AS "T";
+
+--#[interval-16]
+SELECT INTERVAL '10' MINUTE AS "i" FROM "default"."T" AS "T";
+
+--#[interval-17]
+SELECT INTERVAL '-10' MINUTE AS "i" FROM "default"."T" AS "T";
+
+--#[interval-18]
+SELECT INTERVAL '10' MINUTE AS "i" FROM "default"."T" AS "T";
+
+--#[interval-19]
+SELECT INTERVAL '-10' MINUTE AS "i" FROM "default"."T" AS "T";
+
+--#[interval-20]
+SELECT INTERVAL '10' SECOND AS "i" FROM "default"."T" AS "T";
+
+--#[interval-21]
+SELECT INTERVAL '-10' SECOND AS "i" FROM "default"."T" AS "T";
+
+--#[interval-22]
+SELECT INTERVAL '10' SECOND AS "i" FROM "default"."T" AS "T";
+
+--#[interval-23]
+SELECT INTERVAL '-10' SECOND AS "i" FROM "default"."T" AS "T";
+
+--#[interval-24]
+SELECT INTERVAL '10.234' SECOND AS "i" FROM "default"."T" AS "T";
+
+--#[interval-25]
+SELECT INTERVAL '-10.234' SECOND AS "i" FROM "default"."T" AS "T";
+
+-- <start field> TO <end field>
+--#[interval-26]
+SELECT INTERVAL '10-3' YEAR TO MONTH AS "i" FROM "default"."T" AS "T";
+
+--#[interval-27]
+SELECT INTERVAL '-10-3' YEAR TO MONTH AS "i" FROM "default"."T" AS "T";
+
+--#[interval-28]
+SELECT INTERVAL '10-3' YEAR TO MONTH AS "i" FROM "default"."T" AS "T";
+
+--#[interval-29]
+SELECT INTERVAL '-10-3' YEAR TO MONTH AS "i" FROM "default"."T" AS "T";
+
+--#[interval-30]
+SELECT INTERVAL '10 3' DAY TO HOUR AS "i" FROM "default"."T" AS "T";
+
+--#[interval-31]
+SELECT INTERVAL '-10 3' DAY TO HOUR AS "i" FROM "default"."T" AS "T";
+
+--#[interval-32]
+SELECT INTERVAL '10 3' DAY TO HOUR AS "i" FROM "default"."T" AS "T";
+
+--#[interval-33]
+SELECT INTERVAL '-10 3' DAY TO HOUR AS "i" FROM "default"."T" AS "T";
+
+--#[interval-34]
+SELECT INTERVAL '10 3:4' DAY TO MINUTE AS "i" FROM "default"."T" AS "T";
+
+--#[interval-35]
+SELECT INTERVAL '-10 3:4' DAY TO MINUTE AS "i" FROM "default"."T" AS "T";
+
+--#[interval-36]
+SELECT INTERVAL '10 3:4' DAY TO MINUTE AS "i" FROM "default"."T" AS "T";
+
+--#[interval-37]
+SELECT INTERVAL '-10 3:4' DAY TO MINUTE AS "i" FROM "default"."T" AS "T";
+
+--#[interval-38]
+SELECT INTERVAL '10 3:4:5' DAY TO SECOND AS "i" FROM "default"."T" AS "T";
+
+--#[interval-39]
+SELECT INTERVAL '-10 3:4:5' DAY TO SECOND AS "i" FROM "default"."T" AS "T";
+
+--#[interval-40]
+SELECT INTERVAL '10 3:4:5' DAY TO SECOND AS "i" FROM "default"."T" AS "T";
+
+--#[interval-41]
+SELECT INTERVAL '-10 3:4:5' DAY TO SECOND AS "i" FROM "default"."T" AS "T";
+
+--#[interval-42]
+SELECT INTERVAL '10 3:4:5.678' DAY TO SECOND AS "i" FROM "default"."T" AS "T";
+
+--#[interval-43]
+SELECT INTERVAL '-10 3:4:5.678' DAY TO SECOND AS "i" FROM "default"."T" AS "T";
+
+--#[interval-44]
+SELECT INTERVAL '10 3:4:5.678' DAY TO SECOND AS "i" FROM "default"."T" AS "T";
+
+--#[interval-45]
+SELECT INTERVAL '-10 3:4:5.678' DAY TO SECOND AS "i" FROM "default"."T" AS "T";
+
+--#[interval-46]
+SELECT INTERVAL '3:4' HOUR TO MINUTE AS "i" FROM "default"."T" AS "T";
+
+--#[interval-47]
+SELECT INTERVAL '-3:4' HOUR TO MINUTE AS "i" FROM "default"."T" AS "T";
+
+--#[interval-48]
+SELECT INTERVAL '3:4' HOUR TO MINUTE AS "i" FROM "default"."T" AS "T";
+
+--#[interval-49]
+SELECT INTERVAL '-3:4' HOUR TO MINUTE AS "i" FROM "default"."T" AS "T";
+
+--#[interval-50]
+SELECT INTERVAL '2:3:4' HOUR TO SECOND AS "i" FROM "default"."T" AS "T";
+
+--#[interval-51]
+SELECT INTERVAL '-2:3:4' HOUR TO SECOND AS "i" FROM "default"."T" AS "T";
+
+--#[interval-52]
+SELECT INTERVAL '2:3:4' HOUR TO SECOND AS "i" FROM "default"."T" AS "T";
+
+--#[interval-53]
+SELECT INTERVAL '-2:3:4' HOUR TO SECOND AS "i" FROM "default"."T" AS "T";
+
+--#[interval-54]
+SELECT INTERVAL '2:3:4.567' HOUR TO SECOND AS "i" FROM "default"."T" AS "T";
+
+--#[interval-55]
+SELECT INTERVAL '-2:3:4.567' HOUR TO SECOND AS "i" FROM "default"."T" AS "T";
+
+--#[interval-56]
+SELECT INTERVAL '2:3:4.567' HOUR TO SECOND AS "i" FROM "default"."T" AS "T";
+
+--#[interval-57]
+SELECT INTERVAL '-2:3:4.567' HOUR TO SECOND AS "i" FROM "default"."T" AS "T";
+
+--#[interval-58]
+SELECT INTERVAL '3:4' MINUTE TO SECOND AS "i" FROM "default"."T" AS "T";
+
+--#[interval-59]
+SELECT INTERVAL '-3:4' MINUTE TO SECOND AS "i" FROM "default"."T" AS "T";
+
+--#[interval-60]
+SELECT INTERVAL '3:4' MINUTE TO SECOND AS "i" FROM "default"."T" AS "T";
+
+--#[interval-61]
+SELECT INTERVAL '-3:4' MINUTE TO SECOND AS "i" FROM "default"."T" AS "T";
+
+--#[interval-62]
+SELECT INTERVAL '3:4.567' MINUTE TO SECOND AS "i" FROM "default"."T" AS "T";
+
+--#[interval-63]
+SELECT INTERVAL '-3:4.567' MINUTE TO SECOND AS "i" FROM "default"."T" AS "T";
+
+--#[interval-64]
+SELECT INTERVAL '3:4.567' MINUTE TO SECOND AS "i" FROM "default"."T" AS "T";
+
+--#[interval-65]
+SELECT INTERVAL '-3:4.567' MINUTE TO SECOND AS "i" FROM "default"."T" AS "T";

--- a/src/test/resources/outputs/trino/operators/cast.sql
+++ b/src/test/resources/outputs/trino/operators/cast.sql
@@ -127,3 +127,135 @@ SELECT CAST("T"."timestamp_1" AS TIMESTAMP WITH TIME ZONE) AS "res" FROM "defaul
 
 --#[cast-40]
 SELECT CAST("T"."timestamp_1" AS TIMESTAMP (6) WITH TIME ZONE) AS "res" FROM "default"."T" AS "T";
+
+-- INTERVAL YEAR-MONTH
+-- Trino only supports casting to YEAR-MONTH and DAY-SECOND intervals
+-- --#[cast-41]
+-- SELECT CAST("T"."col_y2mon" AS INTERVAL YEAR) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+-- Trino only supports casting to YEAR-MONTH and DAY-SECOND intervals
+-- --#[cast-42]
+-- SELECT CAST("T"."col_y2mon" AS INTERVAL YEAR (2)) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+-- Trino only supports casting to YEAR-MONTH and DAY-SECOND intervals
+-- --#[cast-43]
+-- SELECT CAST("T"."col_y2mon" AS INTERVAL MONTH) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+-- Trino only supports casting to YEAR-MONTH and DAY-SECOND intervals
+-- --#[cast-44]
+-- SELECT CAST("T"."col_y2mon" AS INTERVAL MONTH (2)) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+--#[cast-45]
+SELECT CAST("T"."col_y2mon" AS INTERVAL YEAR TO MONTH) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+-- Trino does not support precision on datetime fields
+--#[cast-46]
+SELECT CAST("T"."col_y2mon" AS INTERVAL YEAR TO MONTH) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+-- INTERVAL DAY-TIME
+-- Trino only supports casting to YEAR-MONTH and DAY-SECOND intervals
+-- --#[cast-47]
+-- SELECT CAST("T"."col_d2s" AS INTERVAL DAY) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+-- Trino only supports casting to YEAR-MONTH and DAY-SECOND intervals
+-- --#[cast-48]
+-- SELECT CAST("T"."col_d2s" AS INTERVAL DAY (2)) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+-- Trino only supports casting to YEAR-MONTH and DAY-SECOND intervals
+-- --#[cast-49]
+-- SELECT CAST("T"."col_d2s" AS INTERVAL HOUR) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+-- Trino only supports casting to YEAR-MONTH and DAY-SECOND intervals
+-- --#[cast-50]
+-- SELECT CAST("T"."col_d2s" AS INTERVAL HOUR (2)) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+-- Trino only supports casting to YEAR-MONTH and DAY-SECOND intervals
+-- --#[cast-51]
+-- SELECT CAST("T"."col_d2s" AS INTERVAL MINUTE) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+-- Trino only supports casting to YEAR-MONTH and DAY-SECOND intervals
+-- --#[cast-52]
+-- SELECT CAST("T"."col_d2s" AS INTERVAL MINUTE (2)) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+-- Trino only supports casting to YEAR-MONTH and DAY-SECOND intervals
+-- --#[cast-53]
+-- SELECT CAST("T"."col_d2s" AS INTERVAL SECOND) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+-- Trino only supports casting to YEAR-MONTH and DAY-SECOND intervals
+-- --#[cast-54]
+-- SELECT CAST("T"."col_d2s" AS INTERVAL SECOND (2)) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+-- Trino only supports casting to YEAR-MONTH and DAY-SECOND intervals
+-- --#[cast-55]
+-- SELECT CAST("T"."col_d2s" AS INTERVAL SECOND (2, 3)) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+-- Trino only supports casting to YEAR-MONTH and DAY-SECOND intervals
+-- --#[cast-56]
+-- SELECT CAST("T"."col_d2s" AS INTERVAL DAY TO HOUR) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+-- Trino only supports casting to YEAR-MONTH and DAY-SECOND intervals
+-- --#[cast-57]
+-- SELECT CAST("T"."col_d2s" AS INTERVAL DAY (2) TO HOUR) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+-- Trino only supports casting to YEAR-MONTH and DAY-SECOND intervals
+-- --#[cast-58]
+-- SELECT CAST("T"."col_d2s" AS INTERVAL DAY TO MINUTE) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+-- Trino only supports casting to YEAR-MONTH and DAY-SECOND intervals
+-- --#[cast-59]
+-- SELECT CAST("T"."col_d2s" AS INTERVAL DAY (2) TO MINUTE) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+--#[cast-60]
+SELECT CAST("T"."col_d2s" AS INTERVAL DAY TO SECOND) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+-- Trino does not support precision on datetime fields
+--#[cast-61]
+SELECT CAST("T"."col_d2s" AS INTERVAL DAY TO SECOND) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+-- Trino does not support precision on datetime fields
+--#[cast-62]
+SELECT CAST("T"."col_d2s" AS INTERVAL DAY TO SECOND) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+-- Trino does not support precision on datetime fields
+--#[cast-63]
+SELECT CAST("T"."col_d2s" AS INTERVAL DAY TO SECOND) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+-- Trino only supports casting to YEAR-MONTH and DAY-SECOND intervals
+-- --#[cast-64]
+-- SELECT CAST("T"."col_d2s" AS INTERVAL HOUR TO MINUTE) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+-- Trino only supports casting to YEAR-MONTH and DAY-SECOND intervals
+-- --#[cast-65]
+-- SELECT CAST("T"."col_d2s" AS INTERVAL HOUR (2) TO MINUTE) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+-- Trino only supports casting to YEAR-MONTH and DAY-SECOND intervals
+-- --#[cast-66]
+-- SELECT CAST("T"."col_d2s" AS INTERVAL HOUR TO SECOND) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+-- Trino only supports casting to YEAR-MONTH and DAY-SECOND intervals
+-- --#[cast-67]
+-- SELECT CAST("T"."col_d2s" AS INTERVAL HOUR (2) TO SECOND) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+-- Trino only supports casting to YEAR-MONTH and DAY-SECOND intervals
+-- --#[cast-68]
+-- SELECT CAST("T"."col_d2s" AS INTERVAL HOUR TO SECOND (3)) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+-- Trino only supports casting to YEAR-MONTH and DAY-SECOND intervals
+-- --#[cast-69]
+-- SELECT CAST("T"."col_d2s" AS INTERVAL HOUR (2) TO SECOND (3)) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+-- Trino only supports casting to YEAR-MONTH and DAY-SECOND intervals
+-- --#[cast-70]
+-- SELECT CAST("T"."col_d2s" AS INTERVAL MINUTE TO SECOND) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+-- Trino only supports casting to YEAR-MONTH and DAY-SECOND intervals
+-- --#[cast-71]
+-- SELECT CAST("T"."col_d2s" AS INTERVAL MINUTE (2) TO SECOND) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+-- Trino only supports casting to YEAR-MONTH and DAY-SECOND intervals
+-- --#[cast-72]
+-- SELECT CAST("T"."col_d2s" AS INTERVAL MINUTE TO SECOND (3)) AS "res" FROM "default"."T_INTERVALS" AS "T";
+
+-- Trino only supports casting to YEAR-MONTH and DAY-SECOND intervals
+-- --#[cast-73]
+-- SELECT CAST("T"."col_d2s" AS INTERVAL MINUTE (2) TO SECOND (3)) AS "res" FROM "default"."T_INTERVALS" AS "T";


### PR DESCRIPTION
TODO
- Operations tests

*Issue #, if available:*

*Description of changes:*
- Adds `INTERVAL` data type support for Trino dialect, notably
  - `INTERVAL` literals
  - `INTERVAL` casts

There are a few differences I've found w/ Trino:
- Trino does not permit precision on any datetime interval fields
- Trino only permits casting to a YEAR-MONTH interval and DAY-SECOND interval

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
