### PR TITLE
fix: invoke transform's getRelConverter rather than RelConverter

### DIFF
--- a/src/main/kotlin/org/partiql/scribe/sql/RexConverter.kt
+++ b/src/main/kotlin/org/partiql/scribe/sql/RexConverter.kt
@@ -819,7 +819,7 @@ public open class RexConverter(
         ctx: Unit,
     ): Expr {
         val inputRel = rex.input
-        val relConverter = RelConverter(transform, context)
+        val relConverter = transform.getRelConverter()
         return relConverter.apply(inputRel, ctx).toExprQuerySet()
     }
 


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Invoke the current `PlanToAst`'s `getRelConverter` rather than the general `RelConverter` base class. Verified that the other invocations of `RelConverter` and `RexConverter` follow the correct pattern.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
