### PR TITLE
Support struct type in Scribe

### DIFF
--- a/api/Scribe.api
+++ b/api/Scribe.api
@@ -425,6 +425,12 @@ public class org/partiql/scribe/targets/redshift/RedshiftRelConverter : org/part
 
 public class org/partiql/scribe/targets/redshift/RedshiftRewriter : org/partiql/plan/OperatorRewriter {
 	public fun <init> (Lorg/partiql/scribe/ScribeContext;)V
+	public synthetic fun visitPathKey (Lorg/partiql/plan/rex/RexPathKey;Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun visitPathKey (Lorg/partiql/plan/rex/RexPathKey;Ljava/lang/Object;)Lorg/partiql/plan/Operator;
+	public fun visitPathKey (Lorg/partiql/plan/rex/RexPathKey;Lorg/partiql/scribe/ScribeContext;)Lorg/partiql/plan/Operator;
+	public synthetic fun visitPathSymbol (Lorg/partiql/plan/rex/RexPathSymbol;Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun visitPathSymbol (Lorg/partiql/plan/rex/RexPathSymbol;Ljava/lang/Object;)Lorg/partiql/plan/Operator;
+	public fun visitPathSymbol (Lorg/partiql/plan/rex/RexPathSymbol;Lorg/partiql/scribe/ScribeContext;)Lorg/partiql/plan/Operator;
 	public synthetic fun visitProject (Lorg/partiql/plan/rel/RelProject;Ljava/lang/Object;)Ljava/lang/Object;
 	public synthetic fun visitProject (Lorg/partiql/plan/rel/RelProject;Ljava/lang/Object;)Lorg/partiql/plan/Operator;
 	public fun visitProject (Lorg/partiql/plan/rel/RelProject;Lorg/partiql/scribe/ScribeContext;)Lorg/partiql/plan/Operator;

--- a/api/Scribe.api
+++ b/api/Scribe.api
@@ -478,6 +478,8 @@ public class org/partiql/scribe/targets/spark/SparkAstToSql : org/partiql/scribe
 	public fun visitExprQuerySet (Lorg/partiql/ast/expr/ExprQuerySet;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExprStruct (Lorg/partiql/ast/expr/ExprStruct;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprStruct (Lorg/partiql/ast/expr/ExprStruct;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
+	public synthetic fun visitExprStructField (Lorg/partiql/ast/expr/ExprStruct$Field;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitExprStructField (Lorg/partiql/ast/expr/ExprStruct$Field;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExprTrim (Lorg/partiql/ast/expr/ExprTrim;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprTrim (Lorg/partiql/ast/expr/ExprTrim;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitFromExpr (Lorg/partiql/ast/FromExpr;Ljava/lang/Object;)Ljava/lang/Object;
@@ -581,6 +583,8 @@ public class org/partiql/scribe/targets/trino/TrinoAstToSql : org/partiql/scribe
 	public fun visitExprQuerySet (Lorg/partiql/ast/expr/ExprQuerySet;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExprSessionAttribute (Lorg/partiql/ast/expr/ExprSessionAttribute;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprSessionAttribute (Lorg/partiql/ast/expr/ExprSessionAttribute;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
+	public synthetic fun visitExprStruct (Lorg/partiql/ast/expr/ExprStruct;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitExprStruct (Lorg/partiql/ast/expr/ExprStruct;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitIntervalQualifier (Lorg/partiql/ast/IntervalQualifier;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitIntervalQualifier (Lorg/partiql/ast/IntervalQualifier;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitIntervalQualifierRange (Lorg/partiql/ast/IntervalQualifier$Range;Ljava/lang/Object;)Ljava/lang/Object;

--- a/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftRewriter.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftRewriter.kt
@@ -4,14 +4,18 @@ import org.partiql.plan.Operator
 import org.partiql.plan.OperatorRewriter
 import org.partiql.plan.rel.RelExclude
 import org.partiql.plan.rel.RelProject
+import org.partiql.plan.rex.RexPathKey
+import org.partiql.plan.rex.RexPathSymbol
 import org.partiql.plan.rex.RexStruct
 import org.partiql.plan.rex.RexVar
 import org.partiql.scribe.ScribeContext
+import org.partiql.scribe.problems.ScribeProblem
 import org.partiql.scribe.sql.utils.isPathRex
 import org.partiql.scribe.targets.redshift.utils.rewriteToObjectTransform
 import org.partiql.spi.types.PType
 
 public open class RedshiftRewriter(context: ScribeContext) : OperatorRewriter<ScribeContext>() {
+    private val listener = context.getProblemListener()
     override fun visitProject(
         rel: RelProject,
         ctx: ScribeContext?,
@@ -32,6 +36,38 @@ public open class RedshiftRewriter(context: ScribeContext) : OperatorRewriter<Sc
                 rel
             }
         return super.visitProject(newNode, ctx)
+    }
+
+    override fun visitPathKey(
+        rex: RexPathKey,
+        ctx: ScribeContext,
+    ): Operator {
+        val visited = super.visitPathKey(rex, ctx) as RexPathKey
+        if (visited.operand is RexStruct) {
+            listener.reportAndThrow(
+                ScribeProblem.simpleError(
+                    code = ScribeProblem.UNSUPPORTED_OPERATION,
+                    message = "Redshift does not support field access on constructed structs.",
+                ),
+            )
+        }
+        return visited
+    }
+
+    override fun visitPathSymbol(
+        rex: RexPathSymbol,
+        ctx: ScribeContext,
+    ): Operator {
+        val visited = super.visitPathSymbol(rex, ctx) as RexPathSymbol
+        if (visited.operand is RexStruct) {
+            listener.reportAndThrow(
+                ScribeProblem.simpleError(
+                    code = ScribeProblem.UNSUPPORTED_OPERATION,
+                    message = "Redshift does not support field access on constructed structs.",
+                ),
+            )
+        }
+        return visited
     }
 
     override fun visitStruct(

--- a/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftRewriter.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftRewriter.kt
@@ -16,6 +16,7 @@ import org.partiql.spi.types.PType
 
 public open class RedshiftRewriter(context: ScribeContext) : OperatorRewriter<ScribeContext>() {
     private val listener = context.getProblemListener()
+
     override fun visitProject(
         rel: RelProject,
         ctx: ScribeContext?,

--- a/src/main/kotlin/org/partiql/scribe/targets/spark/SparkAstToSql.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/spark/SparkAstToSql.kt
@@ -2,9 +2,7 @@ package org.partiql.scribe.targets.spark
 
 import org.partiql.ast.Ast.exprPathStepField
 import org.partiql.ast.Ast.exprQuerySet
-import org.partiql.ast.Ast.identifierSimple
 import org.partiql.ast.Ast.orderBy
-import org.partiql.ast.Ast.selectItemExpr
 import org.partiql.ast.Ast.sort
 import org.partiql.ast.DataType
 import org.partiql.ast.FromExpr
@@ -145,24 +143,24 @@ public open class SparkAstToSql(context: ScribeContext) : AstToSql(context) {
         return tail concat ".${node.field.sql()}"
     }
 
-    // Spark's equivalent for PartiQL's STRUCT type is struct type. Can use the `STRUCT` function to create Spark
-    // structs: https://spark.apache.org/docs/latest/api/sql/#struct. Names are provided by using an `AS` alias.
+    // Spark's equivalent for PartiQL's STRUCT type is struct type. Can use the `NAMED_STRUCT` function to create Spark
+    // structs: https://spark.apache.org/docs/latest/api/sql/#named_struct.
     override fun visitExprStruct(
         node: ExprStruct,
         tail: SqlBlock,
     ): SqlBlock {
-        val fieldsAsSparkStructs =
-            node.fields.map { field ->
-                selectItemExpr(
-                    expr = field.value,
-                    asAlias =
-                        identifierSimple(
-                            symbol = (field.name as ExprLit).lit.stringValue(),
-                            isRegular = true,
-                        ),
-                )
-            }
-        return tail concat list(this, "STRUCT(", ")") { fieldsAsSparkStructs }
+        return tail concat list(this, "NAMED_STRUCT(", ")") { node.fields }
+    }
+
+    override fun visitExprStructField(
+        node: ExprStruct.Field,
+        tail: SqlBlock,
+    ): SqlBlock {
+        var t = tail
+        t = visitExprWrapped(node.name, t)
+        t = t concat ", "
+        t = visitExprWrapped(node.value, t)
+        return t
     }
 
     override fun visitExprArray(

--- a/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoAstToSql.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoAstToSql.kt
@@ -399,7 +399,7 @@ public open class TrinoAstToSql(context: ScribeContext) : AstToSql(context) {
     ): SqlBlock {
         listener.report(
             ScribeProblem.simpleError(
-                code = ScribeProblem.UNSUPPORTED_AST_TO_TEXT_CONVERSION,
+                code = ScribeProblem.INVALID_PLAN,
                 message = "Error when converting PartiQL struct. `Struct` is rewritten in plan to ROW function and should not reach here.",
             ),
         )

--- a/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoAstToSql.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoAstToSql.kt
@@ -19,6 +19,7 @@ import org.partiql.ast.expr.ExprCast
 import org.partiql.ast.expr.ExprLit
 import org.partiql.ast.expr.ExprQuerySet
 import org.partiql.ast.expr.ExprSessionAttribute
+import org.partiql.ast.expr.ExprStruct
 import org.partiql.ast.expr.PathStep
 import org.partiql.ast.sql.SqlBlock
 import org.partiql.ast.sql.sql
@@ -390,5 +391,16 @@ public open class TrinoAstToSql(context: ScribeContext) : AstToSql(context) {
             }
         // types are modeled as text; as we don't want to reflow
         return SqlBlock.Text(t)
+    }
+
+    override fun visitExprStruct(
+        node: ExprStruct,
+        tail: SqlBlock,
+    ): SqlBlock {
+        listener.report(ScribeProblem.simpleError(
+            code = ScribeProblem.UNSUPPORTED_AST_TO_TEXT_CONVERSION,
+            message = "Error when converting PartiQL struct. `Struct` is rewritten in plan to ROW function and should not reach here.",
+        ))
+        return tail
     }
 }

--- a/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoAstToSql.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoAstToSql.kt
@@ -397,10 +397,12 @@ public open class TrinoAstToSql(context: ScribeContext) : AstToSql(context) {
         node: ExprStruct,
         tail: SqlBlock,
     ): SqlBlock {
-        listener.report(ScribeProblem.simpleError(
-            code = ScribeProblem.UNSUPPORTED_AST_TO_TEXT_CONVERSION,
-            message = "Error when converting PartiQL struct. `Struct` is rewritten in plan to ROW function and should not reach here.",
-        ))
+        listener.report(
+            ScribeProblem.simpleError(
+                code = ScribeProblem.UNSUPPORTED_AST_TO_TEXT_CONVERSION,
+                message = "Error when converting PartiQL struct. `Struct` is rewritten in plan to ROW function and should not reach here.",
+            ),
+        )
         return tail
     }
 }

--- a/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoRewriter.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoRewriter.kt
@@ -53,7 +53,7 @@ public open class TrinoRewriter(internal val context: ScribeContext) : OperatorR
                 val type = field.value.type
                 // Rewrite any structs that have a field that's a ROW type and is a var reference or path.
                 val newOp =
-                    if (fieldValue is RexVar || fieldValue.isPathRex()) {
+                    if (fieldValue is RexVar || fieldValue.isPathRex() || fieldValue is RexStruct) {
                         type.pType.toRexTrino(
                             prefixPath = fieldValue,
                             context = context,

--- a/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoRewriter.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoRewriter.kt
@@ -84,7 +84,16 @@ public open class TrinoRewriter(internal val context: ScribeContext) : OperatorR
         if (rex.key.type.pType.code() != PType.STRING) {
             error("Trino path expression must be a string literal.")
         }
-        return super.visitPathKey(rex, ctx)
+        val visited = super.visitPathKey(rex, ctx) as RexPathKey
+        // Wrap RexStruct operand in CAST(ROW(...) AS ROW(...))
+        val operand = visited.operand
+        if (operand is RexStruct) {
+            val wrapped = operand.type.pType.toRexTrino(prefixPath = operand, context = context)
+            val newPath = RexPathKey.create(wrapped, visited.key)
+            newPath.type = visited.type
+            return newPath
+        }
+        return visited
     }
 
     override fun visitPathSymbol(
@@ -94,7 +103,16 @@ public open class TrinoRewriter(internal val context: ScribeContext) : OperatorR
         if (rex.operand.type.pType.code() != PType.ROW) {
             error("Trino path expression must be on a ROW type (PartiQL STRUCT), found ${rex.operand.type}")
         }
-        return super.visitPathSymbol(rex, ctx)
+        val visited = super.visitPathSymbol(rex, ctx) as RexPathSymbol
+        // Wrap RexStruct operand in CAST(ROW(...) AS ROW(...))
+        val operand = visited.operand
+        if (operand is RexStruct) {
+            val wrapped = operand.type.pType.toRexTrino(prefixPath = operand, context = context)
+            val newPath = RexPathSymbol.create(wrapped, visited.symbol)
+            newPath.type = visited.type
+            return newPath
+        }
+        return visited
     }
 
     /**

--- a/src/main/kotlin/org/partiql/scribe/targets/trino/utils/TrinoExcludeUtils.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/trino/utils/TrinoExcludeUtils.kt
@@ -48,7 +48,7 @@ internal fun PType.toRexTrino(
         return when (type.code()) {
             PType.ROW -> {
                 when (type.fields.size) {
-                    0 -> context.logError("Currently Trino does not allow empty ROWs. Consider `EXCLUDE` on the outer struct")
+                    0 -> context.logError("Currently Trino does not allow empty ROW/struct values.")
                     else -> type.toRexCastRow(prefixPath, context)
                 }
             }

--- a/src/main/kotlin/org/partiql/scribe/targets/trino/utils/TrinoExcludeUtils.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/trino/utils/TrinoExcludeUtils.kt
@@ -5,6 +5,7 @@ import org.partiql.plan.rex.RexArray
 import org.partiql.plan.rex.RexCall
 import org.partiql.plan.rex.RexLit
 import org.partiql.plan.rex.RexPathKey
+import org.partiql.plan.rex.RexStruct
 import org.partiql.scribe.ScribeContext
 import org.partiql.scribe.problems.ScribeProblem
 import org.partiql.scribe.sql.utils.containsExcludedFieldMeta
@@ -43,19 +44,20 @@ internal fun PType.toRexTrino(
     context: ScribeContext,
 ): Rex {
     val type = this
-    if (!type.containsExcludedFieldMeta()) {
-        return prefixPath
-    }
-    return when (type.code()) {
-        PType.ROW -> {
-            when (type.fields.size) {
-                0 -> context.logError("Currently Trino does not allow empty ROWs. Consider `EXCLUDE` on the outer struct")
-                else -> type.toRexCastRow(prefixPath, context)
+    if (this.containsExcludedFieldMeta() || prefixPath is RexStruct) {
+        return when (type.code()) {
+            PType.ROW -> {
+                when (type.fields.size) {
+                    0 -> context.logError("Currently Trino does not allow empty ROWs. Consider `EXCLUDE` on the outer struct")
+                    else -> type.toRexCastRow(prefixPath, context)
+                }
             }
+            PType.ARRAY, PType.BAG -> type.toRexCallTransform(prefixPath, context)
+            else -> prefixPath
         }
-        PType.ARRAY, PType.BAG -> type.toRexCallTransform(prefixPath, context)
-        else -> prefixPath
     }
+
+    return prefixPath
 }
 
 private val cast_row_fn_sig =
@@ -78,7 +80,10 @@ private fun PType.toRexCastRow(
     prefixPath: Rex,
     context: ScribeContext,
 ): RexCall {
-    val rowValues =
+    val rowValues = if (prefixPath is RexStruct) {
+        // For the original Rex is raw RexStruct, we should return fields directly instead of recreation.
+        prefixPath.fields.map { field -> field.value }
+    } else {
         this.fields.map { field ->
             val newPath =
                 RexPathKey.create(
@@ -92,6 +97,7 @@ private fun PType.toRexCastRow(
                 )
             newV
         }
+    }
     val castType = RexLit.create(Datum.string(this.toTrinoString(context)))
     return RexCall.create(
         cast_row_fn_sig,
@@ -267,7 +273,7 @@ private fun PType.toTrinoString(context: ScribeContext): String {
         }
         PType.REAL -> "REAL"
         PType.DOUBLE -> "DOUBLE"
-        PType.UNKNOWN -> "NULL"
+        PType.UNKNOWN -> context.logError("Not able to convert PType $this to Trino")
         PType.ARRAY, PType.BAG -> {
             val head = "ARRAY<"
             val elementType = type.typeParameter.toTrinoString(context)

--- a/src/main/kotlin/org/partiql/scribe/targets/trino/utils/TrinoExcludeUtils.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/trino/utils/TrinoExcludeUtils.kt
@@ -82,7 +82,8 @@ private fun PType.toRexCastRow(
 ): RexCall {
     val rowValues =
         if (prefixPath is RexStruct) {
-            // For the original Rex is raw RexStruct, we should return fields directly instead of recreation.
+            // For the original Rex is raw RexStruct, we should return fields directly.
+            // Nested structs have already been processed by TrinoRewriter.visitStruct.
             prefixPath.fields.map { field -> field.value }
         } else {
             this.fields.map { field ->

--- a/src/main/kotlin/org/partiql/scribe/targets/trino/utils/TrinoExcludeUtils.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/trino/utils/TrinoExcludeUtils.kt
@@ -80,24 +80,25 @@ private fun PType.toRexCastRow(
     prefixPath: Rex,
     context: ScribeContext,
 ): RexCall {
-    val rowValues = if (prefixPath is RexStruct) {
-        // For the original Rex is raw RexStruct, we should return fields directly instead of recreation.
-        prefixPath.fields.map { field -> field.value }
-    } else {
-        this.fields.map { field ->
-            val newPath =
-                RexPathKey.create(
-                    prefixPath,
-                    RexLit.create(Datum.string(field.name)),
-                )
-            val newV =
-                field.type.toRexTrino(
-                    prefixPath = newPath,
-                    context = context,
-                )
-            newV
+    val rowValues =
+        if (prefixPath is RexStruct) {
+            // For the original Rex is raw RexStruct, we should return fields directly instead of recreation.
+            prefixPath.fields.map { field -> field.value }
+        } else {
+            this.fields.map { field ->
+                val newPath =
+                    RexPathKey.create(
+                        prefixPath,
+                        RexLit.create(Datum.string(field.name)),
+                    )
+                val newV =
+                    field.type.toRexTrino(
+                        prefixPath = newPath,
+                        context = context,
+                    )
+                newV
+            }
         }
-    }
     val castType = RexLit.create(Datum.string(this.toTrinoString(context)))
     return RexCall.create(
         cast_row_fn_sig,

--- a/src/test/resources/catalogs/default/T_ALL_TYPES.ion
+++ b/src/test/resources/catalogs/default/T_ALL_TYPES.ion
@@ -88,15 +88,41 @@
         },
       },
       {
-        name: "col_struct",
+        name: "col_struct_simple",
         type: {
           type: "struct",
           constraints: [ closed, ordered, unique ],
           fields: [
+            { name: "level1_col_int", type: "int32" },
+            { name: "level1_col_double", type: "float64" },
+            { name: "level1_col_string", type: "string" },
+            { name: "level1_col_timestamp", type: "timestamp" },
+          ]
+        },
+      },
+      {
+        name: "col_struct_nested",
+        type: {
+          type: "struct",
+          constraints: [ closed, ordered, unique ],
+          fields: [
+            { name: "level1_col_int", type: "int32" },
+            { name: "level1_col_double", type: "float64" },
+            { name: "level1_col_string", type: "string" },
+            { name: "level1_col_timestamp", type: "timestamp" },
             {
-              name: "nested_field",
-              type: "string"
-            }
+              name: "level1_col_struct",
+              type: {
+                type: "struct",
+                constraints: [ closed, ordered, unique ],
+                fields: [
+                  { name: "level2_col_int", type: "int32" },
+                  { name: "level2_col_double", type: "float64" },
+                  { name: "level2_col_string", type: "string" },
+                  { name: "level2_col_timestamp", type: "timestamp" },
+                ]
+              },
+            },
           ]
         },
       },

--- a/src/test/resources/inputs/basics/struct.sql
+++ b/src/test/resources/inputs/basics/struct.sql
@@ -161,3 +161,19 @@ SELECT { 'value': 123, 'optional_field': NULL, 'description': 'test' } AS data F
 --#[struct-29]
 -- Construct struct with arithmetic expressions
 SELECT { 'sum': 10 + 5, 'product': 3 * 7, 'ratio': 100.0 / 4 } AS calculations FROM T_ALL_TYPES AS T;
+
+-- ----------------------------------------
+--  Access field in constructed struct
+-- ----------------------------------------
+
+--#[struct-30]
+-- Access field from a constructed struct
+SELECT { 'a': T.col_int32, 'b': T.col_string }.a AS a_val FROM T_ALL_TYPES AS T;
+
+--#[struct-31]
+-- Access field from a struct constructed from struct fields
+SELECT { 'x': T.col_struct_simple.level1_col_int, 'y': T.col_struct_simple.level1_col_string }.y AS y_val FROM T_ALL_TYPES AS T;
+
+--#[struct-32]
+-- Access nested field from a constructed nested struct
+SELECT { 'outer': { 'inner_val': T.col_struct_nested.level1_col_struct.level2_col_int } }."outer".inner_val AS inner_val FROM T_ALL_TYPES AS T;

--- a/src/test/resources/inputs/basics/struct.sql
+++ b/src/test/resources/inputs/basics/struct.sql
@@ -11,26 +11,18 @@ SELECT T.col_struct_simple FROM T_ALL_TYPES AS T;
 SELECT T.col_struct_nested FROM T_ALL_TYPES AS T;
 
 --#[struct-02]
--- Select both struct columns
-SELECT T.col_struct_simple, T.col_struct_nested FROM T_ALL_TYPES AS T;
-
---#[struct-03]
 -- Select struct alongside scalar columns
-SELECT T.col_int32, T.col_string, T.col_struct_simple FROM T_ALL_TYPES AS T;
+SELECT T.col_int32, T.col_string, T.col_struct_simple, T.col_struct_nested FROM T_ALL_TYPES AS T;
 
 -- ----------------------------------------
 --  Path navigation — simple struct
 -- ----------------------------------------
 
---#[struct-04]
--- Access a field of a simple struct
-SELECT T.col_struct_simple.level1_col_int FROM T_ALL_TYPES AS T;
-
---#[struct-05]
+--#[struct-03]
 -- Access multiple fields of a simple struct
 SELECT T.col_struct_simple.level1_col_int, T.col_struct_simple.level1_col_string FROM T_ALL_TYPES AS T;
 
---#[struct-06]
+--#[struct-04]
 -- Access all fields of a simple struct
 SELECT T.col_struct_simple.level1_col_int, T.col_struct_simple.level1_col_double, T.col_struct_simple.level1_col_string, T.col_struct_simple.level1_col_timestamp FROM T_ALL_TYPES AS T;
 
@@ -38,21 +30,11 @@ SELECT T.col_struct_simple.level1_col_int, T.col_struct_simple.level1_col_double
 --  Path navigation — nested struct
 -- ----------------------------------------
 
--- Single field access on nested struct (e.g. T.col_struct_nested.level1_col_int) covered by struct-04 pattern
-
---#[struct-07]
--- Access the nested struct itself
-SELECT T.col_struct_nested.level1_col_struct FROM T_ALL_TYPES AS T;
-
---#[struct-08]
--- Access a field within the nested struct (2-level path)
-SELECT T.col_struct_nested.level1_col_struct.level2_col_int FROM T_ALL_TYPES AS T;
-
---#[struct-09]
+--#[struct-05]
 -- Access multiple fields within the nested struct
 SELECT T.col_struct_nested.level1_col_struct.level2_col_int, T.col_struct_nested.level1_col_struct.level2_col_string FROM T_ALL_TYPES AS T;
 
---#[struct-10]
+--#[struct-06]
 -- Mix top-level and nested field access
 SELECT T.col_struct_nested.level1_col_int, T.col_struct_nested.level1_col_struct.level2_col_double FROM T_ALL_TYPES AS T;
 
@@ -60,19 +42,19 @@ SELECT T.col_struct_nested.level1_col_int, T.col_struct_nested.level1_col_struct
 --  Struct wildcard (dot-star)
 -- ----------------------------------------
 
---#[struct-11]
+--#[struct-07]
 -- Wildcard on simple struct
 SELECT T.col_struct_simple.* FROM T_ALL_TYPES AS T;
 
---#[struct-12]
+--#[struct-08]
 -- Wildcard on nested struct
 SELECT T.col_struct_nested.* FROM T_ALL_TYPES AS T;
 
---#[struct-13]
+--#[struct-09]
 -- Wildcard on inner nested struct
 SELECT T.col_struct_nested.level1_col_struct.* FROM T_ALL_TYPES AS T;
 
---#[struct-14]
+--#[struct-10]
 -- Wildcard with other columns
 SELECT T.col_int32, T.col_struct_simple.* FROM T_ALL_TYPES AS T;
 
@@ -80,15 +62,15 @@ SELECT T.col_int32, T.col_struct_simple.* FROM T_ALL_TYPES AS T;
 --  Struct construction in SELECT
 -- ----------------------------------------
 
---#[struct-15]
+--#[struct-11]
 -- Construct a struct literal in SELECT
 SELECT { 'a': T.col_int32, 'b': T.col_string } AS constructed FROM T_ALL_TYPES AS T;
 
---#[struct-16]
+--#[struct-12]
 -- Construct a struct from struct fields
 SELECT { 'x': T.col_struct_simple.level1_col_int, 'y': T.col_struct_simple.level1_col_string } AS constructed FROM T_ALL_TYPES AS T;
 
---#[struct-17]
+--#[struct-13]
 -- Construct a nested struct literal
 SELECT { 'outer': { 'inner_val': T.col_struct_nested.level1_col_struct.level2_col_int } } AS constructed FROM T_ALL_TYPES AS T;
 
@@ -96,33 +78,31 @@ SELECT { 'outer': { 'inner_val': T.col_struct_nested.level1_col_struct.level2_co
 --  Filtering on struct fields
 -- ----------------------------------------
 
---#[struct-18]
+--#[struct-14]
 -- WHERE on a simple struct field
-SELECT * FROM T_ALL_TYPES AS T WHERE T.col_struct_simple.level1_col_int > 10;
+SELECT T.col_int32, T.col_string, T.col_struct_simple.level1_col_int, T.col_struct_nested.level1_col_struct.level2_col_string FROM T_ALL_TYPES AS T WHERE T.col_struct_simple.level1_col_int > 10;
 
---#[struct-19]
+--#[struct-15]
 -- WHERE on a nested struct field
-SELECT * FROM T_ALL_TYPES AS T WHERE T.col_struct_nested.level1_col_struct.level2_col_string = 'hello';
+SELECT T.col_int32, T.col_string, T.col_struct_simple.level1_col_int, T.col_struct_nested.level1_col_struct.level2_col_string FROM T_ALL_TYPES AS T WHERE T.col_struct_nested.level1_col_struct.level2_col_string = 'hello';
 
---#[struct-20]
+--#[struct-16]
 -- WHERE with multiple struct field conditions
-SELECT * FROM T_ALL_TYPES AS T WHERE T.col_struct_simple.level1_col_int > 0 AND T.col_struct_nested.level1_col_double < 100.0;
+SELECT T.col_int32, T.col_string, T.col_struct_simple.level1_col_int, T.col_struct_nested.level1_col_struct.level2_col_string FROM T_ALL_TYPES AS T WHERE T.col_struct_simple.level1_col_int > 0 AND T.col_struct_nested.level1_col_double < 100.0;
 
---#[struct-21]
+--#[struct-17]
 -- IS NULL check on struct field
-SELECT * FROM T_ALL_TYPES AS T WHERE T.col_struct_simple.level1_col_string IS NULL;
+SELECT T.col_int32, T.col_string, T.col_struct_simple.level1_col_int, T.col_struct_nested.level1_col_struct.level2_col_string FROM T_ALL_TYPES AS T WHERE T.col_struct_simple.level1_col_string IS NULL;
 
---#[struct-22]
+--#[struct-18]
 -- IS NOT NULL check on nested struct field
-SELECT * FROM T_ALL_TYPES AS T WHERE T.col_struct_nested.level1_col_struct.level2_col_timestamp IS NOT NULL;
+SELECT T.col_int32, T.col_string, T.col_struct_simple.level1_col_int, T.col_struct_nested.level1_col_struct.level2_col_string FROM T_ALL_TYPES AS T WHERE T.col_struct_nested.level1_col_struct.level2_col_timestamp IS NOT NULL;
 
 -- ----------------------------------------
 --  Aliasing struct fields
 -- ----------------------------------------
 
--- Single alias on struct path (e.g. T.col_struct_simple.level1_col_int AS x) covered by struct-04 pattern
-
---#[struct-23]
+--#[struct-19]
 -- Alias multiple struct paths at different nesting levels
 SELECT T.col_struct_simple.level1_col_int AS s_int, T.col_struct_nested.level1_col_struct.level2_col_string AS n_str FROM T_ALL_TYPES AS T;
 
@@ -130,11 +110,11 @@ SELECT T.col_struct_simple.level1_col_int AS s_int, T.col_struct_nested.level1_c
 --  Struct fields in ORDER BY / GROUP BY
 -- ----------------------------------------
 
---#[struct-24]
+--#[struct-20]
 -- ORDER BY a struct field
 SELECT T.col_struct_simple.level1_col_int, T.col_string FROM T_ALL_TYPES AS T ORDER BY T.col_struct_simple.level1_col_int;
 
---#[struct-25]
+--#[struct-21]
 -- GROUP BY a struct field
 SELECT T.col_struct_simple.level1_col_string, COUNT(*) AS cnt FROM T_ALL_TYPES AS T GROUP BY T.col_struct_simple.level1_col_string;
 
@@ -142,11 +122,11 @@ SELECT T.col_struct_simple.level1_col_string, COUNT(*) AS cnt FROM T_ALL_TYPES A
 --  Struct with JOIN
 -- ----------------------------------------
 
---#[struct-26]
+--#[struct-22]
 -- Join on struct fields
 SELECT t1.col_struct_simple.level1_col_int, T2.col_struct_nested.level1_col_string FROM T_ALL_TYPES AS t1 JOIN T_ALL_TYPES AS T2 ON t1.col_struct_simple.level1_col_int = T2.col_struct_nested.level1_col_int;
 
---#[struct-27]
+--#[struct-23]
 -- Left join with nested struct field in condition
 SELECT t1.col_struct_simple, T2.col_struct_nested.level1_col_struct.level2_col_int FROM T_ALL_TYPES AS t1 LEFT JOIN T_ALL_TYPES AS T2 ON t1.col_struct_simple.level1_col_string = T2.col_struct_nested.level1_col_struct.level2_col_string;
 
@@ -154,11 +134,11 @@ SELECT t1.col_struct_simple, T2.col_struct_nested.level1_col_struct.level2_col_i
 --  Struct in subquery
 -- ----------------------------------------
 
---#[struct-28]
+--#[struct-24]
 -- Subquery selecting struct fields
 SELECT T.col_struct_simple.level1_col_int FROM T_ALL_TYPES AS T WHERE T.col_struct_simple.level1_col_int > (SELECT T2.col_struct_nested.level1_col_struct.level2_col_int FROM T_ALL_TYPES AS T2 WHERE T2.col_struct_nested.level1_col_struct.level2_col_int = 1);
 
---#[struct-29]
+--#[struct-25]
 -- Struct field in IN subquery
 SELECT T.col_struct_nested.level1_col_struct.level2_col_int FROM T_ALL_TYPES AS T WHERE T.col_struct_simple.level1_col_int IN (SELECT T2.col_struct_nested.level1_col_struct.level2_col_int FROM T_ALL_TYPES AS T2);
 
@@ -166,18 +146,18 @@ SELECT T.col_struct_nested.level1_col_struct.level2_col_int FROM T_ALL_TYPES AS 
 --  Struct construction with real values
 -- ----------------------------------------
 
---#[struct-30]
+--#[struct-26]
 -- Construct struct with mixed literal types
 SELECT { 'count': 42, 'rate': 3.14, 'message': 'hello', 'enabled': false } AS config FROM T_ALL_TYPES AS T;
 
---#[struct-31]
+--#[struct-27]
 -- Construct nested struct with literal values
 SELECT { 'user': { 'id': 100, 'email': 'test@example.com' }, 'timestamp': '2023-01-01T00:00:00Z' } AS record FROM T_ALL_TYPES AS T;
 
---#[struct-32]
+--#[struct-28]
 -- Construct struct with null values
 SELECT { 'value': 123, 'optional_field': NULL, 'description': 'test' } AS data FROM T_ALL_TYPES AS T;
 
---#[struct-33]
+--#[struct-29]
 -- Construct struct with arithmetic expressions
 SELECT { 'sum': 10 + 5, 'product': 3 * 7, 'ratio': 100.0 / 4 } AS calculations FROM T_ALL_TYPES AS T;

--- a/src/test/resources/inputs/basics/struct.sql
+++ b/src/test/resources/inputs/basics/struct.sql
@@ -1,0 +1,183 @@
+-- ----------------------------------------
+--  Select struct columns
+-- ----------------------------------------
+
+--#[struct-00]
+-- Select a simple struct column
+SELECT T.col_struct_simple FROM T_ALL_TYPES AS T;
+
+--#[struct-01]
+-- Select a nested struct column
+SELECT T.col_struct_nested FROM T_ALL_TYPES AS T;
+
+--#[struct-02]
+-- Select both struct columns
+SELECT T.col_struct_simple, T.col_struct_nested FROM T_ALL_TYPES AS T;
+
+--#[struct-03]
+-- Select struct alongside scalar columns
+SELECT T.col_int32, T.col_string, T.col_struct_simple FROM T_ALL_TYPES AS T;
+
+-- ----------------------------------------
+--  Path navigation — simple struct
+-- ----------------------------------------
+
+--#[struct-04]
+-- Access a field of a simple struct
+SELECT T.col_struct_simple.level1_col_int FROM T_ALL_TYPES AS T;
+
+--#[struct-05]
+-- Access multiple fields of a simple struct
+SELECT T.col_struct_simple.level1_col_int, T.col_struct_simple.level1_col_string FROM T_ALL_TYPES AS T;
+
+--#[struct-06]
+-- Access all fields of a simple struct
+SELECT T.col_struct_simple.level1_col_int, T.col_struct_simple.level1_col_double, T.col_struct_simple.level1_col_string, T.col_struct_simple.level1_col_timestamp FROM T_ALL_TYPES AS T;
+
+-- ----------------------------------------
+--  Path navigation — nested struct
+-- ----------------------------------------
+
+-- Single field access on nested struct (e.g. T.col_struct_nested.level1_col_int) covered by struct-04 pattern
+
+--#[struct-07]
+-- Access the nested struct itself
+SELECT T.col_struct_nested.level1_col_struct FROM T_ALL_TYPES AS T;
+
+--#[struct-08]
+-- Access a field within the nested struct (2-level path)
+SELECT T.col_struct_nested.level1_col_struct.level2_col_int FROM T_ALL_TYPES AS T;
+
+--#[struct-09]
+-- Access multiple fields within the nested struct
+SELECT T.col_struct_nested.level1_col_struct.level2_col_int, T.col_struct_nested.level1_col_struct.level2_col_string FROM T_ALL_TYPES AS T;
+
+--#[struct-10]
+-- Mix top-level and nested field access
+SELECT T.col_struct_nested.level1_col_int, T.col_struct_nested.level1_col_struct.level2_col_double FROM T_ALL_TYPES AS T;
+
+-- ----------------------------------------
+--  Struct wildcard (dot-star)
+-- ----------------------------------------
+
+--#[struct-11]
+-- Wildcard on simple struct
+SELECT T.col_struct_simple.* FROM T_ALL_TYPES AS T;
+
+--#[struct-12]
+-- Wildcard on nested struct
+SELECT T.col_struct_nested.* FROM T_ALL_TYPES AS T;
+
+--#[struct-13]
+-- Wildcard on inner nested struct
+SELECT T.col_struct_nested.level1_col_struct.* FROM T_ALL_TYPES AS T;
+
+--#[struct-14]
+-- Wildcard with other columns
+SELECT T.col_int32, T.col_struct_simple.* FROM T_ALL_TYPES AS T;
+
+-- ----------------------------------------
+--  Struct construction in SELECT
+-- ----------------------------------------
+
+--#[struct-15]
+-- Construct a struct literal in SELECT
+SELECT { 'a': T.col_int32, 'b': T.col_string } AS constructed FROM T_ALL_TYPES AS T;
+
+--#[struct-16]
+-- Construct a struct from struct fields
+SELECT { 'x': T.col_struct_simple.level1_col_int, 'y': T.col_struct_simple.level1_col_string } AS constructed FROM T_ALL_TYPES AS T;
+
+--#[struct-17]
+-- Construct a nested struct literal
+SELECT { 'outer': { 'inner_val': T.col_struct_nested.level1_col_struct.level2_col_int } } AS constructed FROM T_ALL_TYPES AS T;
+
+-- ----------------------------------------
+--  Filtering on struct fields
+-- ----------------------------------------
+
+--#[struct-18]
+-- WHERE on a simple struct field
+SELECT * FROM T_ALL_TYPES AS T WHERE T.col_struct_simple.level1_col_int > 10;
+
+--#[struct-19]
+-- WHERE on a nested struct field
+SELECT * FROM T_ALL_TYPES AS T WHERE T.col_struct_nested.level1_col_struct.level2_col_string = 'hello';
+
+--#[struct-20]
+-- WHERE with multiple struct field conditions
+SELECT * FROM T_ALL_TYPES AS T WHERE T.col_struct_simple.level1_col_int > 0 AND T.col_struct_nested.level1_col_double < 100.0;
+
+--#[struct-21]
+-- IS NULL check on struct field
+SELECT * FROM T_ALL_TYPES AS T WHERE T.col_struct_simple.level1_col_string IS NULL;
+
+--#[struct-22]
+-- IS NOT NULL check on nested struct field
+SELECT * FROM T_ALL_TYPES AS T WHERE T.col_struct_nested.level1_col_struct.level2_col_timestamp IS NOT NULL;
+
+-- ----------------------------------------
+--  Aliasing struct fields
+-- ----------------------------------------
+
+-- Single alias on struct path (e.g. T.col_struct_simple.level1_col_int AS x) covered by struct-04 pattern
+
+--#[struct-23]
+-- Alias multiple struct paths at different nesting levels
+SELECT T.col_struct_simple.level1_col_int AS s_int, T.col_struct_nested.level1_col_struct.level2_col_string AS n_str FROM T_ALL_TYPES AS T;
+
+-- ----------------------------------------
+--  Struct fields in ORDER BY / GROUP BY
+-- ----------------------------------------
+
+--#[struct-24]
+-- ORDER BY a struct field
+SELECT T.col_struct_simple.level1_col_int, T.col_string FROM T_ALL_TYPES AS T ORDER BY T.col_struct_simple.level1_col_int;
+
+--#[struct-25]
+-- GROUP BY a struct field
+SELECT T.col_struct_simple.level1_col_string, COUNT(*) AS cnt FROM T_ALL_TYPES AS T GROUP BY T.col_struct_simple.level1_col_string;
+
+-- ----------------------------------------
+--  Struct with JOIN
+-- ----------------------------------------
+
+--#[struct-26]
+-- Join on struct fields
+SELECT t1.col_struct_simple.level1_col_int, T2.col_struct_nested.level1_col_string FROM T_ALL_TYPES AS t1 JOIN T_ALL_TYPES AS T2 ON t1.col_struct_simple.level1_col_int = T2.col_struct_nested.level1_col_int;
+
+--#[struct-27]
+-- Left join with nested struct field in condition
+SELECT t1.col_struct_simple, T2.col_struct_nested.level1_col_struct.level2_col_int FROM T_ALL_TYPES AS t1 LEFT JOIN T_ALL_TYPES AS T2 ON t1.col_struct_simple.level1_col_string = T2.col_struct_nested.level1_col_struct.level2_col_string;
+
+-- ----------------------------------------
+--  Struct in subquery
+-- ----------------------------------------
+
+--#[struct-28]
+-- Subquery selecting struct fields
+SELECT T.col_struct_simple.level1_col_int FROM T_ALL_TYPES AS T WHERE T.col_struct_simple.level1_col_int > (SELECT T2.col_struct_nested.level1_col_struct.level2_col_int FROM T_ALL_TYPES AS T2 WHERE T2.col_struct_nested.level1_col_struct.level2_col_int = 1);
+
+--#[struct-29]
+-- Struct field in IN subquery
+SELECT T.col_struct_nested.level1_col_struct.level2_col_int FROM T_ALL_TYPES AS T WHERE T.col_struct_simple.level1_col_int IN (SELECT T2.col_struct_nested.level1_col_struct.level2_col_int FROM T_ALL_TYPES AS T2);
+
+-- ----------------------------------------
+--  Struct construction with real values
+-- ----------------------------------------
+
+--#[struct-30]
+-- Construct struct with mixed literal types
+SELECT { 'count': 42, 'rate': 3.14, 'message': 'hello', 'enabled': false } AS config FROM T_ALL_TYPES AS T;
+
+--#[struct-31]
+-- Construct nested struct with literal values
+SELECT { 'user': { 'id': 100, 'email': 'test@example.com' }, 'timestamp': '2023-01-01T00:00:00Z' } AS record FROM T_ALL_TYPES AS T;
+
+--#[struct-32]
+-- Construct struct with null values
+SELECT { 'value': 123, 'optional_field': NULL, 'description': 'test' } AS data FROM T_ALL_TYPES AS T;
+
+--#[struct-33]
+-- Construct struct with arithmetic expressions
+SELECT { 'sum': 10 + 5, 'product': 3 * 7, 'ratio': 100.0 / 4 } AS calculations FROM T_ALL_TYPES AS T;

--- a/src/test/resources/outputs/partiql/basics/struct.sql
+++ b/src/test/resources/outputs/partiql/basics/struct.sql
@@ -162,3 +162,19 @@ SELECT {'value': 123, 'optional_field': NULL, 'description': 'test'} AS "data" F
 -- Construct struct with arithmetic expressions
 SELECT {'sum': 10 + 5, 'product': 3 * 7, 'ratio': 100.0 / CAST(4 AS DECIMAL(10,0))} AS "calculations" FROM "default"."T_ALL_TYPES" AS "T";
 
+-- ----------------------------------------
+--  Access field in constructed struct
+-- ----------------------------------------
+
+--#[struct-30]
+-- Access field from a constructed struct
+SELECT {'a': "T"['col_int32'], 'b': "T"['col_string']}['a'] AS "a_val" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-31]
+-- Access field from a struct constructed from struct fields
+SELECT {'x': "T"['col_struct_simple']['level1_col_int'], 'y': "T"['col_struct_simple']['level1_col_string']}['y'] AS "y_val" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-32]
+-- Access nested field from a constructed nested struct
+SELECT {'outer': {'inner_val': "T"['col_struct_nested']['level1_col_struct']['level2_col_int']}}['outer']['inner_val'] AS "inner_val" FROM "default"."T_ALL_TYPES" AS "T";
+

--- a/src/test/resources/outputs/partiql/basics/struct.sql
+++ b/src/test/resources/outputs/partiql/basics/struct.sql
@@ -1,0 +1,184 @@
+-- ----------------------------------------
+--  Select struct columns
+-- ----------------------------------------
+
+--#[struct-00]
+-- Select a simple struct column
+SELECT "T"['col_struct_simple'] AS "col_struct_simple" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-01]
+-- Select a nested struct column
+SELECT "T"['col_struct_nested'] AS "col_struct_nested" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-02]
+-- Select both struct columns
+SELECT "T"['col_struct_simple'] AS "col_struct_simple", "T"['col_struct_nested'] AS "col_struct_nested" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-03]
+-- Select struct alongside scalar columns
+SELECT "T"['col_int32'] AS "col_int32", "T"['col_string'] AS "col_string", "T"['col_struct_simple'] AS "col_struct_simple" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Path navigation — simple struct
+-- ----------------------------------------
+
+--#[struct-04]
+-- Access a field of a simple struct
+SELECT "T"['col_struct_simple']['level1_col_int'] AS "level1_col_int" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-05]
+-- Access multiple fields of a simple struct
+SELECT "T"['col_struct_simple']['level1_col_int'] AS "level1_col_int", "T"['col_struct_simple']['level1_col_string'] AS "level1_col_string" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-06]
+-- Access all fields of a simple struct
+SELECT "T"['col_struct_simple']['level1_col_int'] AS "level1_col_int", "T"['col_struct_simple']['level1_col_double'] AS "level1_col_double", "T"['col_struct_simple']['level1_col_string'] AS "level1_col_string", "T"['col_struct_simple']['level1_col_timestamp'] AS "level1_col_timestamp" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Path navigation — nested struct
+-- ----------------------------------------
+
+-- Single field access on nested struct (e.g. T.col_struct_nested.level1_col_int) covered by struct-04 pattern
+
+--#[struct-07]
+-- Access the nested struct itself
+SELECT "T"['col_struct_nested']['level1_col_struct'] AS "level1_col_struct" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-08]
+-- Access a field within the nested struct (2-level path)
+SELECT "T"['col_struct_nested']['level1_col_struct']['level2_col_int'] AS "level2_col_int" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-09]
+-- Access multiple fields within the nested struct
+SELECT "T"['col_struct_nested']['level1_col_struct']['level2_col_int'] AS "level2_col_int", "T"['col_struct_nested']['level1_col_struct']['level2_col_string'] AS "level2_col_string" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-10]
+-- Mix top-level and nested field access
+SELECT "T"['col_struct_nested']['level1_col_int'] AS "level1_col_int", "T"['col_struct_nested']['level1_col_struct']['level2_col_double'] AS "level2_col_double" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Struct wildcard (dot-star)
+-- ----------------------------------------
+
+--#[struct-11]
+-- Wildcard on simple struct
+SELECT "T"['col_struct_simple']['level1_col_int'] AS "level1_col_int", "T"['col_struct_simple']['level1_col_double'] AS "level1_col_double", "T"['col_struct_simple']['level1_col_string'] AS "level1_col_string", "T"['col_struct_simple']['level1_col_timestamp'] AS "level1_col_timestamp" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-12]
+-- Wildcard on nested struct
+SELECT "T"['col_struct_nested']['level1_col_int'] AS "level1_col_int", "T"['col_struct_nested']['level1_col_double'] AS "level1_col_double", "T"['col_struct_nested']['level1_col_string'] AS "level1_col_string", "T"['col_struct_nested']['level1_col_timestamp'] AS "level1_col_timestamp", "T"['col_struct_nested']['level1_col_struct'] AS "level1_col_struct" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-13]
+-- Wildcard on inner nested struct
+SELECT "T"['col_struct_nested']['level1_col_struct']['level2_col_int'] AS "level2_col_int", "T"['col_struct_nested']['level1_col_struct']['level2_col_double'] AS "level2_col_double", "T"['col_struct_nested']['level1_col_struct']['level2_col_string'] AS "level2_col_string", "T"['col_struct_nested']['level1_col_struct']['level2_col_timestamp'] AS "level2_col_timestamp" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-14]
+-- Wildcard with other columns
+SELECT "T"['col_int32'] AS "col_int32", "T"['col_struct_simple']['level1_col_int'] AS "level1_col_int", "T"['col_struct_simple']['level1_col_double'] AS "level1_col_double", "T"['col_struct_simple']['level1_col_string'] AS "level1_col_string", "T"['col_struct_simple']['level1_col_timestamp'] AS "level1_col_timestamp" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Struct construction in SELECT
+-- ----------------------------------------
+
+--#[struct-15]
+-- Construct a struct literal in SELECT
+SELECT {'a': "T"['col_int32'], 'b': "T"['col_string']} AS "constructed" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-16]
+-- Construct a struct from struct fields
+SELECT {'x': "T"['col_struct_simple']['level1_col_int'], 'y': "T"['col_struct_simple']['level1_col_string']} AS "constructed" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-17]
+-- Construct a nested struct literal
+SELECT {'outer': {'inner_val': "T"['col_struct_nested']['level1_col_struct']['level2_col_int']}} AS "constructed" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Filtering on struct fields
+-- ----------------------------------------
+
+--#[struct-18]
+-- WHERE on a simple struct field
+SELECT "T"['col_bool'] AS "col_bool", "T"['col_int16'] AS "col_int16", "T"['col_int32'] AS "col_int32", "T"['col_int64'] AS "col_int64", "T"['col_float32'] AS "col_float32", "T"['col_float64'] AS "col_float64", "T"['col_decimal'] AS "col_decimal", "T"['col_string'] AS "col_string", "T"['col_char'] AS "col_char", "T"['col_date'] AS "col_date", "T"['col_time'] AS "col_time", "T"['col_timez'] AS "col_timez", "T"['col_timestamp'] AS "col_timestamp", "T"['col_timestampz'] AS "col_timestampz", "T"['col_blob'] AS "col_blob", "T"['col_clob'] AS "col_clob", "T"['col_list'] AS "col_list", "T"['col_bag'] AS "col_bag", "T"['col_struct_simple'] AS "col_struct_simple", "T"['col_struct_nested'] AS "col_struct_nested", "T"['col_any'] AS "col_any" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"['col_struct_simple']['level1_col_int'] > 10;
+
+--#[struct-19]
+-- WHERE on a nested struct field
+SELECT "T"['col_bool'] AS "col_bool", "T"['col_int16'] AS "col_int16", "T"['col_int32'] AS "col_int32", "T"['col_int64'] AS "col_int64", "T"['col_float32'] AS "col_float32", "T"['col_float64'] AS "col_float64", "T"['col_decimal'] AS "col_decimal", "T"['col_string'] AS "col_string", "T"['col_char'] AS "col_char", "T"['col_date'] AS "col_date", "T"['col_time'] AS "col_time", "T"['col_timez'] AS "col_timez", "T"['col_timestamp'] AS "col_timestamp", "T"['col_timestampz'] AS "col_timestampz", "T"['col_blob'] AS "col_blob", "T"['col_clob'] AS "col_clob", "T"['col_list'] AS "col_list", "T"['col_bag'] AS "col_bag", "T"['col_struct_simple'] AS "col_struct_simple", "T"['col_struct_nested'] AS "col_struct_nested", "T"['col_any'] AS "col_any" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"['col_struct_nested']['level1_col_struct']['level2_col_string'] = 'hello';
+
+--#[struct-20]
+-- WHERE with multiple struct field conditions
+SELECT "T"['col_bool'] AS "col_bool", "T"['col_int16'] AS "col_int16", "T"['col_int32'] AS "col_int32", "T"['col_int64'] AS "col_int64", "T"['col_float32'] AS "col_float32", "T"['col_float64'] AS "col_float64", "T"['col_decimal'] AS "col_decimal", "T"['col_string'] AS "col_string", "T"['col_char'] AS "col_char", "T"['col_date'] AS "col_date", "T"['col_time'] AS "col_time", "T"['col_timez'] AS "col_timez", "T"['col_timestamp'] AS "col_timestamp", "T"['col_timestampz'] AS "col_timestampz", "T"['col_blob'] AS "col_blob", "T"['col_clob'] AS "col_clob", "T"['col_list'] AS "col_list", "T"['col_bag'] AS "col_bag", "T"['col_struct_simple'] AS "col_struct_simple", "T"['col_struct_nested'] AS "col_struct_nested", "T"['col_any'] AS "col_any" FROM "default"."T_ALL_TYPES" AS "T" WHERE ("T"['col_struct_simple']['level1_col_int'] > 0) AND ("T"['col_struct_nested']['level1_col_double'] < 100.0);
+
+--#[struct-21]
+-- IS NULL check on struct field
+SELECT "T"['col_bool'] AS "col_bool", "T"['col_int16'] AS "col_int16", "T"['col_int32'] AS "col_int32", "T"['col_int64'] AS "col_int64", "T"['col_float32'] AS "col_float32", "T"['col_float64'] AS "col_float64", "T"['col_decimal'] AS "col_decimal", "T"['col_string'] AS "col_string", "T"['col_char'] AS "col_char", "T"['col_date'] AS "col_date", "T"['col_time'] AS "col_time", "T"['col_timez'] AS "col_timez", "T"['col_timestamp'] AS "col_timestamp", "T"['col_timestampz'] AS "col_timestampz", "T"['col_blob'] AS "col_blob", "T"['col_clob'] AS "col_clob", "T"['col_list'] AS "col_list", "T"['col_bag'] AS "col_bag", "T"['col_struct_simple'] AS "col_struct_simple", "T"['col_struct_nested'] AS "col_struct_nested", "T"['col_any'] AS "col_any" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"['col_struct_simple']['level1_col_string'] IS NULL;
+
+--#[struct-22]
+-- IS NOT NULL check on nested struct field
+SELECT "T"['col_bool'] AS "col_bool", "T"['col_int16'] AS "col_int16", "T"['col_int32'] AS "col_int32", "T"['col_int64'] AS "col_int64", "T"['col_float32'] AS "col_float32", "T"['col_float64'] AS "col_float64", "T"['col_decimal'] AS "col_decimal", "T"['col_string'] AS "col_string", "T"['col_char'] AS "col_char", "T"['col_date'] AS "col_date", "T"['col_time'] AS "col_time", "T"['col_timez'] AS "col_timez", "T"['col_timestamp'] AS "col_timestamp", "T"['col_timestampz'] AS "col_timestampz", "T"['col_blob'] AS "col_blob", "T"['col_clob'] AS "col_clob", "T"['col_list'] AS "col_list", "T"['col_bag'] AS "col_bag", "T"['col_struct_simple'] AS "col_struct_simple", "T"['col_struct_nested'] AS "col_struct_nested", "T"['col_any'] AS "col_any" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"['col_struct_nested']['level1_col_struct']['level2_col_timestamp'] IS NOT NULL;
+
+-- ----------------------------------------
+--  Aliasing struct fields
+-- ----------------------------------------
+
+-- Single alias on struct path (e.g. T.col_struct_simple.level1_col_int AS x) covered by struct-04 pattern
+
+--#[struct-23]
+-- Alias multiple struct paths at different nesting levels
+SELECT "T"['col_struct_simple']['level1_col_int'] AS "s_int", "T"['col_struct_nested']['level1_col_struct']['level2_col_string'] AS "n_str" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Struct fields in ORDER BY / GROUP BY
+-- ----------------------------------------
+
+--#[struct-24]
+-- ORDER BY a struct field
+SELECT "T"['col_struct_simple']['level1_col_int'] AS "level1_col_int", "T"['col_string'] AS "col_string" FROM "default"."T_ALL_TYPES" AS "T" ORDER BY "T"['col_struct_simple']['level1_col_int'] ASC NULLS LAST;
+
+--#[struct-25]
+-- GROUP BY a struct field
+SELECT "T"['col_struct_simple']['level1_col_string'] AS "level1_col_string", count(1) AS "cnt" FROM "default"."T_ALL_TYPES" AS "T" GROUP BY "T"['col_struct_simple']['level1_col_string'];
+
+-- ----------------------------------------
+--  Struct with JOIN
+-- ----------------------------------------
+
+--#[struct-26]
+-- Join on struct fields
+SELECT "t1"['col_struct_simple']['level1_col_int'] AS "level1_col_int", "T2"['col_struct_nested']['level1_col_string'] AS "level1_col_string" FROM "default"."T_ALL_TYPES" AS "t1" INNER JOIN "default"."T_ALL_TYPES" AS "T2" ON "t1"['col_struct_simple']['level1_col_int'] = "T2"['col_struct_nested']['level1_col_int'];
+
+--#[struct-27]
+-- Left join with nested struct field in condition
+SELECT "t1"['col_struct_simple'] AS "col_struct_simple", "T2"['col_struct_nested']['level1_col_struct']['level2_col_int'] AS "level2_col_int" FROM "default"."T_ALL_TYPES" AS "t1" LEFT JOIN "default"."T_ALL_TYPES" AS "T2" ON "t1"['col_struct_simple']['level1_col_string'] = "T2"['col_struct_nested']['level1_col_struct']['level2_col_string'];
+
+-- ----------------------------------------
+--  Struct in subquery
+-- ----------------------------------------
+
+--#[struct-28]
+-- Subquery selecting struct fields
+SELECT "T"['col_struct_simple']['level1_col_int'] AS "level1_col_int" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"['col_struct_simple']['level1_col_int'] > (SELECT "T2"['col_struct_nested']['level1_col_struct']['level2_col_int'] AS "level2_col_int" FROM "default"."T_ALL_TYPES" AS "T2" WHERE "T2"['col_struct_nested']['level1_col_struct']['level2_col_int'] = 1);
+
+--#[struct-29]
+-- Struct field in IN subquery
+SELECT "T"['col_struct_nested']['level1_col_struct']['level2_col_int'] AS "level2_col_int" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"['col_struct_simple']['level1_col_int'] IN (SELECT "T2"['col_struct_nested']['level1_col_struct']['level2_col_int'] AS "level2_col_int" FROM "default"."T_ALL_TYPES" AS "T2");
+
+-- ----------------------------------------
+--  Struct construction with real values
+-- ----------------------------------------
+
+--#[struct-30]
+-- Construct struct with mixed literal types
+SELECT {'count': 42, 'rate': 3.14, 'message': 'hello', 'enabled': false} AS "config" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-31]
+-- Construct nested struct with literal values
+SELECT {'user': {'id': 100, 'email': 'test@example.com'}, 'timestamp': '2023-01-01T00:00:00Z'} AS "record" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-32]
+-- Construct struct with null values
+SELECT {'value': 123, 'optional_field': NULL, 'description': 'test'} AS "data" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-33]
+-- Construct struct with arithmetic expressions
+SELECT {'sum': 10 + 5, 'product': 3 * 7, 'ratio': 100.0 / CAST(4 AS DECIMAL(10,0))} AS "calculations" FROM "default"."T_ALL_TYPES" AS "T";
+

--- a/src/test/resources/outputs/partiql/basics/struct.sql
+++ b/src/test/resources/outputs/partiql/basics/struct.sql
@@ -11,26 +11,18 @@ SELECT "T"['col_struct_simple'] AS "col_struct_simple" FROM "default"."T_ALL_TYP
 SELECT "T"['col_struct_nested'] AS "col_struct_nested" FROM "default"."T_ALL_TYPES" AS "T";
 
 --#[struct-02]
--- Select both struct columns
-SELECT "T"['col_struct_simple'] AS "col_struct_simple", "T"['col_struct_nested'] AS "col_struct_nested" FROM "default"."T_ALL_TYPES" AS "T";
-
---#[struct-03]
 -- Select struct alongside scalar columns
-SELECT "T"['col_int32'] AS "col_int32", "T"['col_string'] AS "col_string", "T"['col_struct_simple'] AS "col_struct_simple" FROM "default"."T_ALL_TYPES" AS "T";
+SELECT "T"['col_int32'] AS "col_int32", "T"['col_string'] AS "col_string", "T"['col_struct_simple'] AS "col_struct_simple", "T"['col_struct_nested'] AS "col_struct_nested" FROM "default"."T_ALL_TYPES" AS "T";
 
 -- ----------------------------------------
 --  Path navigation — simple struct
 -- ----------------------------------------
 
---#[struct-04]
--- Access a field of a simple struct
-SELECT "T"['col_struct_simple']['level1_col_int'] AS "level1_col_int" FROM "default"."T_ALL_TYPES" AS "T";
-
---#[struct-05]
+--#[struct-03]
 -- Access multiple fields of a simple struct
 SELECT "T"['col_struct_simple']['level1_col_int'] AS "level1_col_int", "T"['col_struct_simple']['level1_col_string'] AS "level1_col_string" FROM "default"."T_ALL_TYPES" AS "T";
 
---#[struct-06]
+--#[struct-04]
 -- Access all fields of a simple struct
 SELECT "T"['col_struct_simple']['level1_col_int'] AS "level1_col_int", "T"['col_struct_simple']['level1_col_double'] AS "level1_col_double", "T"['col_struct_simple']['level1_col_string'] AS "level1_col_string", "T"['col_struct_simple']['level1_col_timestamp'] AS "level1_col_timestamp" FROM "default"."T_ALL_TYPES" AS "T";
 
@@ -38,21 +30,11 @@ SELECT "T"['col_struct_simple']['level1_col_int'] AS "level1_col_int", "T"['col_
 --  Path navigation — nested struct
 -- ----------------------------------------
 
--- Single field access on nested struct (e.g. T.col_struct_nested.level1_col_int) covered by struct-04 pattern
-
---#[struct-07]
--- Access the nested struct itself
-SELECT "T"['col_struct_nested']['level1_col_struct'] AS "level1_col_struct" FROM "default"."T_ALL_TYPES" AS "T";
-
---#[struct-08]
--- Access a field within the nested struct (2-level path)
-SELECT "T"['col_struct_nested']['level1_col_struct']['level2_col_int'] AS "level2_col_int" FROM "default"."T_ALL_TYPES" AS "T";
-
---#[struct-09]
+--#[struct-05]
 -- Access multiple fields within the nested struct
 SELECT "T"['col_struct_nested']['level1_col_struct']['level2_col_int'] AS "level2_col_int", "T"['col_struct_nested']['level1_col_struct']['level2_col_string'] AS "level2_col_string" FROM "default"."T_ALL_TYPES" AS "T";
 
---#[struct-10]
+--#[struct-06]
 -- Mix top-level and nested field access
 SELECT "T"['col_struct_nested']['level1_col_int'] AS "level1_col_int", "T"['col_struct_nested']['level1_col_struct']['level2_col_double'] AS "level2_col_double" FROM "default"."T_ALL_TYPES" AS "T";
 
@@ -60,19 +42,19 @@ SELECT "T"['col_struct_nested']['level1_col_int'] AS "level1_col_int", "T"['col_
 --  Struct wildcard (dot-star)
 -- ----------------------------------------
 
---#[struct-11]
+--#[struct-07]
 -- Wildcard on simple struct
 SELECT "T"['col_struct_simple']['level1_col_int'] AS "level1_col_int", "T"['col_struct_simple']['level1_col_double'] AS "level1_col_double", "T"['col_struct_simple']['level1_col_string'] AS "level1_col_string", "T"['col_struct_simple']['level1_col_timestamp'] AS "level1_col_timestamp" FROM "default"."T_ALL_TYPES" AS "T";
 
---#[struct-12]
+--#[struct-08]
 -- Wildcard on nested struct
 SELECT "T"['col_struct_nested']['level1_col_int'] AS "level1_col_int", "T"['col_struct_nested']['level1_col_double'] AS "level1_col_double", "T"['col_struct_nested']['level1_col_string'] AS "level1_col_string", "T"['col_struct_nested']['level1_col_timestamp'] AS "level1_col_timestamp", "T"['col_struct_nested']['level1_col_struct'] AS "level1_col_struct" FROM "default"."T_ALL_TYPES" AS "T";
 
---#[struct-13]
+--#[struct-09]
 -- Wildcard on inner nested struct
 SELECT "T"['col_struct_nested']['level1_col_struct']['level2_col_int'] AS "level2_col_int", "T"['col_struct_nested']['level1_col_struct']['level2_col_double'] AS "level2_col_double", "T"['col_struct_nested']['level1_col_struct']['level2_col_string'] AS "level2_col_string", "T"['col_struct_nested']['level1_col_struct']['level2_col_timestamp'] AS "level2_col_timestamp" FROM "default"."T_ALL_TYPES" AS "T";
 
---#[struct-14]
+--#[struct-10]
 -- Wildcard with other columns
 SELECT "T"['col_int32'] AS "col_int32", "T"['col_struct_simple']['level1_col_int'] AS "level1_col_int", "T"['col_struct_simple']['level1_col_double'] AS "level1_col_double", "T"['col_struct_simple']['level1_col_string'] AS "level1_col_string", "T"['col_struct_simple']['level1_col_timestamp'] AS "level1_col_timestamp" FROM "default"."T_ALL_TYPES" AS "T";
 
@@ -80,15 +62,15 @@ SELECT "T"['col_int32'] AS "col_int32", "T"['col_struct_simple']['level1_col_int
 --  Struct construction in SELECT
 -- ----------------------------------------
 
---#[struct-15]
+--#[struct-11]
 -- Construct a struct literal in SELECT
 SELECT {'a': "T"['col_int32'], 'b': "T"['col_string']} AS "constructed" FROM "default"."T_ALL_TYPES" AS "T";
 
---#[struct-16]
+--#[struct-12]
 -- Construct a struct from struct fields
 SELECT {'x': "T"['col_struct_simple']['level1_col_int'], 'y': "T"['col_struct_simple']['level1_col_string']} AS "constructed" FROM "default"."T_ALL_TYPES" AS "T";
 
---#[struct-17]
+--#[struct-13]
 -- Construct a nested struct literal
 SELECT {'outer': {'inner_val': "T"['col_struct_nested']['level1_col_struct']['level2_col_int']}} AS "constructed" FROM "default"."T_ALL_TYPES" AS "T";
 
@@ -96,33 +78,31 @@ SELECT {'outer': {'inner_val': "T"['col_struct_nested']['level1_col_struct']['le
 --  Filtering on struct fields
 -- ----------------------------------------
 
---#[struct-18]
+--#[struct-14]
 -- WHERE on a simple struct field
-SELECT "T"['col_bool'] AS "col_bool", "T"['col_int16'] AS "col_int16", "T"['col_int32'] AS "col_int32", "T"['col_int64'] AS "col_int64", "T"['col_float32'] AS "col_float32", "T"['col_float64'] AS "col_float64", "T"['col_decimal'] AS "col_decimal", "T"['col_string'] AS "col_string", "T"['col_char'] AS "col_char", "T"['col_date'] AS "col_date", "T"['col_time'] AS "col_time", "T"['col_timez'] AS "col_timez", "T"['col_timestamp'] AS "col_timestamp", "T"['col_timestampz'] AS "col_timestampz", "T"['col_blob'] AS "col_blob", "T"['col_clob'] AS "col_clob", "T"['col_list'] AS "col_list", "T"['col_bag'] AS "col_bag", "T"['col_struct_simple'] AS "col_struct_simple", "T"['col_struct_nested'] AS "col_struct_nested", "T"['col_any'] AS "col_any" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"['col_struct_simple']['level1_col_int'] > 10;
+SELECT "T"['col_int32'] AS "col_int32", "T"['col_string'] AS "col_string", "T"['col_struct_simple']['level1_col_int'] AS "level1_col_int", "T"['col_struct_nested']['level1_col_struct']['level2_col_string'] AS "level2_col_string" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"['col_struct_simple']['level1_col_int'] > 10;
 
---#[struct-19]
+--#[struct-15]
 -- WHERE on a nested struct field
-SELECT "T"['col_bool'] AS "col_bool", "T"['col_int16'] AS "col_int16", "T"['col_int32'] AS "col_int32", "T"['col_int64'] AS "col_int64", "T"['col_float32'] AS "col_float32", "T"['col_float64'] AS "col_float64", "T"['col_decimal'] AS "col_decimal", "T"['col_string'] AS "col_string", "T"['col_char'] AS "col_char", "T"['col_date'] AS "col_date", "T"['col_time'] AS "col_time", "T"['col_timez'] AS "col_timez", "T"['col_timestamp'] AS "col_timestamp", "T"['col_timestampz'] AS "col_timestampz", "T"['col_blob'] AS "col_blob", "T"['col_clob'] AS "col_clob", "T"['col_list'] AS "col_list", "T"['col_bag'] AS "col_bag", "T"['col_struct_simple'] AS "col_struct_simple", "T"['col_struct_nested'] AS "col_struct_nested", "T"['col_any'] AS "col_any" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"['col_struct_nested']['level1_col_struct']['level2_col_string'] = 'hello';
+SELECT "T"['col_int32'] AS "col_int32", "T"['col_string'] AS "col_string", "T"['col_struct_simple']['level1_col_int'] AS "level1_col_int", "T"['col_struct_nested']['level1_col_struct']['level2_col_string'] AS "level2_col_string" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"['col_struct_nested']['level1_col_struct']['level2_col_string'] = 'hello';
 
---#[struct-20]
+--#[struct-16]
 -- WHERE with multiple struct field conditions
-SELECT "T"['col_bool'] AS "col_bool", "T"['col_int16'] AS "col_int16", "T"['col_int32'] AS "col_int32", "T"['col_int64'] AS "col_int64", "T"['col_float32'] AS "col_float32", "T"['col_float64'] AS "col_float64", "T"['col_decimal'] AS "col_decimal", "T"['col_string'] AS "col_string", "T"['col_char'] AS "col_char", "T"['col_date'] AS "col_date", "T"['col_time'] AS "col_time", "T"['col_timez'] AS "col_timez", "T"['col_timestamp'] AS "col_timestamp", "T"['col_timestampz'] AS "col_timestampz", "T"['col_blob'] AS "col_blob", "T"['col_clob'] AS "col_clob", "T"['col_list'] AS "col_list", "T"['col_bag'] AS "col_bag", "T"['col_struct_simple'] AS "col_struct_simple", "T"['col_struct_nested'] AS "col_struct_nested", "T"['col_any'] AS "col_any" FROM "default"."T_ALL_TYPES" AS "T" WHERE ("T"['col_struct_simple']['level1_col_int'] > 0) AND ("T"['col_struct_nested']['level1_col_double'] < 100.0);
+SELECT "T"['col_int32'] AS "col_int32", "T"['col_string'] AS "col_string", "T"['col_struct_simple']['level1_col_int'] AS "level1_col_int", "T"['col_struct_nested']['level1_col_struct']['level2_col_string'] AS "level2_col_string" FROM "default"."T_ALL_TYPES" AS "T" WHERE ("T"['col_struct_simple']['level1_col_int'] > 0) AND ("T"['col_struct_nested']['level1_col_double'] < 100.0);
 
---#[struct-21]
+--#[struct-17]
 -- IS NULL check on struct field
-SELECT "T"['col_bool'] AS "col_bool", "T"['col_int16'] AS "col_int16", "T"['col_int32'] AS "col_int32", "T"['col_int64'] AS "col_int64", "T"['col_float32'] AS "col_float32", "T"['col_float64'] AS "col_float64", "T"['col_decimal'] AS "col_decimal", "T"['col_string'] AS "col_string", "T"['col_char'] AS "col_char", "T"['col_date'] AS "col_date", "T"['col_time'] AS "col_time", "T"['col_timez'] AS "col_timez", "T"['col_timestamp'] AS "col_timestamp", "T"['col_timestampz'] AS "col_timestampz", "T"['col_blob'] AS "col_blob", "T"['col_clob'] AS "col_clob", "T"['col_list'] AS "col_list", "T"['col_bag'] AS "col_bag", "T"['col_struct_simple'] AS "col_struct_simple", "T"['col_struct_nested'] AS "col_struct_nested", "T"['col_any'] AS "col_any" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"['col_struct_simple']['level1_col_string'] IS NULL;
+SELECT "T"['col_int32'] AS "col_int32", "T"['col_string'] AS "col_string", "T"['col_struct_simple']['level1_col_int'] AS "level1_col_int", "T"['col_struct_nested']['level1_col_struct']['level2_col_string'] AS "level2_col_string" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"['col_struct_simple']['level1_col_string'] IS NULL;
 
---#[struct-22]
+--#[struct-18]
 -- IS NOT NULL check on nested struct field
-SELECT "T"['col_bool'] AS "col_bool", "T"['col_int16'] AS "col_int16", "T"['col_int32'] AS "col_int32", "T"['col_int64'] AS "col_int64", "T"['col_float32'] AS "col_float32", "T"['col_float64'] AS "col_float64", "T"['col_decimal'] AS "col_decimal", "T"['col_string'] AS "col_string", "T"['col_char'] AS "col_char", "T"['col_date'] AS "col_date", "T"['col_time'] AS "col_time", "T"['col_timez'] AS "col_timez", "T"['col_timestamp'] AS "col_timestamp", "T"['col_timestampz'] AS "col_timestampz", "T"['col_blob'] AS "col_blob", "T"['col_clob'] AS "col_clob", "T"['col_list'] AS "col_list", "T"['col_bag'] AS "col_bag", "T"['col_struct_simple'] AS "col_struct_simple", "T"['col_struct_nested'] AS "col_struct_nested", "T"['col_any'] AS "col_any" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"['col_struct_nested']['level1_col_struct']['level2_col_timestamp'] IS NOT NULL;
+SELECT "T"['col_int32'] AS "col_int32", "T"['col_string'] AS "col_string", "T"['col_struct_simple']['level1_col_int'] AS "level1_col_int", "T"['col_struct_nested']['level1_col_struct']['level2_col_string'] AS "level2_col_string" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"['col_struct_nested']['level1_col_struct']['level2_col_timestamp'] IS NOT NULL;
 
 -- ----------------------------------------
 --  Aliasing struct fields
 -- ----------------------------------------
 
--- Single alias on struct path (e.g. T.col_struct_simple.level1_col_int AS x) covered by struct-04 pattern
-
---#[struct-23]
+--#[struct-19]
 -- Alias multiple struct paths at different nesting levels
 SELECT "T"['col_struct_simple']['level1_col_int'] AS "s_int", "T"['col_struct_nested']['level1_col_struct']['level2_col_string'] AS "n_str" FROM "default"."T_ALL_TYPES" AS "T";
 
@@ -130,11 +110,11 @@ SELECT "T"['col_struct_simple']['level1_col_int'] AS "s_int", "T"['col_struct_ne
 --  Struct fields in ORDER BY / GROUP BY
 -- ----------------------------------------
 
---#[struct-24]
+--#[struct-20]
 -- ORDER BY a struct field
 SELECT "T"['col_struct_simple']['level1_col_int'] AS "level1_col_int", "T"['col_string'] AS "col_string" FROM "default"."T_ALL_TYPES" AS "T" ORDER BY "T"['col_struct_simple']['level1_col_int'] ASC NULLS LAST;
 
---#[struct-25]
+--#[struct-21]
 -- GROUP BY a struct field
 SELECT "T"['col_struct_simple']['level1_col_string'] AS "level1_col_string", count(1) AS "cnt" FROM "default"."T_ALL_TYPES" AS "T" GROUP BY "T"['col_struct_simple']['level1_col_string'];
 
@@ -142,11 +122,11 @@ SELECT "T"['col_struct_simple']['level1_col_string'] AS "level1_col_string", cou
 --  Struct with JOIN
 -- ----------------------------------------
 
---#[struct-26]
+--#[struct-22]
 -- Join on struct fields
 SELECT "t1"['col_struct_simple']['level1_col_int'] AS "level1_col_int", "T2"['col_struct_nested']['level1_col_string'] AS "level1_col_string" FROM "default"."T_ALL_TYPES" AS "t1" INNER JOIN "default"."T_ALL_TYPES" AS "T2" ON "t1"['col_struct_simple']['level1_col_int'] = "T2"['col_struct_nested']['level1_col_int'];
 
---#[struct-27]
+--#[struct-23]
 -- Left join with nested struct field in condition
 SELECT "t1"['col_struct_simple'] AS "col_struct_simple", "T2"['col_struct_nested']['level1_col_struct']['level2_col_int'] AS "level2_col_int" FROM "default"."T_ALL_TYPES" AS "t1" LEFT JOIN "default"."T_ALL_TYPES" AS "T2" ON "t1"['col_struct_simple']['level1_col_string'] = "T2"['col_struct_nested']['level1_col_struct']['level2_col_string'];
 
@@ -154,11 +134,11 @@ SELECT "t1"['col_struct_simple'] AS "col_struct_simple", "T2"['col_struct_nested
 --  Struct in subquery
 -- ----------------------------------------
 
---#[struct-28]
+--#[struct-24]
 -- Subquery selecting struct fields
 SELECT "T"['col_struct_simple']['level1_col_int'] AS "level1_col_int" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"['col_struct_simple']['level1_col_int'] > (SELECT "T2"['col_struct_nested']['level1_col_struct']['level2_col_int'] AS "level2_col_int" FROM "default"."T_ALL_TYPES" AS "T2" WHERE "T2"['col_struct_nested']['level1_col_struct']['level2_col_int'] = 1);
 
---#[struct-29]
+--#[struct-25]
 -- Struct field in IN subquery
 SELECT "T"['col_struct_nested']['level1_col_struct']['level2_col_int'] AS "level2_col_int" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"['col_struct_simple']['level1_col_int'] IN (SELECT "T2"['col_struct_nested']['level1_col_struct']['level2_col_int'] AS "level2_col_int" FROM "default"."T_ALL_TYPES" AS "T2");
 
@@ -166,19 +146,19 @@ SELECT "T"['col_struct_nested']['level1_col_struct']['level2_col_int'] AS "level
 --  Struct construction with real values
 -- ----------------------------------------
 
---#[struct-30]
+--#[struct-26]
 -- Construct struct with mixed literal types
 SELECT {'count': 42, 'rate': 3.14, 'message': 'hello', 'enabled': false} AS "config" FROM "default"."T_ALL_TYPES" AS "T";
 
---#[struct-31]
+--#[struct-27]
 -- Construct nested struct with literal values
 SELECT {'user': {'id': 100, 'email': 'test@example.com'}, 'timestamp': '2023-01-01T00:00:00Z'} AS "record" FROM "default"."T_ALL_TYPES" AS "T";
 
---#[struct-32]
+--#[struct-28]
 -- Construct struct with null values
 SELECT {'value': 123, 'optional_field': NULL, 'description': 'test'} AS "data" FROM "default"."T_ALL_TYPES" AS "T";
 
---#[struct-33]
+--#[struct-29]
 -- Construct struct with arithmetic expressions
 SELECT {'sum': 10 + 5, 'product': 3 * 7, 'ratio': 100.0 / CAST(4 AS DECIMAL(10,0))} AS "calculations" FROM "default"."T_ALL_TYPES" AS "T";
 

--- a/src/test/resources/outputs/redshift/basics/struct.sql
+++ b/src/test/resources/outputs/redshift/basics/struct.sql
@@ -11,26 +11,18 @@ SELECT "T"."col_struct_simple" FROM "default"."T_ALL_TYPES" AS "T";
 SELECT "T"."col_struct_nested" FROM "default"."T_ALL_TYPES" AS "T";
 
 --#[struct-02]
--- Select both struct columns
-SELECT "T"."col_struct_simple", "T"."col_struct_nested" FROM "default"."T_ALL_TYPES" AS "T";
-
---#[struct-03]
 -- Select struct alongside scalar columns
-SELECT "T"."col_int32", "T"."col_string", "T"."col_struct_simple" FROM "default"."T_ALL_TYPES" AS "T";
+SELECT "T"."col_int32", "T"."col_string", "T"."col_struct_simple", "T"."col_struct_nested" FROM "default"."T_ALL_TYPES" AS "T";
 
 -- ----------------------------------------
 --  Path navigation — simple struct
 -- ----------------------------------------
 
---#[struct-04]
--- Access a field of a simple struct
-SELECT "T"."col_struct_simple"."level1_col_int" FROM "default"."T_ALL_TYPES" AS "T";
-
---#[struct-05]
+--#[struct-03]
 -- Access multiple fields of a simple struct
 SELECT "T"."col_struct_simple"."level1_col_int", "T"."col_struct_simple"."level1_col_string" FROM "default"."T_ALL_TYPES" AS "T";
 
---#[struct-06]
+--#[struct-04]
 -- Access all fields of a simple struct
 SELECT "T"."col_struct_simple"."level1_col_int", "T"."col_struct_simple"."level1_col_double", "T"."col_struct_simple"."level1_col_string", "T"."col_struct_simple"."level1_col_timestamp" FROM "default"."T_ALL_TYPES" AS "T";
 
@@ -38,21 +30,11 @@ SELECT "T"."col_struct_simple"."level1_col_int", "T"."col_struct_simple"."level1
 --  Path navigation — nested struct
 -- ----------------------------------------
 
--- Single field access on nested struct (e.g. T.col_struct_nested.level1_col_int) covered by struct-04 pattern
-
---#[struct-07]
--- Access the nested struct itself
-SELECT "T"."col_struct_nested"."level1_col_struct" FROM "default"."T_ALL_TYPES" AS "T";
-
---#[struct-08]
--- Access a field within the nested struct (2-level path)
-SELECT "T"."col_struct_nested"."level1_col_struct"."level2_col_int" FROM "default"."T_ALL_TYPES" AS "T";
-
---#[struct-09]
+--#[struct-05]
 -- Access multiple fields within the nested struct
 SELECT "T"."col_struct_nested"."level1_col_struct"."level2_col_int", "T"."col_struct_nested"."level1_col_struct"."level2_col_string" FROM "default"."T_ALL_TYPES" AS "T";
 
---#[struct-10]
+--#[struct-06]
 -- Mix top-level and nested field access
 SELECT "T"."col_struct_nested"."level1_col_int", "T"."col_struct_nested"."level1_col_struct"."level2_col_double" FROM "default"."T_ALL_TYPES" AS "T";
 
@@ -60,19 +42,19 @@ SELECT "T"."col_struct_nested"."level1_col_int", "T"."col_struct_nested"."level1
 --  Struct wildcard (dot-star)
 -- ----------------------------------------
 
---#[struct-11]
+--#[struct-07]
 -- Wildcard on simple struct
 SELECT "T"."col_struct_simple"."level1_col_int", "T"."col_struct_simple"."level1_col_double", "T"."col_struct_simple"."level1_col_string", "T"."col_struct_simple"."level1_col_timestamp" FROM "default"."T_ALL_TYPES" AS "T";
 
---#[struct-12]
+--#[struct-08]
 -- Wildcard on nested struct
 SELECT "T"."col_struct_nested"."level1_col_int", "T"."col_struct_nested"."level1_col_double", "T"."col_struct_nested"."level1_col_string", "T"."col_struct_nested"."level1_col_timestamp", "T"."col_struct_nested"."level1_col_struct" FROM "default"."T_ALL_TYPES" AS "T";
 
---#[struct-13]
+--#[struct-09]
 -- Wildcard on inner nested struct
 SELECT "T"."col_struct_nested"."level1_col_struct"."level2_col_int", "T"."col_struct_nested"."level1_col_struct"."level2_col_double", "T"."col_struct_nested"."level1_col_struct"."level2_col_string", "T"."col_struct_nested"."level1_col_struct"."level2_col_timestamp" FROM "default"."T_ALL_TYPES" AS "T";
 
---#[struct-14]
+--#[struct-10]
 -- Wildcard with other columns
 SELECT "T"."col_int32", "T"."col_struct_simple"."level1_col_int", "T"."col_struct_simple"."level1_col_double", "T"."col_struct_simple"."level1_col_string", "T"."col_struct_simple"."level1_col_timestamp" FROM "default"."T_ALL_TYPES" AS "T";
 
@@ -80,15 +62,15 @@ SELECT "T"."col_int32", "T"."col_struct_simple"."level1_col_int", "T"."col_struc
 --  Struct construction in SELECT
 -- ----------------------------------------
 
---#[struct-15]
+--#[struct-11]
 -- Construct a struct literal in SELECT
 SELECT OBJECT('a', "T"."col_int32", 'b', "T"."col_string") AS "constructed" FROM "default"."T_ALL_TYPES" AS "T";
 
---#[struct-16]
+--#[struct-12]
 -- Construct a struct from struct fields
 SELECT OBJECT('x', "T"."col_struct_simple"."level1_col_int", 'y', "T"."col_struct_simple"."level1_col_string") AS "constructed" FROM "default"."T_ALL_TYPES" AS "T";
 
---#[struct-17]
+--#[struct-13]
 -- Construct a nested struct literal
 SELECT OBJECT('outer', OBJECT('inner_val', "T"."col_struct_nested"."level1_col_struct"."level2_col_int")) AS "constructed" FROM "default"."T_ALL_TYPES" AS "T";
 
@@ -96,33 +78,31 @@ SELECT OBJECT('outer', OBJECT('inner_val', "T"."col_struct_nested"."level1_col_s
 --  Filtering on struct fields
 -- ----------------------------------------
 
---#[struct-18]
+--#[struct-14]
 -- WHERE on a simple struct field
-SELECT "T"."col_bool", "T"."col_int16", "T"."col_int32", "T"."col_int64", "T"."col_float32", "T"."col_float64", "T"."col_decimal", "T"."col_string", "T"."col_char", "T"."col_date", "T"."col_time", "T"."col_timez", "T"."col_timestamp", "T"."col_timestampz", "T"."col_blob", "T"."col_clob", "T"."col_list", "T"."col_bag", "T"."col_struct_simple", "T"."col_struct_nested", "T"."col_any" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_struct_simple"."level1_col_int" > 10;
+SELECT "T"."col_int32", "T"."col_string", "T"."col_struct_simple"."level1_col_int", "T"."col_struct_nested"."level1_col_struct"."level2_col_string" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_struct_simple"."level1_col_int" > 10;
 
---#[struct-19]
+--#[struct-15]
 -- WHERE on a nested struct field
-SELECT "T"."col_bool", "T"."col_int16", "T"."col_int32", "T"."col_int64", "T"."col_float32", "T"."col_float64", "T"."col_decimal", "T"."col_string", "T"."col_char", "T"."col_date", "T"."col_time", "T"."col_timez", "T"."col_timestamp", "T"."col_timestampz", "T"."col_blob", "T"."col_clob", "T"."col_list", "T"."col_bag", "T"."col_struct_simple", "T"."col_struct_nested", "T"."col_any" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_struct_nested"."level1_col_struct"."level2_col_string" = 'hello';
+SELECT "T"."col_int32", "T"."col_string", "T"."col_struct_simple"."level1_col_int", "T"."col_struct_nested"."level1_col_struct"."level2_col_string" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_struct_nested"."level1_col_struct"."level2_col_string" = 'hello';
 
---#[struct-20]
+--#[struct-16]
 -- WHERE with multiple struct field conditions
-SELECT "T"."col_bool", "T"."col_int16", "T"."col_int32", "T"."col_int64", "T"."col_float32", "T"."col_float64", "T"."col_decimal", "T"."col_string", "T"."col_char", "T"."col_date", "T"."col_time", "T"."col_timez", "T"."col_timestamp", "T"."col_timestampz", "T"."col_blob", "T"."col_clob", "T"."col_list", "T"."col_bag", "T"."col_struct_simple", "T"."col_struct_nested", "T"."col_any" FROM "default"."T_ALL_TYPES" AS "T" WHERE ("T"."col_struct_simple"."level1_col_int" > 0) AND ("T"."col_struct_nested"."level1_col_double" < 100.0);
+SELECT "T"."col_int32", "T"."col_string", "T"."col_struct_simple"."level1_col_int", "T"."col_struct_nested"."level1_col_struct"."level2_col_string" FROM "default"."T_ALL_TYPES" AS "T" WHERE ("T"."col_struct_simple"."level1_col_int" > 0) AND ("T"."col_struct_nested"."level1_col_double" < 100.0);
 
---#[struct-21]
+--#[struct-17]
 -- IS NULL check on struct field
-SELECT "T"."col_bool", "T"."col_int16", "T"."col_int32", "T"."col_int64", "T"."col_float32", "T"."col_float64", "T"."col_decimal", "T"."col_string", "T"."col_char", "T"."col_date", "T"."col_time", "T"."col_timez", "T"."col_timestamp", "T"."col_timestampz", "T"."col_blob", "T"."col_clob", "T"."col_list", "T"."col_bag", "T"."col_struct_simple", "T"."col_struct_nested", "T"."col_any" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_struct_simple"."level1_col_string" IS NULL;
+SELECT "T"."col_int32", "T"."col_string", "T"."col_struct_simple"."level1_col_int", "T"."col_struct_nested"."level1_col_struct"."level2_col_string" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_struct_simple"."level1_col_string" IS NULL;
 
---#[struct-22]
+--#[struct-18]
 -- IS NOT NULL check on nested struct field
-SELECT "T"."col_bool", "T"."col_int16", "T"."col_int32", "T"."col_int64", "T"."col_float32", "T"."col_float64", "T"."col_decimal", "T"."col_string", "T"."col_char", "T"."col_date", "T"."col_time", "T"."col_timez", "T"."col_timestamp", "T"."col_timestampz", "T"."col_blob", "T"."col_clob", "T"."col_list", "T"."col_bag", "T"."col_struct_simple", "T"."col_struct_nested", "T"."col_any" FROM "default"."T_ALL_TYPES" AS "T" WHERE CAST("T"."col_struct_nested"."level1_col_struct"."level2_col_timestamp" AS TIMESTAMP) IS NOT NULL;
+SELECT "T"."col_int32", "T"."col_string", "T"."col_struct_simple"."level1_col_int", "T"."col_struct_nested"."level1_col_struct"."level2_col_string" FROM "default"."T_ALL_TYPES" AS "T" WHERE CAST("T"."col_struct_nested"."level1_col_struct"."level2_col_timestamp" AS TIMESTAMP) IS NOT NULL;
 
 -- ----------------------------------------
 --  Aliasing struct fields
 -- ----------------------------------------
 
--- Single alias on struct path (e.g. T.col_struct_simple.level1_col_int AS x) covered by struct-04 pattern
-
---#[struct-23]
+--#[struct-19]
 -- Alias multiple struct paths at different nesting levels
 SELECT "T"."col_struct_simple"."level1_col_int" AS "s_int", "T"."col_struct_nested"."level1_col_struct"."level2_col_string" AS "n_str" FROM "default"."T_ALL_TYPES" AS "T";
 
@@ -130,11 +110,11 @@ SELECT "T"."col_struct_simple"."level1_col_int" AS "s_int", "T"."col_struct_nest
 --  Struct fields in ORDER BY / GROUP BY
 -- ----------------------------------------
 
---#[struct-24]
+--#[struct-20]
 -- ORDER BY a struct field
 SELECT "T"."col_struct_simple"."level1_col_int", "T"."col_string" FROM "default"."T_ALL_TYPES" AS "T" ORDER BY "T"."col_struct_simple"."level1_col_int" ASC NULLS LAST;
 
---#[struct-25]
+--#[struct-21]
 -- GROUP BY a struct field
 SELECT "T"."col_struct_simple"."level1_col_string", count(1) AS "cnt" FROM "default"."T_ALL_TYPES" AS "T" GROUP BY "T"."col_struct_simple"."level1_col_string";
 
@@ -142,11 +122,11 @@ SELECT "T"."col_struct_simple"."level1_col_string", count(1) AS "cnt" FROM "defa
 --  Struct with JOIN
 -- ----------------------------------------
 
---#[struct-26]
+--#[struct-22]
 -- Join on struct fields
 SELECT "t1"."col_struct_simple"."level1_col_int", "T2"."col_struct_nested"."level1_col_string" FROM "default"."T_ALL_TYPES" AS "t1" INNER JOIN "default"."T_ALL_TYPES" AS "T2" ON "t1"."col_struct_simple"."level1_col_int" = "T2"."col_struct_nested"."level1_col_int";
 
---#[struct-27]
+--#[struct-23]
 -- Left join with nested struct field in condition
 SELECT "t1"."col_struct_simple", "T2"."col_struct_nested"."level1_col_struct"."level2_col_int" FROM "default"."T_ALL_TYPES" AS "t1" LEFT JOIN "default"."T_ALL_TYPES" AS "T2" ON "t1"."col_struct_simple"."level1_col_string" = "T2"."col_struct_nested"."level1_col_struct"."level2_col_string";
 
@@ -154,11 +134,11 @@ SELECT "t1"."col_struct_simple", "T2"."col_struct_nested"."level1_col_struct"."l
 --  Struct in subquery
 -- ----------------------------------------
 
---#[struct-28]
+--#[struct-24]
 -- Subquery selecting struct fields
 SELECT "T"."col_struct_simple"."level1_col_int" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_struct_simple"."level1_col_int" > (SELECT "T2"."col_struct_nested"."level1_col_struct"."level2_col_int" FROM "default"."T_ALL_TYPES" AS "T2" WHERE "T2"."col_struct_nested"."level1_col_struct"."level2_col_int" = 1);
 
---#[struct-29]
+--#[struct-25]
 -- Struct field in IN subquery
 SELECT "T"."col_struct_nested"."level1_col_struct"."level2_col_int" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_struct_simple"."level1_col_int" IN (SELECT "T2"."col_struct_nested"."level1_col_struct"."level2_col_int" FROM "default"."T_ALL_TYPES" AS "T2");
 
@@ -166,18 +146,18 @@ SELECT "T"."col_struct_nested"."level1_col_struct"."level2_col_int" FROM "defaul
 --  Struct construction with real values
 -- ----------------------------------------
 
---#[struct-30]
+--#[struct-26]
 -- Construct struct with mixed literal types
 SELECT OBJECT('count', 42, 'rate', 3.14, 'message', 'hello', 'enabled', false) AS "config" FROM "default"."T_ALL_TYPES" AS "T";
 
---#[struct-31]
+--#[struct-27]
 -- Construct nested struct with literal values
 SELECT OBJECT('user', OBJECT('id', 100, 'email', 'test@example.com'), 'timestamp', '2023-01-01T00:00:00Z') AS "record" FROM "default"."T_ALL_TYPES" AS "T";
 
---#[struct-32]
+--#[struct-28]
 -- Construct struct with null values
 SELECT OBJECT('value', 123, 'optional_field', NULL, 'description', 'test') AS "data" FROM "default"."T_ALL_TYPES" AS "T";
 
---#[struct-33]
+--#[struct-29]
 -- Construct struct with arithmetic expressions
 SELECT OBJECT('sum', 10 + 5, 'product', 3 * 7, 'ratio', 100.0 / CAST(4 AS DECIMAL(10,0))) AS "calculations" FROM "default"."T_ALL_TYPES" AS "T";

--- a/src/test/resources/outputs/redshift/basics/struct.sql
+++ b/src/test/resources/outputs/redshift/basics/struct.sql
@@ -1,0 +1,183 @@
+-- ----------------------------------------
+--  Select struct columns
+-- ----------------------------------------
+
+--#[struct-00]
+-- Select a simple struct column
+SELECT "T"."col_struct_simple" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-01]
+-- Select a nested struct column
+SELECT "T"."col_struct_nested" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-02]
+-- Select both struct columns
+SELECT "T"."col_struct_simple", "T"."col_struct_nested" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-03]
+-- Select struct alongside scalar columns
+SELECT "T"."col_int32", "T"."col_string", "T"."col_struct_simple" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Path navigation — simple struct
+-- ----------------------------------------
+
+--#[struct-04]
+-- Access a field of a simple struct
+SELECT "T"."col_struct_simple"."level1_col_int" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-05]
+-- Access multiple fields of a simple struct
+SELECT "T"."col_struct_simple"."level1_col_int", "T"."col_struct_simple"."level1_col_string" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-06]
+-- Access all fields of a simple struct
+SELECT "T"."col_struct_simple"."level1_col_int", "T"."col_struct_simple"."level1_col_double", "T"."col_struct_simple"."level1_col_string", "T"."col_struct_simple"."level1_col_timestamp" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Path navigation — nested struct
+-- ----------------------------------------
+
+-- Single field access on nested struct (e.g. T.col_struct_nested.level1_col_int) covered by struct-04 pattern
+
+--#[struct-07]
+-- Access the nested struct itself
+SELECT "T"."col_struct_nested"."level1_col_struct" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-08]
+-- Access a field within the nested struct (2-level path)
+SELECT "T"."col_struct_nested"."level1_col_struct"."level2_col_int" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-09]
+-- Access multiple fields within the nested struct
+SELECT "T"."col_struct_nested"."level1_col_struct"."level2_col_int", "T"."col_struct_nested"."level1_col_struct"."level2_col_string" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-10]
+-- Mix top-level and nested field access
+SELECT "T"."col_struct_nested"."level1_col_int", "T"."col_struct_nested"."level1_col_struct"."level2_col_double" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Struct wildcard (dot-star)
+-- ----------------------------------------
+
+--#[struct-11]
+-- Wildcard on simple struct
+SELECT "T"."col_struct_simple"."level1_col_int", "T"."col_struct_simple"."level1_col_double", "T"."col_struct_simple"."level1_col_string", "T"."col_struct_simple"."level1_col_timestamp" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-12]
+-- Wildcard on nested struct
+SELECT "T"."col_struct_nested"."level1_col_int", "T"."col_struct_nested"."level1_col_double", "T"."col_struct_nested"."level1_col_string", "T"."col_struct_nested"."level1_col_timestamp", "T"."col_struct_nested"."level1_col_struct" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-13]
+-- Wildcard on inner nested struct
+SELECT "T"."col_struct_nested"."level1_col_struct"."level2_col_int", "T"."col_struct_nested"."level1_col_struct"."level2_col_double", "T"."col_struct_nested"."level1_col_struct"."level2_col_string", "T"."col_struct_nested"."level1_col_struct"."level2_col_timestamp" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-14]
+-- Wildcard with other columns
+SELECT "T"."col_int32", "T"."col_struct_simple"."level1_col_int", "T"."col_struct_simple"."level1_col_double", "T"."col_struct_simple"."level1_col_string", "T"."col_struct_simple"."level1_col_timestamp" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Struct construction in SELECT
+-- ----------------------------------------
+
+--#[struct-15]
+-- Construct a struct literal in SELECT
+SELECT OBJECT('a', "T"."col_int32", 'b', "T"."col_string") AS "constructed" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-16]
+-- Construct a struct from struct fields
+SELECT OBJECT('x', "T"."col_struct_simple"."level1_col_int", 'y', "T"."col_struct_simple"."level1_col_string") AS "constructed" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-17]
+-- Construct a nested struct literal
+SELECT OBJECT('outer', OBJECT('inner_val', "T"."col_struct_nested"."level1_col_struct"."level2_col_int")) AS "constructed" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Filtering on struct fields
+-- ----------------------------------------
+
+--#[struct-18]
+-- WHERE on a simple struct field
+SELECT "T"."col_bool", "T"."col_int16", "T"."col_int32", "T"."col_int64", "T"."col_float32", "T"."col_float64", "T"."col_decimal", "T"."col_string", "T"."col_char", "T"."col_date", "T"."col_time", "T"."col_timez", "T"."col_timestamp", "T"."col_timestampz", "T"."col_blob", "T"."col_clob", "T"."col_list", "T"."col_bag", "T"."col_struct_simple", "T"."col_struct_nested", "T"."col_any" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_struct_simple"."level1_col_int" > 10;
+
+--#[struct-19]
+-- WHERE on a nested struct field
+SELECT "T"."col_bool", "T"."col_int16", "T"."col_int32", "T"."col_int64", "T"."col_float32", "T"."col_float64", "T"."col_decimal", "T"."col_string", "T"."col_char", "T"."col_date", "T"."col_time", "T"."col_timez", "T"."col_timestamp", "T"."col_timestampz", "T"."col_blob", "T"."col_clob", "T"."col_list", "T"."col_bag", "T"."col_struct_simple", "T"."col_struct_nested", "T"."col_any" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_struct_nested"."level1_col_struct"."level2_col_string" = 'hello';
+
+--#[struct-20]
+-- WHERE with multiple struct field conditions
+SELECT "T"."col_bool", "T"."col_int16", "T"."col_int32", "T"."col_int64", "T"."col_float32", "T"."col_float64", "T"."col_decimal", "T"."col_string", "T"."col_char", "T"."col_date", "T"."col_time", "T"."col_timez", "T"."col_timestamp", "T"."col_timestampz", "T"."col_blob", "T"."col_clob", "T"."col_list", "T"."col_bag", "T"."col_struct_simple", "T"."col_struct_nested", "T"."col_any" FROM "default"."T_ALL_TYPES" AS "T" WHERE ("T"."col_struct_simple"."level1_col_int" > 0) AND ("T"."col_struct_nested"."level1_col_double" < 100.0);
+
+--#[struct-21]
+-- IS NULL check on struct field
+SELECT "T"."col_bool", "T"."col_int16", "T"."col_int32", "T"."col_int64", "T"."col_float32", "T"."col_float64", "T"."col_decimal", "T"."col_string", "T"."col_char", "T"."col_date", "T"."col_time", "T"."col_timez", "T"."col_timestamp", "T"."col_timestampz", "T"."col_blob", "T"."col_clob", "T"."col_list", "T"."col_bag", "T"."col_struct_simple", "T"."col_struct_nested", "T"."col_any" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_struct_simple"."level1_col_string" IS NULL;
+
+--#[struct-22]
+-- IS NOT NULL check on nested struct field
+SELECT "T"."col_bool", "T"."col_int16", "T"."col_int32", "T"."col_int64", "T"."col_float32", "T"."col_float64", "T"."col_decimal", "T"."col_string", "T"."col_char", "T"."col_date", "T"."col_time", "T"."col_timez", "T"."col_timestamp", "T"."col_timestampz", "T"."col_blob", "T"."col_clob", "T"."col_list", "T"."col_bag", "T"."col_struct_simple", "T"."col_struct_nested", "T"."col_any" FROM "default"."T_ALL_TYPES" AS "T" WHERE CAST("T"."col_struct_nested"."level1_col_struct"."level2_col_timestamp" AS TIMESTAMP) IS NOT NULL;
+
+-- ----------------------------------------
+--  Aliasing struct fields
+-- ----------------------------------------
+
+-- Single alias on struct path (e.g. T.col_struct_simple.level1_col_int AS x) covered by struct-04 pattern
+
+--#[struct-23]
+-- Alias multiple struct paths at different nesting levels
+SELECT "T"."col_struct_simple"."level1_col_int" AS "s_int", "T"."col_struct_nested"."level1_col_struct"."level2_col_string" AS "n_str" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Struct fields in ORDER BY / GROUP BY
+-- ----------------------------------------
+
+--#[struct-24]
+-- ORDER BY a struct field
+SELECT "T"."col_struct_simple"."level1_col_int", "T"."col_string" FROM "default"."T_ALL_TYPES" AS "T" ORDER BY "T"."col_struct_simple"."level1_col_int" ASC NULLS LAST;
+
+--#[struct-25]
+-- GROUP BY a struct field
+SELECT "T"."col_struct_simple"."level1_col_string", count(1) AS "cnt" FROM "default"."T_ALL_TYPES" AS "T" GROUP BY "T"."col_struct_simple"."level1_col_string";
+
+-- ----------------------------------------
+--  Struct with JOIN
+-- ----------------------------------------
+
+--#[struct-26]
+-- Join on struct fields
+SELECT "t1"."col_struct_simple"."level1_col_int", "T2"."col_struct_nested"."level1_col_string" FROM "default"."T_ALL_TYPES" AS "t1" INNER JOIN "default"."T_ALL_TYPES" AS "T2" ON "t1"."col_struct_simple"."level1_col_int" = "T2"."col_struct_nested"."level1_col_int";
+
+--#[struct-27]
+-- Left join with nested struct field in condition
+SELECT "t1"."col_struct_simple", "T2"."col_struct_nested"."level1_col_struct"."level2_col_int" FROM "default"."T_ALL_TYPES" AS "t1" LEFT JOIN "default"."T_ALL_TYPES" AS "T2" ON "t1"."col_struct_simple"."level1_col_string" = "T2"."col_struct_nested"."level1_col_struct"."level2_col_string";
+
+-- ----------------------------------------
+--  Struct in subquery
+-- ----------------------------------------
+
+--#[struct-28]
+-- Subquery selecting struct fields
+SELECT "T"."col_struct_simple"."level1_col_int" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_struct_simple"."level1_col_int" > (SELECT "T2"."col_struct_nested"."level1_col_struct"."level2_col_int" FROM "default"."T_ALL_TYPES" AS "T2" WHERE "T2"."col_struct_nested"."level1_col_struct"."level2_col_int" = 1);
+
+--#[struct-29]
+-- Struct field in IN subquery
+SELECT "T"."col_struct_nested"."level1_col_struct"."level2_col_int" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_struct_simple"."level1_col_int" IN (SELECT "T2"."col_struct_nested"."level1_col_struct"."level2_col_int" FROM "default"."T_ALL_TYPES" AS "T2");
+
+-- ----------------------------------------
+--  Struct construction with real values
+-- ----------------------------------------
+
+--#[struct-30]
+-- Construct struct with mixed literal types
+SELECT OBJECT('count', 42, 'rate', 3.14, 'message', 'hello', 'enabled', false) AS "config" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-31]
+-- Construct nested struct with literal values
+SELECT OBJECT('user', OBJECT('id', 100, 'email', 'test@example.com'), 'timestamp', '2023-01-01T00:00:00Z') AS "record" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-32]
+-- Construct struct with null values
+SELECT OBJECT('value', 123, 'optional_field', NULL, 'description', 'test') AS "data" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-33]
+-- Construct struct with arithmetic expressions
+SELECT OBJECT('sum', 10 + 5, 'product', 3 * 7, 'ratio', 100.0 / CAST(4 AS DECIMAL(10,0))) AS "calculations" FROM "default"."T_ALL_TYPES" AS "T";

--- a/src/test/resources/outputs/redshift/basics/struct.sql
+++ b/src/test/resources/outputs/redshift/basics/struct.sql
@@ -161,3 +161,20 @@ SELECT OBJECT('value', 123, 'optional_field', NULL, 'description', 'test') AS "d
 --#[struct-29]
 -- Construct struct with arithmetic expressions
 SELECT OBJECT('sum', 10 + 5, 'product', 3 * 7, 'ratio', 100.0 / CAST(4 AS DECIMAL(10,0))) AS "calculations" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Access field in constructed struct
+-- Skip as Redshift does not support field access on constructed structs.
+-- ----------------------------------------
+
+-- --#[struct-30]
+-- -- Access field from a constructed struct
+-- SELECT OBJECT('a', "T"."col_int32", 'b', "T"."col_string")."a" AS "a_val" FROM "default"."T_ALL_TYPES" AS "T";
+--
+-- --#[struct-31]
+-- -- Access field from a struct constructed from struct fields
+-- SELECT OBJECT('x', "T"."col_struct_simple"."level1_col_int", 'y', "T"."col_struct_simple"."level1_col_string")."y" AS "y_val" FROM "default"."T_ALL_TYPES" AS "T";
+--
+-- --#[struct-32]
+-- -- Access nested field from a constructed nested struct
+-- SELECT OBJECT('outer', OBJECT('inner_val', "T"."col_struct_nested"."level1_col_struct"."level2_col_int"))."outer"."inner_val" FROM "default"."T_ALL_TYPES" AS "T";

--- a/src/test/resources/outputs/spark/basics/exclude.sql
+++ b/src/test/resources/outputs/spark/basics/exclude.sql
@@ -35,7 +35,7 @@ SELECT `t1`.`flds` AS `flds`, NAMED_STRUCT('a', `t2`.`flds`.`a`, 'c', NAMED_STRU
 
 --#[exclude-10]
 -- EXCLUDE with multiple JOIN and WHERE clause
-SELECT NAMED_STRUCT('b', NAMED_STRUCT('field_x', `t1`.`flds`.`b`.`field_x`, 'field_y', `t1`.`flds`.`b`.`field_y`), 'c', NAMED_STRUCT('field_x', `t1`.`flds`.`c`.`field_x`, 'field_y', `t1`.`flds`.`c`.`field_y`)) AS `flds`, `t1`.`foo` AS `foo`, NAMED_STRUCT('a', NAMED_STRUCT('field_x', `t2`.`flds`.`a`.`field_x`, 'field_y', `t2`.`flds`.`a`.`field_y`), 'c', NAMED_STRUCT('field_x', `t2`.`flds`.`c`.`field_x`, 'field_y', `t2`.`flds`.`c`.`field_y`)) AS `flds`, `t2`.`foo` AS `foo`, NAMED_STRUCT('a', NAMED_STRUCT('field_x', `t3`.`flds`.`a`.`field_x`, 'field_y', `t3`.`flds`.`a`.`field_y`), 'b', NAMED_STRUCT('field_x', `t3`.`flds`.`b`.`field_x`, 'field_y', `t3`.`flds`.`b`.`field_y`)) AS `flds`, `t3`.`foo` AS `foo` FROM `default`.`EXCLUDE_T` AS `t1` INNER JOIN `default`.`EXCLUDE_T` AS `t2` ON true INNER JOIN `default`.`EXCLUDE_T` AS `t3` ON true WHERE (`t1`.`foo` = `t2`.`foo`) AND (`t2`.`foo` = `t3`.`foo`);
+SELECT NAMED_STRUCT('b', `t1`.`flds`.`b`, 'c', `t1`.`flds`.`c`) AS `flds`, `t1`.`foo` AS `foo`, NAMED_STRUCT('a', `t2`.`flds`.`a`, 'c', `t2`.`flds`.`c`) AS `flds`, `t2`.`foo` AS `foo`, NAMED_STRUCT('a', `t3`.`flds`.`a`, 'b', `t3`.`flds`.`b`) AS `flds`, `t3`.`foo` AS `foo` FROM `default`.`EXCLUDE_T` AS `t1` INNER JOIN `default`.`EXCLUDE_T` AS `t2` ON true INNER JOIN `default`.`EXCLUDE_T` AS `t3` ON true WHERE (`t1`.`foo` = `t2`.`foo`) AND (`t2`.`foo` = `t3`.`foo`);
 
 --#[exclude-11]
 -- EXCLUDE with select projection list and multiple JOINs

--- a/src/test/resources/outputs/spark/basics/exclude.sql
+++ b/src/test/resources/outputs/spark/basics/exclude.sql
@@ -5,16 +5,16 @@ SELECT `t`.`flds` AS `flds` FROM `default`.`EXCLUDE_T` AS `t`;
 SELECT `t`.`foo` AS `foo` FROM `default`.`EXCLUDE_T` AS `t`;
 
 --#[exclude-02]
-SELECT STRUCT(`t`.`flds`.`a` AS `a`, `t`.`flds`.`c` AS `c`) AS `flds`, `t`.`foo` AS `foo` FROM `default`.`EXCLUDE_T` AS `t`;
+SELECT NAMED_STRUCT('a', `t`.`flds`.`a`, 'c', `t`.`flds`.`c`) AS `flds`, `t`.`foo` AS `foo` FROM `default`.`EXCLUDE_T` AS `t`;
 
 --#[exclude-03]
-SELECT STRUCT(`t`.`flds`.`a` AS `a`, `t`.`flds`.`b` AS `b`, STRUCT(`t`.`flds`.`c`.`field_y` AS `field_y`) AS `c`) AS `flds`, `t`.`foo` AS `foo` FROM `default`.`EXCLUDE_T` AS `t`;
+SELECT NAMED_STRUCT('a', `t`.`flds`.`a`, 'b', `t`.`flds`.`b`, 'c', NAMED_STRUCT('field_y', `t`.`flds`.`c`.`field_y`)) AS `flds`, `t`.`foo` AS `foo` FROM `default`.`EXCLUDE_T` AS `t`;
 
 --#[exclude-04]
-SELECT STRUCT(`t`.`flds`.`a` AS `a`, STRUCT(`t`.`flds`.`c`.`field_y` AS `field_y`) AS `c`) AS `flds`, `t`.`foo` AS `foo` FROM `default`.`EXCLUDE_T` AS `t`;
+SELECT NAMED_STRUCT('a', `t`.`flds`.`a`, 'c', NAMED_STRUCT('field_y', `t`.`flds`.`c`.`field_y`)) AS `flds`, `t`.`foo` AS `foo` FROM `default`.`EXCLUDE_T` AS `t`;
 
 --#[exclude-05]
-SELECT STRUCT(`t`.`flds`.`a` AS `a`, `t`.`flds`.`b` AS `b`, STRUCT(`t`.`flds`.`c`.`field_x` AS `field_x`) AS `c`) AS `flds`, `t`.`foo` AS `foo` FROM `default`.`EXCLUDE_T` AS `t`;
+SELECT NAMED_STRUCT('a', `t`.`flds`.`a`, 'b', `t`.`flds`.`b`, 'c', NAMED_STRUCT('field_x', `t`.`flds`.`c`.`field_x`)) AS `flds`, `t`.`foo` AS `foo` FROM `default`.`EXCLUDE_T` AS `t`;
 
 -- --#[exclude-06]
 -- Exclude all the fields of `t.flds.c`; Spark support for empty structs is confusing and varies across versions.
@@ -24,22 +24,22 @@ SELECT STRUCT(`t`.`flds`.`a` AS `a`, `t`.`flds`.`b` AS `b`, STRUCT(`t`.`flds`.`c
 
 -- START OF EXCLUDE with COLLECTION WILDCARD
 --#[exclude-07]
-SELECT `transform`(`t`.`a`, `___coll_wildcard___` -> STRUCT(`___coll_wildcard___`.`field_y` AS `field_y`)) AS `a`, `t`.`foo` AS `foo` FROM `default`.`EXCLUDE_T_COLL_WILDCARD` AS `t`;
+SELECT `transform`(`t`.`a`, `___coll_wildcard___` -> NAMED_STRUCT('field_y', `___coll_wildcard___`.`field_y`)) AS `a`, `t`.`foo` AS `foo` FROM `default`.`EXCLUDE_T_COLL_WILDCARD` AS `t`;
 
 --#[exclude-08]
-SELECT `transform`(`t`.`a`, `___coll_wildcard___` -> STRUCT(`___coll_wildcard___`.`field_x` AS `field_x`)) AS `a`, `t`.`foo` AS `foo` FROM `default`.`EXCLUDE_T_COLL_WILDCARD` AS `t`;
+SELECT `transform`(`t`.`a`, `___coll_wildcard___` -> NAMED_STRUCT('field_x', `___coll_wildcard___`.`field_x`)) AS `a`, `t`.`foo` AS `foo` FROM `default`.`EXCLUDE_T_COLL_WILDCARD` AS `t`;
 
 --#[exclude-09]
 -- EXCLUDE with JOIN and WHERE clause
-SELECT `t1`.`flds` AS `flds`, STRUCT(`t2`.`flds`.`a` AS `a`, STRUCT(`t2`.`flds`.`c`.`field_y` AS `field_y`) AS `c`) AS `flds`, `t2`.`foo` AS `foo` FROM `default`.`EXCLUDE_T` AS `t1` INNER JOIN `default`.`EXCLUDE_T` AS `t2` ON true WHERE `t1`.`foo` = `t2`.`foo`;
+SELECT `t1`.`flds` AS `flds`, NAMED_STRUCT('a', `t2`.`flds`.`a`, 'c', NAMED_STRUCT('field_y', `t2`.`flds`.`c`.`field_y`)) AS `flds`, `t2`.`foo` AS `foo` FROM `default`.`EXCLUDE_T` AS `t1` INNER JOIN `default`.`EXCLUDE_T` AS `t2` ON true WHERE `t1`.`foo` = `t2`.`foo`;
 
 --#[exclude-10]
 -- EXCLUDE with multiple JOIN and WHERE clause
-SELECT STRUCT(STRUCT(`t1`.`flds`.`b`.`field_x` AS `field_x`, `t1`.`flds`.`b`.`field_y` AS `field_y`) AS `b`, STRUCT(`t1`.`flds`.`c`.`field_x` AS `field_x`, `t1`.`flds`.`c`.`field_y` AS `field_y`) AS `c`) AS `flds`, `t1`.`foo` AS `foo`, STRUCT(STRUCT(`t2`.`flds`.`a`.`field_x` AS `field_x`, `t2`.`flds`.`a`.`field_y` AS `field_y`) AS `a`, STRUCT(`t2`.`flds`.`c`.`field_x` AS `field_x`, `t2`.`flds`.`c`.`field_y` AS `field_y`) AS `c`) AS `flds`, `t2`.`foo` AS `foo`, STRUCT(STRUCT(`t3`.`flds`.`a`.`field_x` AS `field_x`, `t3`.`flds`.`a`.`field_y` AS `field_y`) AS `a`, STRUCT(`t3`.`flds`.`b`.`field_x` AS `field_x`, `t3`.`flds`.`b`.`field_y` AS `field_y`) AS `b`) AS `flds`, `t3`.`foo` AS `foo` FROM `default`.`EXCLUDE_T` AS `t1` INNER JOIN `default`.`EXCLUDE_T` AS `t2` ON true INNER JOIN `default`.`EXCLUDE_T` AS `t3` ON true WHERE (`t1`.`foo` = `t2`.`foo`) AND (`t2`.`foo` = `t3`.`foo`)
+SELECT NAMED_STRUCT('b', NAMED_STRUCT('field_x', `t1`.`flds`.`b`.`field_x`, 'field_y', `t1`.`flds`.`b`.`field_y`), 'c', NAMED_STRUCT('field_x', `t1`.`flds`.`c`.`field_x`, 'field_y', `t1`.`flds`.`c`.`field_y`)) AS `flds`, `t1`.`foo` AS `foo`, NAMED_STRUCT('a', NAMED_STRUCT('field_x', `t2`.`flds`.`a`.`field_x`, 'field_y', `t2`.`flds`.`a`.`field_y`), 'c', NAMED_STRUCT('field_x', `t2`.`flds`.`c`.`field_x`, 'field_y', `t2`.`flds`.`c`.`field_y`)) AS `flds`, `t2`.`foo` AS `foo`, NAMED_STRUCT('a', NAMED_STRUCT('field_x', `t3`.`flds`.`a`.`field_x`, 'field_y', `t3`.`flds`.`a`.`field_y`), 'b', NAMED_STRUCT('field_x', `t3`.`flds`.`b`.`field_x`, 'field_y', `t3`.`flds`.`b`.`field_y`)) AS `flds`, `t3`.`foo` AS `foo` FROM `default`.`EXCLUDE_T` AS `t1` INNER JOIN `default`.`EXCLUDE_T` AS `t2` ON true INNER JOIN `default`.`EXCLUDE_T` AS `t3` ON true WHERE (`t1`.`foo` = `t2`.`foo`) AND (`t2`.`foo` = `t3`.`foo`);
 
 --#[exclude-11]
 -- EXCLUDE with select projection list and multiple JOINs
-SELECT STRUCT(`t1`.`flds`.`b` AS `b`, `t1`.`flds`.`c` AS `c`) AS `flds`, STRUCT(`t2`.`flds`.`a` AS `a`, `t2`.`flds`.`c` AS `c`) AS `flds`, STRUCT(`t3`.`flds`.`a` AS `a`, `t3`.`flds`.`b` AS `b`) AS `flds` FROM `default`.`EXCLUDE_T` AS `t1` INNER JOIN `default`.`EXCLUDE_T` AS `t2` ON true INNER JOIN `default`.`EXCLUDE_T` AS `t3` ON true WHERE (`t1`.`foo` = `t2`.`foo`) AND (`t2`.`foo` = `t3`.`foo`);
+SELECT NAMED_STRUCT('b', `t1`.`flds`.`b`, 'c', `t1`.`flds`.`c`) AS `flds`, NAMED_STRUCT('a', `t2`.`flds`.`a`, 'c', `t2`.`flds`.`c`) AS `flds`, NAMED_STRUCT('a', `t3`.`flds`.`a`, 'b', `t3`.`flds`.`b`) AS `flds` FROM `default`.`EXCLUDE_T` AS `t1` INNER JOIN `default`.`EXCLUDE_T` AS `t2` ON true INNER JOIN `default`.`EXCLUDE_T` AS `t3` ON true WHERE (`t1`.`foo` = `t2`.`foo`) AND (`t2`.`foo` = `t3`.`foo`);
 
 -- Tests for EXCLUDE on top-level columns only --
 -- Baseline query without `EXCLUDE`
@@ -104,16 +104,16 @@ WHERE `t1`.`a` AND `t2`.`a`;
 
 --#[exclude-49]
 -- Exclude two nested fields; same transpiled query (other than table name) as #[exclude-04]
-SELECT STRUCT(`t`.`flds`.`a` AS `a`, STRUCT(`t`.`flds`.`c`.`field_y` AS `field_y`) AS `c`) AS `flds`, `t`.`foo` AS `foo` FROM `default`.`EXCLUDE_T` AS `t`;
+SELECT NAMED_STRUCT('a', `t`.`flds`.`a`, 'c', NAMED_STRUCT('field_y', `t`.`flds`.`c`.`field_y`)) AS `flds`, `t`.`foo` AS `foo` FROM `default`.`EXCLUDE_T` AS `t`;
 
 --#[exclude-50]
-SELECT `transform`(`t`.`a`, `___coll_wildcard___` -> STRUCT(`___coll_wildcard___`.`field_y` AS `field_y`, `___coll_wildcard___`.`field_z` AS `field_z`, `___coll_wildcard___`.`nested_list` AS `nested_list`)) AS `a`, `t`.`foo` AS `foo` FROM `default`.`EXCLUDE_T_NESTED_LIST` AS `t`;
+SELECT `transform`(`t`.`a`, `___coll_wildcard___` -> NAMED_STRUCT('field_y', `___coll_wildcard___`.`field_y`, 'field_z', `___coll_wildcard___`.`field_z`, 'nested_list', `___coll_wildcard___`.`nested_list`)) AS `a`, `t`.`foo` AS `foo` FROM `default`.`EXCLUDE_T_NESTED_LIST` AS `t`;
 
 --#[exclude-51]
-SELECT `transform`(`t`.`a`, `___coll_wildcard___` -> STRUCT(`___coll_wildcard___`.`field_x` AS `field_x`, `___coll_wildcard___`.`field_z` AS `field_z`, `___coll_wildcard___`.`nested_list` AS `nested_list`)) AS `a`, `t`.`foo` AS `foo` FROM `default`.`EXCLUDE_T_NESTED_LIST` AS `t`;
+SELECT `transform`(`t`.`a`, `___coll_wildcard___` -> NAMED_STRUCT('field_x', `___coll_wildcard___`.`field_x`, 'field_z', `___coll_wildcard___`.`field_z`, 'nested_list', `___coll_wildcard___`.`nested_list`)) AS `a`, `t`.`foo` AS `foo` FROM `default`.`EXCLUDE_T_NESTED_LIST` AS `t`;
 
 --#[exclude-52]
-SELECT `transform`(`t`.`a`, `___coll_wildcard___` -> STRUCT(`___coll_wildcard___`.`field_x` AS `field_x`, `___coll_wildcard___`.`field_y` AS `field_y`, `___coll_wildcard___`.`nested_list` AS `nested_list`)) AS `a`, `t`.`foo` AS `foo` FROM `default`.`EXCLUDE_T_NESTED_LIST` AS `t`;
+SELECT `transform`(`t`.`a`, `___coll_wildcard___` -> NAMED_STRUCT('field_x', `___coll_wildcard___`.`field_x`, 'field_y', `___coll_wildcard___`.`field_y`, 'nested_list', `___coll_wildcard___`.`nested_list`)) AS `a`, `t`.`foo` AS `foo` FROM `default`.`EXCLUDE_T_NESTED_LIST` AS `t`;
 
 --#[exclude-53]
-SELECT `transform`(`t`.`a`, `___coll_wildcard___` -> STRUCT(`___coll_wildcard___`.`field_x` AS `field_x`, `___coll_wildcard___`.`field_y` AS `field_y`, `___coll_wildcard___`.`field_z` AS `field_z`)) AS `a`, `t`.`foo` AS `foo` FROM `default`.`EXCLUDE_T_NESTED_LIST` AS `t`;
+SELECT `transform`(`t`.`a`, `___coll_wildcard___` -> NAMED_STRUCT('field_x', `___coll_wildcard___`.`field_x`, 'field_y', `___coll_wildcard___`.`field_y`, 'field_z', `___coll_wildcard___`.`field_z`)) AS `a`, `t`.`foo` AS `foo` FROM `default`.`EXCLUDE_T_NESTED_LIST` AS `t`;

--- a/src/test/resources/outputs/spark/basics/struct.sql
+++ b/src/test/resources/outputs/spark/basics/struct.sql
@@ -1,0 +1,183 @@
+-- ----------------------------------------
+--  Select struct columns
+-- ----------------------------------------
+
+--#[struct-00]
+-- Select a simple struct column
+SELECT `T`.`col_struct_simple` AS `col_struct_simple` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[struct-01]
+-- Select a nested struct column
+SELECT `T`.`col_struct_nested` AS `col_struct_nested` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[struct-02]
+-- Select both struct columns
+SELECT `T`.`col_struct_simple` AS `col_struct_simple`, `T`.`col_struct_nested` AS `col_struct_nested` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[struct-03]
+-- Select struct alongside scalar columns
+SELECT `T`.`col_int32` AS `col_int32`, `T`.`col_string` AS `col_string`, `T`.`col_struct_simple` AS `col_struct_simple` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+-- ----------------------------------------
+--  Path navigation — simple struct
+-- ----------------------------------------
+
+--#[struct-04]
+-- Access a field of a simple struct
+SELECT `T`.`col_struct_simple`.`level1_col_int` AS `level1_col_int` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[struct-05]
+-- Access multiple fields of a simple struct
+SELECT `T`.`col_struct_simple`.`level1_col_int` AS `level1_col_int`, `T`.`col_struct_simple`.`level1_col_string` AS `level1_col_string` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[struct-06]
+-- Access all fields of a simple struct
+SELECT `T`.`col_struct_simple`.`level1_col_int` AS `level1_col_int`, `T`.`col_struct_simple`.`level1_col_double` AS `level1_col_double`, `T`.`col_struct_simple`.`level1_col_string` AS `level1_col_string`, `T`.`col_struct_simple`.`level1_col_timestamp` AS `level1_col_timestamp` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+-- ----------------------------------------
+--  Path navigation — nested struct
+-- ----------------------------------------
+
+-- Single field access on nested struct (e.g. T.col_struct_nested.level1_col_int) covered by struct-04 pattern
+
+--#[struct-07]
+-- Access the nested struct itself
+SELECT `T`.`col_struct_nested`.`level1_col_struct` AS `level1_col_struct` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[struct-08]
+-- Access a field within the nested struct (2-level path)
+SELECT `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_int` AS `level2_col_int` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[struct-09]
+-- Access multiple fields within the nested struct
+SELECT `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_int` AS `level2_col_int`, `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_string` AS `level2_col_string` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[struct-10]
+-- Mix top-level and nested field access
+SELECT `T`.`col_struct_nested`.`level1_col_int` AS `level1_col_int`, `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_double` AS `level2_col_double` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+-- ----------------------------------------
+--  Struct wildcard (dot-star)
+-- ----------------------------------------
+
+--#[struct-11]
+-- Wildcard on simple struct
+SELECT `T`.`col_struct_simple`.`level1_col_int` AS `level1_col_int`, `T`.`col_struct_simple`.`level1_col_double` AS `level1_col_double`, `T`.`col_struct_simple`.`level1_col_string` AS `level1_col_string`, `T`.`col_struct_simple`.`level1_col_timestamp` AS `level1_col_timestamp` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[struct-12]
+-- Wildcard on nested struct
+SELECT `T`.`col_struct_nested`.`level1_col_int` AS `level1_col_int`, `T`.`col_struct_nested`.`level1_col_double` AS `level1_col_double`, `T`.`col_struct_nested`.`level1_col_string` AS `level1_col_string`, `T`.`col_struct_nested`.`level1_col_timestamp` AS `level1_col_timestamp`, `T`.`col_struct_nested`.`level1_col_struct` AS `level1_col_struct` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[struct-13]
+-- Wildcard on inner nested struct
+SELECT `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_int` AS `level2_col_int`, `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_double` AS `level2_col_double`, `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_string` AS `level2_col_string`, `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_timestamp` AS `level2_col_timestamp` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[struct-14]
+-- Wildcard with other columns
+SELECT `T`.`col_int32` AS `col_int32`, `T`.`col_struct_simple`.`level1_col_int` AS `level1_col_int`, `T`.`col_struct_simple`.`level1_col_double` AS `level1_col_double`, `T`.`col_struct_simple`.`level1_col_string` AS `level1_col_string`, `T`.`col_struct_simple`.`level1_col_timestamp` AS `level1_col_timestamp` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+-- ----------------------------------------
+--  Struct construction in SELECT
+-- ----------------------------------------
+
+--#[struct-15]
+-- Construct a struct literal in SELECT
+SELECT NAMED_STRUCT('a', `T`.`col_int32`, 'b', `T`.`col_string`) AS `constructed` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[struct-16]
+-- Construct a struct from struct fields
+SELECT NAMED_STRUCT('x', `T`.`col_struct_simple`.`level1_col_int`, 'y', `T`.`col_struct_simple`.`level1_col_string`) AS `constructed` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[struct-17]
+-- Construct a nested struct literal
+SELECT NAMED_STRUCT('outer', NAMED_STRUCT('inner_val', `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_int`)) AS `constructed` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+-- ----------------------------------------
+--  Filtering on struct fields
+-- ----------------------------------------
+
+--#[struct-18]
+-- WHERE on a simple struct field
+SELECT `T`.`col_bool` AS `col_bool`, `T`.`col_int16` AS `col_int16`, `T`.`col_int32` AS `col_int32`, `T`.`col_int64` AS `col_int64`, `T`.`col_float32` AS `col_float32`, `T`.`col_float64` AS `col_float64`, `T`.`col_decimal` AS `col_decimal`, `T`.`col_string` AS `col_string`, `T`.`col_char` AS `col_char`, `T`.`col_date` AS `col_date`, `T`.`col_time` AS `col_time`, `T`.`col_timez` AS `col_timez`, `T`.`col_timestamp` AS `col_timestamp`, `T`.`col_timestampz` AS `col_timestampz`, `T`.`col_blob` AS `col_blob`, `T`.`col_clob` AS `col_clob`, `T`.`col_list` AS `col_list`, `T`.`col_bag` AS `col_bag`, `T`.`col_struct_simple` AS `col_struct_simple`, `T`.`col_struct_nested` AS `col_struct_nested`, `T`.`col_any` AS `col_any` FROM `default`.`T_ALL_TYPES` AS `T` WHERE `T`.`col_struct_simple`.`level1_col_int` > 10;
+
+--#[struct-19]
+-- WHERE on a nested struct field
+SELECT `T`.`col_bool` AS `col_bool`, `T`.`col_int16` AS `col_int16`, `T`.`col_int32` AS `col_int32`, `T`.`col_int64` AS `col_int64`, `T`.`col_float32` AS `col_float32`, `T`.`col_float64` AS `col_float64`, `T`.`col_decimal` AS `col_decimal`, `T`.`col_string` AS `col_string`, `T`.`col_char` AS `col_char`, `T`.`col_date` AS `col_date`, `T`.`col_time` AS `col_time`, `T`.`col_timez` AS `col_timez`, `T`.`col_timestamp` AS `col_timestamp`, `T`.`col_timestampz` AS `col_timestampz`, `T`.`col_blob` AS `col_blob`, `T`.`col_clob` AS `col_clob`, `T`.`col_list` AS `col_list`, `T`.`col_bag` AS `col_bag`, `T`.`col_struct_simple` AS `col_struct_simple`, `T`.`col_struct_nested` AS `col_struct_nested`, `T`.`col_any` AS `col_any` FROM `default`.`T_ALL_TYPES` AS `T` WHERE `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_string` = 'hello';
+
+--#[struct-20]
+-- WHERE with multiple struct field conditions
+SELECT `T`.`col_bool` AS `col_bool`, `T`.`col_int16` AS `col_int16`, `T`.`col_int32` AS `col_int32`, `T`.`col_int64` AS `col_int64`, `T`.`col_float32` AS `col_float32`, `T`.`col_float64` AS `col_float64`, `T`.`col_decimal` AS `col_decimal`, `T`.`col_string` AS `col_string`, `T`.`col_char` AS `col_char`, `T`.`col_date` AS `col_date`, `T`.`col_time` AS `col_time`, `T`.`col_timez` AS `col_timez`, `T`.`col_timestamp` AS `col_timestamp`, `T`.`col_timestampz` AS `col_timestampz`, `T`.`col_blob` AS `col_blob`, `T`.`col_clob` AS `col_clob`, `T`.`col_list` AS `col_list`, `T`.`col_bag` AS `col_bag`, `T`.`col_struct_simple` AS `col_struct_simple`, `T`.`col_struct_nested` AS `col_struct_nested`, `T`.`col_any` AS `col_any` FROM `default`.`T_ALL_TYPES` AS `T` WHERE (`T`.`col_struct_simple`.`level1_col_int` > 0) AND (`T`.`col_struct_nested`.`level1_col_double` < 100.0);
+
+--#[struct-21]
+-- IS NULL check on struct field
+SELECT `T`.`col_bool` AS `col_bool`, `T`.`col_int16` AS `col_int16`, `T`.`col_int32` AS `col_int32`, `T`.`col_int64` AS `col_int64`, `T`.`col_float32` AS `col_float32`, `T`.`col_float64` AS `col_float64`, `T`.`col_decimal` AS `col_decimal`, `T`.`col_string` AS `col_string`, `T`.`col_char` AS `col_char`, `T`.`col_date` AS `col_date`, `T`.`col_time` AS `col_time`, `T`.`col_timez` AS `col_timez`, `T`.`col_timestamp` AS `col_timestamp`, `T`.`col_timestampz` AS `col_timestampz`, `T`.`col_blob` AS `col_blob`, `T`.`col_clob` AS `col_clob`, `T`.`col_list` AS `col_list`, `T`.`col_bag` AS `col_bag`, `T`.`col_struct_simple` AS `col_struct_simple`, `T`.`col_struct_nested` AS `col_struct_nested`, `T`.`col_any` AS `col_any` FROM `default`.`T_ALL_TYPES` AS `T` WHERE `T`.`col_struct_simple`.`level1_col_string` IS NULL;
+
+--#[struct-22]
+-- IS NOT NULL check on nested struct field
+SELECT `T`.`col_bool` AS `col_bool`, `T`.`col_int16` AS `col_int16`, `T`.`col_int32` AS `col_int32`, `T`.`col_int64` AS `col_int64`, `T`.`col_float32` AS `col_float32`, `T`.`col_float64` AS `col_float64`, `T`.`col_decimal` AS `col_decimal`, `T`.`col_string` AS `col_string`, `T`.`col_char` AS `col_char`, `T`.`col_date` AS `col_date`, `T`.`col_time` AS `col_time`, `T`.`col_timez` AS `col_timez`, `T`.`col_timestamp` AS `col_timestamp`, `T`.`col_timestampz` AS `col_timestampz`, `T`.`col_blob` AS `col_blob`, `T`.`col_clob` AS `col_clob`, `T`.`col_list` AS `col_list`, `T`.`col_bag` AS `col_bag`, `T`.`col_struct_simple` AS `col_struct_simple`, `T`.`col_struct_nested` AS `col_struct_nested`, `T`.`col_any` AS `col_any` FROM `default`.`T_ALL_TYPES` AS `T` WHERE `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_timestamp` IS NOT NULL;
+
+-- ----------------------------------------
+--  Aliasing struct fields
+-- ----------------------------------------
+
+-- Single alias on struct path (e.g. T.col_struct_simple.level1_col_int AS x) covered by struct-04 pattern
+
+--#[struct-23]
+-- Alias multiple struct paths at different nesting levels
+SELECT `T`.`col_struct_simple`.`level1_col_int` AS `s_int`, `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_string` AS `n_str` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+-- ----------------------------------------
+--  Struct fields in ORDER BY / GROUP BY
+-- ----------------------------------------
+
+--#[struct-24]
+-- ORDER BY a struct field
+SELECT `T`.`col_struct_simple`.`level1_col_int` AS `level1_col_int`, `T`.`col_string` AS `col_string` FROM `default`.`T_ALL_TYPES` AS `T` ORDER BY `T`.`col_struct_simple`.`level1_col_int` ASC NULLS LAST;
+
+--#[struct-25]
+-- GROUP BY a struct field
+SELECT `T`.`col_struct_simple`.`level1_col_string` AS `level1_col_string`, `count`(1) AS `cnt` FROM `default`.`T_ALL_TYPES` AS `T` GROUP BY `T`.`col_struct_simple`.`level1_col_string`;
+
+-- ----------------------------------------
+--  Struct with JOIN
+-- ----------------------------------------
+
+--#[struct-26]
+-- Join on struct fields
+SELECT `t1`.`col_struct_simple`.`level1_col_int` AS `level1_col_int`, `T2`.`col_struct_nested`.`level1_col_string` AS `level1_col_string` FROM `default`.`T_ALL_TYPES` AS `t1` INNER JOIN `default`.`T_ALL_TYPES` AS `T2` ON `t1`.`col_struct_simple`.`level1_col_int` = `T2`.`col_struct_nested`.`level1_col_int`;
+
+--#[struct-27]
+-- Left join with nested struct field in condition
+SELECT `t1`.`col_struct_simple` AS `col_struct_simple`, `T2`.`col_struct_nested`.`level1_col_struct`.`level2_col_int` AS `level2_col_int` FROM `default`.`T_ALL_TYPES` AS `t1` LEFT JOIN `default`.`T_ALL_TYPES` AS `T2` ON `t1`.`col_struct_simple`.`level1_col_string` = `T2`.`col_struct_nested`.`level1_col_struct`.`level2_col_string`;
+
+-- ----------------------------------------
+--  Struct in subquery
+-- ----------------------------------------
+
+--#[struct-28]
+-- Subquery selecting struct fields
+SELECT `T`.`col_struct_simple`.`level1_col_int` AS `level1_col_int` FROM `default`.`T_ALL_TYPES` AS `T` WHERE `T`.`col_struct_simple`.`level1_col_int` > (SELECT `T2`.`col_struct_nested`.`level1_col_struct`.`level2_col_int` AS `level2_col_int` FROM `default`.`T_ALL_TYPES` AS `T2` WHERE `T2`.`col_struct_nested`.`level1_col_struct`.`level2_col_int` = 1);
+
+--#[struct-29]
+-- Struct field in IN subquery
+SELECT `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_int` AS `level2_col_int` FROM `default`.`T_ALL_TYPES` AS `T` WHERE `T`.`col_struct_simple`.`level1_col_int` IN (SELECT `T2`.`col_struct_nested`.`level1_col_struct`.`level2_col_int` AS `level2_col_int` FROM `default`.`T_ALL_TYPES` AS `T2`);
+
+-- ----------------------------------------
+--  Struct construction with real values
+-- ----------------------------------------
+
+--#[struct-30]
+-- Construct struct with mixed literal types
+SELECT NAMED_STRUCT('count', 42, 'rate', 3.14, 'message', 'hello', 'enabled', false) AS `config` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[struct-31]
+-- Construct nested struct with literal values
+SELECT NAMED_STRUCT('user', NAMED_STRUCT('id', 100, 'email', 'test@example.com'), 'timestamp', '2023-01-01T00:00:00Z') AS `record` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[struct-32]
+-- Construct struct with null values
+SELECT NAMED_STRUCT('value', 123, 'optional_field', NULL, 'description', 'test') AS `data` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[struct-33]
+-- Construct struct with arithmetic expressions
+SELECT NAMED_STRUCT('sum', 10 + 5, 'product', 3 * 7, 'ratio', 100.0 / CAST(4 AS DECIMAL(10,0))) AS `calculations` FROM `default`.`T_ALL_TYPES` AS `T`;

--- a/src/test/resources/outputs/spark/basics/struct.sql
+++ b/src/test/resources/outputs/spark/basics/struct.sql
@@ -161,3 +161,19 @@ SELECT NAMED_STRUCT('value', 123, 'optional_field', NULL, 'description', 'test')
 --#[struct-29]
 -- Construct struct with arithmetic expressions
 SELECT NAMED_STRUCT('sum', 10 + 5, 'product', 3 * 7, 'ratio', 100.0 / CAST(4 AS DECIMAL(10,0))) AS `calculations` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+-- ----------------------------------------
+--  Access field in constructed struct
+-- ----------------------------------------
+
+--#[struct-30]
+-- Access field from a constructed struct
+SELECT NAMED_STRUCT('a', `T`.`col_int32`, 'b', `T`.`col_string`).`a` AS `a_val` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[struct-31]
+-- Access field from a struct constructed from struct fields
+SELECT NAMED_STRUCT('x', `T`.`col_struct_simple`.`level1_col_int`, 'y', `T`.`col_struct_simple`.`level1_col_string`).`y` AS `y_val` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[struct-32]
+-- Access nested field from a constructed nested struct
+SELECT NAMED_STRUCT('outer', NAMED_STRUCT('inner_val', `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_int`)).`outer`.`inner_val` AS `inner_val` FROM `default`.`T_ALL_TYPES` AS `T`;

--- a/src/test/resources/outputs/spark/basics/struct.sql
+++ b/src/test/resources/outputs/spark/basics/struct.sql
@@ -11,26 +11,18 @@ SELECT `T`.`col_struct_simple` AS `col_struct_simple` FROM `default`.`T_ALL_TYPE
 SELECT `T`.`col_struct_nested` AS `col_struct_nested` FROM `default`.`T_ALL_TYPES` AS `T`;
 
 --#[struct-02]
--- Select both struct columns
-SELECT `T`.`col_struct_simple` AS `col_struct_simple`, `T`.`col_struct_nested` AS `col_struct_nested` FROM `default`.`T_ALL_TYPES` AS `T`;
-
---#[struct-03]
 -- Select struct alongside scalar columns
-SELECT `T`.`col_int32` AS `col_int32`, `T`.`col_string` AS `col_string`, `T`.`col_struct_simple` AS `col_struct_simple` FROM `default`.`T_ALL_TYPES` AS `T`;
+SELECT `T`.`col_int32` AS `col_int32`, `T`.`col_string` AS `col_string`, `T`.`col_struct_simple` AS `col_struct_simple`, `T`.`col_struct_nested` AS `col_struct_nested` FROM `default`.`T_ALL_TYPES` AS `T`;
 
 -- ----------------------------------------
 --  Path navigation — simple struct
 -- ----------------------------------------
 
---#[struct-04]
--- Access a field of a simple struct
-SELECT `T`.`col_struct_simple`.`level1_col_int` AS `level1_col_int` FROM `default`.`T_ALL_TYPES` AS `T`;
-
---#[struct-05]
+--#[struct-03]
 -- Access multiple fields of a simple struct
 SELECT `T`.`col_struct_simple`.`level1_col_int` AS `level1_col_int`, `T`.`col_struct_simple`.`level1_col_string` AS `level1_col_string` FROM `default`.`T_ALL_TYPES` AS `T`;
 
---#[struct-06]
+--#[struct-04]
 -- Access all fields of a simple struct
 SELECT `T`.`col_struct_simple`.`level1_col_int` AS `level1_col_int`, `T`.`col_struct_simple`.`level1_col_double` AS `level1_col_double`, `T`.`col_struct_simple`.`level1_col_string` AS `level1_col_string`, `T`.`col_struct_simple`.`level1_col_timestamp` AS `level1_col_timestamp` FROM `default`.`T_ALL_TYPES` AS `T`;
 
@@ -38,21 +30,11 @@ SELECT `T`.`col_struct_simple`.`level1_col_int` AS `level1_col_int`, `T`.`col_st
 --  Path navigation — nested struct
 -- ----------------------------------------
 
--- Single field access on nested struct (e.g. T.col_struct_nested.level1_col_int) covered by struct-04 pattern
-
---#[struct-07]
--- Access the nested struct itself
-SELECT `T`.`col_struct_nested`.`level1_col_struct` AS `level1_col_struct` FROM `default`.`T_ALL_TYPES` AS `T`;
-
---#[struct-08]
--- Access a field within the nested struct (2-level path)
-SELECT `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_int` AS `level2_col_int` FROM `default`.`T_ALL_TYPES` AS `T`;
-
---#[struct-09]
+--#[struct-05]
 -- Access multiple fields within the nested struct
 SELECT `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_int` AS `level2_col_int`, `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_string` AS `level2_col_string` FROM `default`.`T_ALL_TYPES` AS `T`;
 
---#[struct-10]
+--#[struct-06]
 -- Mix top-level and nested field access
 SELECT `T`.`col_struct_nested`.`level1_col_int` AS `level1_col_int`, `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_double` AS `level2_col_double` FROM `default`.`T_ALL_TYPES` AS `T`;
 
@@ -60,19 +42,19 @@ SELECT `T`.`col_struct_nested`.`level1_col_int` AS `level1_col_int`, `T`.`col_st
 --  Struct wildcard (dot-star)
 -- ----------------------------------------
 
---#[struct-11]
+--#[struct-07]
 -- Wildcard on simple struct
 SELECT `T`.`col_struct_simple`.`level1_col_int` AS `level1_col_int`, `T`.`col_struct_simple`.`level1_col_double` AS `level1_col_double`, `T`.`col_struct_simple`.`level1_col_string` AS `level1_col_string`, `T`.`col_struct_simple`.`level1_col_timestamp` AS `level1_col_timestamp` FROM `default`.`T_ALL_TYPES` AS `T`;
 
---#[struct-12]
+--#[struct-08]
 -- Wildcard on nested struct
 SELECT `T`.`col_struct_nested`.`level1_col_int` AS `level1_col_int`, `T`.`col_struct_nested`.`level1_col_double` AS `level1_col_double`, `T`.`col_struct_nested`.`level1_col_string` AS `level1_col_string`, `T`.`col_struct_nested`.`level1_col_timestamp` AS `level1_col_timestamp`, `T`.`col_struct_nested`.`level1_col_struct` AS `level1_col_struct` FROM `default`.`T_ALL_TYPES` AS `T`;
 
---#[struct-13]
+--#[struct-09]
 -- Wildcard on inner nested struct
 SELECT `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_int` AS `level2_col_int`, `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_double` AS `level2_col_double`, `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_string` AS `level2_col_string`, `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_timestamp` AS `level2_col_timestamp` FROM `default`.`T_ALL_TYPES` AS `T`;
 
---#[struct-14]
+--#[struct-10]
 -- Wildcard with other columns
 SELECT `T`.`col_int32` AS `col_int32`, `T`.`col_struct_simple`.`level1_col_int` AS `level1_col_int`, `T`.`col_struct_simple`.`level1_col_double` AS `level1_col_double`, `T`.`col_struct_simple`.`level1_col_string` AS `level1_col_string`, `T`.`col_struct_simple`.`level1_col_timestamp` AS `level1_col_timestamp` FROM `default`.`T_ALL_TYPES` AS `T`;
 
@@ -80,15 +62,15 @@ SELECT `T`.`col_int32` AS `col_int32`, `T`.`col_struct_simple`.`level1_col_int` 
 --  Struct construction in SELECT
 -- ----------------------------------------
 
---#[struct-15]
+--#[struct-11]
 -- Construct a struct literal in SELECT
 SELECT NAMED_STRUCT('a', `T`.`col_int32`, 'b', `T`.`col_string`) AS `constructed` FROM `default`.`T_ALL_TYPES` AS `T`;
 
---#[struct-16]
+--#[struct-12]
 -- Construct a struct from struct fields
 SELECT NAMED_STRUCT('x', `T`.`col_struct_simple`.`level1_col_int`, 'y', `T`.`col_struct_simple`.`level1_col_string`) AS `constructed` FROM `default`.`T_ALL_TYPES` AS `T`;
 
---#[struct-17]
+--#[struct-13]
 -- Construct a nested struct literal
 SELECT NAMED_STRUCT('outer', NAMED_STRUCT('inner_val', `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_int`)) AS `constructed` FROM `default`.`T_ALL_TYPES` AS `T`;
 
@@ -96,33 +78,31 @@ SELECT NAMED_STRUCT('outer', NAMED_STRUCT('inner_val', `T`.`col_struct_nested`.`
 --  Filtering on struct fields
 -- ----------------------------------------
 
---#[struct-18]
+--#[struct-14]
 -- WHERE on a simple struct field
-SELECT `T`.`col_bool` AS `col_bool`, `T`.`col_int16` AS `col_int16`, `T`.`col_int32` AS `col_int32`, `T`.`col_int64` AS `col_int64`, `T`.`col_float32` AS `col_float32`, `T`.`col_float64` AS `col_float64`, `T`.`col_decimal` AS `col_decimal`, `T`.`col_string` AS `col_string`, `T`.`col_char` AS `col_char`, `T`.`col_date` AS `col_date`, `T`.`col_time` AS `col_time`, `T`.`col_timez` AS `col_timez`, `T`.`col_timestamp` AS `col_timestamp`, `T`.`col_timestampz` AS `col_timestampz`, `T`.`col_blob` AS `col_blob`, `T`.`col_clob` AS `col_clob`, `T`.`col_list` AS `col_list`, `T`.`col_bag` AS `col_bag`, `T`.`col_struct_simple` AS `col_struct_simple`, `T`.`col_struct_nested` AS `col_struct_nested`, `T`.`col_any` AS `col_any` FROM `default`.`T_ALL_TYPES` AS `T` WHERE `T`.`col_struct_simple`.`level1_col_int` > 10;
+SELECT `T`.`col_int32` AS `col_int32`, `T`.`col_string` AS `col_string`, `T`.`col_struct_simple`.`level1_col_int` AS `level1_col_int`, `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_string` AS `level2_col_string` FROM `default`.`T_ALL_TYPES` AS `T` WHERE `T`.`col_struct_simple`.`level1_col_int` > 10;
 
---#[struct-19]
+--#[struct-15]
 -- WHERE on a nested struct field
-SELECT `T`.`col_bool` AS `col_bool`, `T`.`col_int16` AS `col_int16`, `T`.`col_int32` AS `col_int32`, `T`.`col_int64` AS `col_int64`, `T`.`col_float32` AS `col_float32`, `T`.`col_float64` AS `col_float64`, `T`.`col_decimal` AS `col_decimal`, `T`.`col_string` AS `col_string`, `T`.`col_char` AS `col_char`, `T`.`col_date` AS `col_date`, `T`.`col_time` AS `col_time`, `T`.`col_timez` AS `col_timez`, `T`.`col_timestamp` AS `col_timestamp`, `T`.`col_timestampz` AS `col_timestampz`, `T`.`col_blob` AS `col_blob`, `T`.`col_clob` AS `col_clob`, `T`.`col_list` AS `col_list`, `T`.`col_bag` AS `col_bag`, `T`.`col_struct_simple` AS `col_struct_simple`, `T`.`col_struct_nested` AS `col_struct_nested`, `T`.`col_any` AS `col_any` FROM `default`.`T_ALL_TYPES` AS `T` WHERE `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_string` = 'hello';
+SELECT `T`.`col_int32` AS `col_int32`, `T`.`col_string` AS `col_string`, `T`.`col_struct_simple`.`level1_col_int` AS `level1_col_int`, `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_string` AS `level2_col_string` FROM `default`.`T_ALL_TYPES` AS `T` WHERE `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_string` = 'hello';
 
---#[struct-20]
+--#[struct-16]
 -- WHERE with multiple struct field conditions
-SELECT `T`.`col_bool` AS `col_bool`, `T`.`col_int16` AS `col_int16`, `T`.`col_int32` AS `col_int32`, `T`.`col_int64` AS `col_int64`, `T`.`col_float32` AS `col_float32`, `T`.`col_float64` AS `col_float64`, `T`.`col_decimal` AS `col_decimal`, `T`.`col_string` AS `col_string`, `T`.`col_char` AS `col_char`, `T`.`col_date` AS `col_date`, `T`.`col_time` AS `col_time`, `T`.`col_timez` AS `col_timez`, `T`.`col_timestamp` AS `col_timestamp`, `T`.`col_timestampz` AS `col_timestampz`, `T`.`col_blob` AS `col_blob`, `T`.`col_clob` AS `col_clob`, `T`.`col_list` AS `col_list`, `T`.`col_bag` AS `col_bag`, `T`.`col_struct_simple` AS `col_struct_simple`, `T`.`col_struct_nested` AS `col_struct_nested`, `T`.`col_any` AS `col_any` FROM `default`.`T_ALL_TYPES` AS `T` WHERE (`T`.`col_struct_simple`.`level1_col_int` > 0) AND (`T`.`col_struct_nested`.`level1_col_double` < 100.0);
+SELECT `T`.`col_int32` AS `col_int32`, `T`.`col_string` AS `col_string`, `T`.`col_struct_simple`.`level1_col_int` AS `level1_col_int`, `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_string` AS `level2_col_string` FROM `default`.`T_ALL_TYPES` AS `T` WHERE (`T`.`col_struct_simple`.`level1_col_int` > 0) AND (`T`.`col_struct_nested`.`level1_col_double` < 100.0);
 
---#[struct-21]
+--#[struct-17]
 -- IS NULL check on struct field
-SELECT `T`.`col_bool` AS `col_bool`, `T`.`col_int16` AS `col_int16`, `T`.`col_int32` AS `col_int32`, `T`.`col_int64` AS `col_int64`, `T`.`col_float32` AS `col_float32`, `T`.`col_float64` AS `col_float64`, `T`.`col_decimal` AS `col_decimal`, `T`.`col_string` AS `col_string`, `T`.`col_char` AS `col_char`, `T`.`col_date` AS `col_date`, `T`.`col_time` AS `col_time`, `T`.`col_timez` AS `col_timez`, `T`.`col_timestamp` AS `col_timestamp`, `T`.`col_timestampz` AS `col_timestampz`, `T`.`col_blob` AS `col_blob`, `T`.`col_clob` AS `col_clob`, `T`.`col_list` AS `col_list`, `T`.`col_bag` AS `col_bag`, `T`.`col_struct_simple` AS `col_struct_simple`, `T`.`col_struct_nested` AS `col_struct_nested`, `T`.`col_any` AS `col_any` FROM `default`.`T_ALL_TYPES` AS `T` WHERE `T`.`col_struct_simple`.`level1_col_string` IS NULL;
+SELECT `T`.`col_int32` AS `col_int32`, `T`.`col_string` AS `col_string`, `T`.`col_struct_simple`.`level1_col_int` AS `level1_col_int`, `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_string` AS `level2_col_string` FROM `default`.`T_ALL_TYPES` AS `T` WHERE `T`.`col_struct_simple`.`level1_col_string` IS NULL;
 
---#[struct-22]
+--#[struct-18]
 -- IS NOT NULL check on nested struct field
-SELECT `T`.`col_bool` AS `col_bool`, `T`.`col_int16` AS `col_int16`, `T`.`col_int32` AS `col_int32`, `T`.`col_int64` AS `col_int64`, `T`.`col_float32` AS `col_float32`, `T`.`col_float64` AS `col_float64`, `T`.`col_decimal` AS `col_decimal`, `T`.`col_string` AS `col_string`, `T`.`col_char` AS `col_char`, `T`.`col_date` AS `col_date`, `T`.`col_time` AS `col_time`, `T`.`col_timez` AS `col_timez`, `T`.`col_timestamp` AS `col_timestamp`, `T`.`col_timestampz` AS `col_timestampz`, `T`.`col_blob` AS `col_blob`, `T`.`col_clob` AS `col_clob`, `T`.`col_list` AS `col_list`, `T`.`col_bag` AS `col_bag`, `T`.`col_struct_simple` AS `col_struct_simple`, `T`.`col_struct_nested` AS `col_struct_nested`, `T`.`col_any` AS `col_any` FROM `default`.`T_ALL_TYPES` AS `T` WHERE `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_timestamp` IS NOT NULL;
+SELECT `T`.`col_int32` AS `col_int32`, `T`.`col_string` AS `col_string`, `T`.`col_struct_simple`.`level1_col_int` AS `level1_col_int`, `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_string` AS `level2_col_string` FROM `default`.`T_ALL_TYPES` AS `T` WHERE `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_timestamp` IS NOT NULL;
 
 -- ----------------------------------------
 --  Aliasing struct fields
 -- ----------------------------------------
 
--- Single alias on struct path (e.g. T.col_struct_simple.level1_col_int AS x) covered by struct-04 pattern
-
---#[struct-23]
+--#[struct-19]
 -- Alias multiple struct paths at different nesting levels
 SELECT `T`.`col_struct_simple`.`level1_col_int` AS `s_int`, `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_string` AS `n_str` FROM `default`.`T_ALL_TYPES` AS `T`;
 
@@ -130,11 +110,11 @@ SELECT `T`.`col_struct_simple`.`level1_col_int` AS `s_int`, `T`.`col_struct_nest
 --  Struct fields in ORDER BY / GROUP BY
 -- ----------------------------------------
 
---#[struct-24]
+--#[struct-20]
 -- ORDER BY a struct field
 SELECT `T`.`col_struct_simple`.`level1_col_int` AS `level1_col_int`, `T`.`col_string` AS `col_string` FROM `default`.`T_ALL_TYPES` AS `T` ORDER BY `T`.`col_struct_simple`.`level1_col_int` ASC NULLS LAST;
 
---#[struct-25]
+--#[struct-21]
 -- GROUP BY a struct field
 SELECT `T`.`col_struct_simple`.`level1_col_string` AS `level1_col_string`, `count`(1) AS `cnt` FROM `default`.`T_ALL_TYPES` AS `T` GROUP BY `T`.`col_struct_simple`.`level1_col_string`;
 
@@ -142,11 +122,11 @@ SELECT `T`.`col_struct_simple`.`level1_col_string` AS `level1_col_string`, `coun
 --  Struct with JOIN
 -- ----------------------------------------
 
---#[struct-26]
+--#[struct-22]
 -- Join on struct fields
 SELECT `t1`.`col_struct_simple`.`level1_col_int` AS `level1_col_int`, `T2`.`col_struct_nested`.`level1_col_string` AS `level1_col_string` FROM `default`.`T_ALL_TYPES` AS `t1` INNER JOIN `default`.`T_ALL_TYPES` AS `T2` ON `t1`.`col_struct_simple`.`level1_col_int` = `T2`.`col_struct_nested`.`level1_col_int`;
 
---#[struct-27]
+--#[struct-23]
 -- Left join with nested struct field in condition
 SELECT `t1`.`col_struct_simple` AS `col_struct_simple`, `T2`.`col_struct_nested`.`level1_col_struct`.`level2_col_int` AS `level2_col_int` FROM `default`.`T_ALL_TYPES` AS `t1` LEFT JOIN `default`.`T_ALL_TYPES` AS `T2` ON `t1`.`col_struct_simple`.`level1_col_string` = `T2`.`col_struct_nested`.`level1_col_struct`.`level2_col_string`;
 
@@ -154,11 +134,11 @@ SELECT `t1`.`col_struct_simple` AS `col_struct_simple`, `T2`.`col_struct_nested`
 --  Struct in subquery
 -- ----------------------------------------
 
---#[struct-28]
+--#[struct-24]
 -- Subquery selecting struct fields
 SELECT `T`.`col_struct_simple`.`level1_col_int` AS `level1_col_int` FROM `default`.`T_ALL_TYPES` AS `T` WHERE `T`.`col_struct_simple`.`level1_col_int` > (SELECT `T2`.`col_struct_nested`.`level1_col_struct`.`level2_col_int` AS `level2_col_int` FROM `default`.`T_ALL_TYPES` AS `T2` WHERE `T2`.`col_struct_nested`.`level1_col_struct`.`level2_col_int` = 1);
 
---#[struct-29]
+--#[struct-25]
 -- Struct field in IN subquery
 SELECT `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_int` AS `level2_col_int` FROM `default`.`T_ALL_TYPES` AS `T` WHERE `T`.`col_struct_simple`.`level1_col_int` IN (SELECT `T2`.`col_struct_nested`.`level1_col_struct`.`level2_col_int` AS `level2_col_int` FROM `default`.`T_ALL_TYPES` AS `T2`);
 
@@ -166,18 +146,18 @@ SELECT `T`.`col_struct_nested`.`level1_col_struct`.`level2_col_int` AS `level2_c
 --  Struct construction with real values
 -- ----------------------------------------
 
---#[struct-30]
+--#[struct-26]
 -- Construct struct with mixed literal types
 SELECT NAMED_STRUCT('count', 42, 'rate', 3.14, 'message', 'hello', 'enabled', false) AS `config` FROM `default`.`T_ALL_TYPES` AS `T`;
 
---#[struct-31]
+--#[struct-27]
 -- Construct nested struct with literal values
 SELECT NAMED_STRUCT('user', NAMED_STRUCT('id', 100, 'email', 'test@example.com'), 'timestamp', '2023-01-01T00:00:00Z') AS `record` FROM `default`.`T_ALL_TYPES` AS `T`;
 
---#[struct-32]
+--#[struct-28]
 -- Construct struct with null values
 SELECT NAMED_STRUCT('value', 123, 'optional_field', NULL, 'description', 'test') AS `data` FROM `default`.`T_ALL_TYPES` AS `T`;
 
---#[struct-33]
+--#[struct-29]
 -- Construct struct with arithmetic expressions
 SELECT NAMED_STRUCT('sum', 10 + 5, 'product', 3 * 7, 'ratio', 100.0 / CAST(4 AS DECIMAL(10,0))) AS `calculations` FROM `default`.`T_ALL_TYPES` AS `T`;

--- a/src/test/resources/outputs/trino/basics/struct.sql
+++ b/src/test/resources/outputs/trino/basics/struct.sql
@@ -161,3 +161,19 @@ SELECT CAST(ROW(CAST(ROW(100, 'test@example.com') AS ROW("id" INTEGER, "email" V
 --#[struct-29]
 -- Construct struct with arithmetic expressions
 SELECT CAST(ROW(10 + 5, 3 * 7, 100.0 / CAST(4 AS DECIMAL(10,0))) AS ROW("sum" INTEGER, "product" INTEGER, "ratio" DECIMAL(15, 12))) AS "calculations" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Access field in constructed struct
+-- ----------------------------------------
+
+--#[struct-30]
+-- Access field from a constructed struct
+SELECT CAST(ROW("T"."col_int32", "T"."col_string") AS ROW("a" INTEGER, "b" VARCHAR))."a" AS "a_val" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-31]
+-- Access field from a struct constructed from struct fields
+SELECT CAST(ROW("T"."col_struct_simple"."level1_col_int", "T"."col_struct_simple"."level1_col_string") AS ROW("x" INTEGER, "y" VARCHAR))."y" AS "y_val" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-32]
+-- Access nested field from a constructed nested struct
+SELECT CAST(ROW(CAST(ROW("T"."col_struct_nested"."level1_col_struct"."level2_col_int") AS ROW("inner_val" INTEGER))) AS ROW("outer" ROW("inner_val" INTEGER)))."outer"."inner_val" AS "inner_val" FROM "default"."T_ALL_TYPES" AS "T";

--- a/src/test/resources/outputs/trino/basics/struct.sql
+++ b/src/test/resources/outputs/trino/basics/struct.sql
@@ -155,7 +155,7 @@ SELECT CAST(ROW(42, 3.14, 'hello', false) AS ROW("count" INTEGER, "rate" DECIMAL
 SELECT CAST(ROW(CAST(ROW(100, 'test@example.com') AS ROW("id" INTEGER, "email" VARCHAR)), '2023-01-01T00:00:00Z') AS ROW("user" ROW("id" INTEGER, "email" VARCHAR), "timestamp" VARCHAR)) AS "record" FROM "default"."T_ALL_TYPES" AS "T";
 
 -- --#[struct-28]
--- -- Construct struct with null values, Unknown type NULL cannot be converted trino.
+-- -- Construct struct with null values, Unknown type NULL cannot be converted to a trino data type.
 -- SELECT CAST(ROW(123, NULL, 'test') AS ROW("value" INTEGER, "optional_field" NULL, "description" VARCHAR)) AS "data" FROM "default"."T_ALL_TYPES" AS "T";
 
 --#[struct-29]

--- a/src/test/resources/outputs/trino/basics/struct.sql
+++ b/src/test/resources/outputs/trino/basics/struct.sql
@@ -1,0 +1,183 @@
+-- ----------------------------------------
+--  Select struct columns
+-- ----------------------------------------
+
+--#[struct-00]
+-- Select a simple struct column
+SELECT "T"."col_struct_simple" AS "col_struct_simple" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-01]
+-- Select a nested struct column
+SELECT "T"."col_struct_nested" AS "col_struct_nested" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-02]
+-- Select both struct columns
+SELECT "T"."col_struct_simple" AS "col_struct_simple", "T"."col_struct_nested" AS "col_struct_nested" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-03]
+-- Select struct alongside scalar columns
+SELECT "T"."col_int32" AS "col_int32", "T"."col_string" AS "col_string", "T"."col_struct_simple" AS "col_struct_simple" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Path navigation — simple struct
+-- ----------------------------------------
+
+--#[struct-04]
+-- Access a field of a simple struct
+SELECT "T"."col_struct_simple"."level1_col_int" AS "level1_col_int" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-05]
+-- Access multiple fields of a simple struct
+SELECT "T"."col_struct_simple"."level1_col_int" AS "level1_col_int", "T"."col_struct_simple"."level1_col_string" AS "level1_col_string" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-06]
+-- Access all fields of a simple struct
+SELECT "T"."col_struct_simple"."level1_col_int" AS "level1_col_int", "T"."col_struct_simple"."level1_col_double" AS "level1_col_double", "T"."col_struct_simple"."level1_col_string" AS "level1_col_string", "T"."col_struct_simple"."level1_col_timestamp" AS "level1_col_timestamp" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Path navigation — nested struct
+-- ----------------------------------------
+
+-- Single field access on nested struct (e.g. T.col_struct_nested.level1_col_int) covered by struct-04 pattern
+
+--#[struct-07]
+-- Access the nested struct itself
+SELECT "T"."col_struct_nested"."level1_col_struct" AS "level1_col_struct" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-08]
+-- Access a field within the nested struct (2-level path)
+SELECT "T"."col_struct_nested"."level1_col_struct"."level2_col_int" AS "level2_col_int" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-09]
+-- Access multiple fields within the nested struct
+SELECT "T"."col_struct_nested"."level1_col_struct"."level2_col_int" AS "level2_col_int", "T"."col_struct_nested"."level1_col_struct"."level2_col_string" AS "level2_col_string" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-10]
+-- Mix top-level and nested field access
+SELECT "T"."col_struct_nested"."level1_col_int" AS "level1_col_int", "T"."col_struct_nested"."level1_col_struct"."level2_col_double" AS "level2_col_double" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Struct wildcard (dot-star)
+-- ----------------------------------------
+
+--#[struct-11]
+-- Wildcard on simple struct
+SELECT "T"."col_struct_simple"."level1_col_int" AS "level1_col_int", "T"."col_struct_simple"."level1_col_double" AS "level1_col_double", "T"."col_struct_simple"."level1_col_string" AS "level1_col_string", "T"."col_struct_simple"."level1_col_timestamp" AS "level1_col_timestamp" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-12]
+-- Wildcard on nested struct
+SELECT "T"."col_struct_nested"."level1_col_int" AS "level1_col_int", "T"."col_struct_nested"."level1_col_double" AS "level1_col_double", "T"."col_struct_nested"."level1_col_string" AS "level1_col_string", "T"."col_struct_nested"."level1_col_timestamp" AS "level1_col_timestamp", "T"."col_struct_nested"."level1_col_struct" AS "level1_col_struct" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-13]
+-- Wildcard on inner nested struct
+SELECT "T"."col_struct_nested"."level1_col_struct"."level2_col_int" AS "level2_col_int", "T"."col_struct_nested"."level1_col_struct"."level2_col_double" AS "level2_col_double", "T"."col_struct_nested"."level1_col_struct"."level2_col_string" AS "level2_col_string", "T"."col_struct_nested"."level1_col_struct"."level2_col_timestamp" AS "level2_col_timestamp" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-14]
+-- Wildcard with other columns
+SELECT "T"."col_int32" AS "col_int32", "T"."col_struct_simple"."level1_col_int" AS "level1_col_int", "T"."col_struct_simple"."level1_col_double" AS "level1_col_double", "T"."col_struct_simple"."level1_col_string" AS "level1_col_string", "T"."col_struct_simple"."level1_col_timestamp" AS "level1_col_timestamp" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Struct construction in SELECT
+-- ----------------------------------------
+
+--#[struct-15]
+-- Construct a struct literal in SELECT
+SELECT CAST(ROW("T"."col_int32", "T"."col_string") AS ROW("a" INTEGER, "b" VARCHAR)) AS "constructed" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-16]
+-- Construct a struct from struct fields
+SELECT CAST(ROW("T"."col_struct_simple"."level1_col_int", "T"."col_struct_simple"."level1_col_string") AS ROW("x" INTEGER, "y" VARCHAR)) AS "constructed" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-17]
+-- Construct a nested struct literal
+SELECT CAST(ROW(CAST(ROW("T"."col_struct_nested"."level1_col_struct"."level2_col_int") AS ROW("inner_val" INTEGER))) AS ROW("outer" ROW("inner_val" INTEGER))) AS "constructed" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Filtering on struct fields
+-- ----------------------------------------
+
+--#[struct-18]
+-- WHERE on a simple struct field
+SELECT "T"."col_bool" AS "col_bool", "T"."col_int16" AS "col_int16", "T"."col_int32" AS "col_int32", "T"."col_int64" AS "col_int64", "T"."col_float32" AS "col_float32", "T"."col_float64" AS "col_float64", "T"."col_decimal" AS "col_decimal", "T"."col_string" AS "col_string", "T"."col_char" AS "col_char", "T"."col_date" AS "col_date", "T"."col_time" AS "col_time", "T"."col_timez" AS "col_timez", "T"."col_timestamp" AS "col_timestamp", "T"."col_timestampz" AS "col_timestampz", "T"."col_blob" AS "col_blob", "T"."col_clob" AS "col_clob", "T"."col_list" AS "col_list", "T"."col_bag" AS "col_bag", "T"."col_struct_simple" AS "col_struct_simple", "T"."col_struct_nested" AS "col_struct_nested", "T"."col_any" AS "col_any" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_struct_simple"."level1_col_int" > 10;
+
+--#[struct-19]
+-- WHERE on a nested struct field
+SELECT "T"."col_bool" AS "col_bool", "T"."col_int16" AS "col_int16", "T"."col_int32" AS "col_int32", "T"."col_int64" AS "col_int64", "T"."col_float32" AS "col_float32", "T"."col_float64" AS "col_float64", "T"."col_decimal" AS "col_decimal", "T"."col_string" AS "col_string", "T"."col_char" AS "col_char", "T"."col_date" AS "col_date", "T"."col_time" AS "col_time", "T"."col_timez" AS "col_timez", "T"."col_timestamp" AS "col_timestamp", "T"."col_timestampz" AS "col_timestampz", "T"."col_blob" AS "col_blob", "T"."col_clob" AS "col_clob", "T"."col_list" AS "col_list", "T"."col_bag" AS "col_bag", "T"."col_struct_simple" AS "col_struct_simple", "T"."col_struct_nested" AS "col_struct_nested", "T"."col_any" AS "col_any" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_struct_nested"."level1_col_struct"."level2_col_string" = 'hello';
+
+--#[struct-20]
+-- WHERE with multiple struct field conditions
+SELECT "T"."col_bool" AS "col_bool", "T"."col_int16" AS "col_int16", "T"."col_int32" AS "col_int32", "T"."col_int64" AS "col_int64", "T"."col_float32" AS "col_float32", "T"."col_float64" AS "col_float64", "T"."col_decimal" AS "col_decimal", "T"."col_string" AS "col_string", "T"."col_char" AS "col_char", "T"."col_date" AS "col_date", "T"."col_time" AS "col_time", "T"."col_timez" AS "col_timez", "T"."col_timestamp" AS "col_timestamp", "T"."col_timestampz" AS "col_timestampz", "T"."col_blob" AS "col_blob", "T"."col_clob" AS "col_clob", "T"."col_list" AS "col_list", "T"."col_bag" AS "col_bag", "T"."col_struct_simple" AS "col_struct_simple", "T"."col_struct_nested" AS "col_struct_nested", "T"."col_any" AS "col_any" FROM "default"."T_ALL_TYPES" AS "T" WHERE ("T"."col_struct_simple"."level1_col_int" > 0) AND ("T"."col_struct_nested"."level1_col_double" < 100.0);
+
+--#[struct-21]
+-- IS NULL check on struct field
+SELECT "T"."col_bool" AS "col_bool", "T"."col_int16" AS "col_int16", "T"."col_int32" AS "col_int32", "T"."col_int64" AS "col_int64", "T"."col_float32" AS "col_float32", "T"."col_float64" AS "col_float64", "T"."col_decimal" AS "col_decimal", "T"."col_string" AS "col_string", "T"."col_char" AS "col_char", "T"."col_date" AS "col_date", "T"."col_time" AS "col_time", "T"."col_timez" AS "col_timez", "T"."col_timestamp" AS "col_timestamp", "T"."col_timestampz" AS "col_timestampz", "T"."col_blob" AS "col_blob", "T"."col_clob" AS "col_clob", "T"."col_list" AS "col_list", "T"."col_bag" AS "col_bag", "T"."col_struct_simple" AS "col_struct_simple", "T"."col_struct_nested" AS "col_struct_nested", "T"."col_any" AS "col_any" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_struct_simple"."level1_col_string" IS NULL;
+
+--#[struct-22]
+-- IS NOT NULL check on nested struct field
+SELECT "T"."col_bool" AS "col_bool", "T"."col_int16" AS "col_int16", "T"."col_int32" AS "col_int32", "T"."col_int64" AS "col_int64", "T"."col_float32" AS "col_float32", "T"."col_float64" AS "col_float64", "T"."col_decimal" AS "col_decimal", "T"."col_string" AS "col_string", "T"."col_char" AS "col_char", "T"."col_date" AS "col_date", "T"."col_time" AS "col_time", "T"."col_timez" AS "col_timez", "T"."col_timestamp" AS "col_timestamp", "T"."col_timestampz" AS "col_timestampz", "T"."col_blob" AS "col_blob", "T"."col_clob" AS "col_clob", "T"."col_list" AS "col_list", "T"."col_bag" AS "col_bag", "T"."col_struct_simple" AS "col_struct_simple", "T"."col_struct_nested" AS "col_struct_nested", "T"."col_any" AS "col_any" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_struct_nested"."level1_col_struct"."level2_col_timestamp" IS NOT NULL;
+
+-- ----------------------------------------
+--  Aliasing struct fields
+-- ----------------------------------------
+
+-- Single alias on struct path (e.g. T.col_struct_simple.level1_col_int AS x) covered by struct-04 pattern
+
+--#[struct-23]
+-- Alias multiple struct paths at different nesting levels
+SELECT "T"."col_struct_simple"."level1_col_int" AS "s_int", "T"."col_struct_nested"."level1_col_struct"."level2_col_string" AS "n_str" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Struct fields in ORDER BY / GROUP BY
+-- ----------------------------------------
+
+--#[struct-24]
+-- ORDER BY a struct field
+SELECT "T"."col_struct_simple"."level1_col_int" AS "level1_col_int", "T"."col_string" AS "col_string" FROM "default"."T_ALL_TYPES" AS "T" ORDER BY "T"."col_struct_simple"."level1_col_int" ASC NULLS LAST;
+
+--#[struct-25]
+-- GROUP BY a struct field
+SELECT "T"."col_struct_simple"."level1_col_string" AS "level1_col_string", count(1) AS "cnt" FROM "default"."T_ALL_TYPES" AS "T" GROUP BY "T"."col_struct_simple"."level1_col_string";
+
+-- ----------------------------------------
+--  Struct with JOIN
+-- ----------------------------------------
+
+--#[struct-26]
+-- Join on struct fields
+SELECT "t1"."col_struct_simple"."level1_col_int" AS "level1_col_int", "T2"."col_struct_nested"."level1_col_string" AS "level1_col_string" FROM "default"."T_ALL_TYPES" AS "t1" INNER JOIN "default"."T_ALL_TYPES" AS "T2" ON "t1"."col_struct_simple"."level1_col_int" = "T2"."col_struct_nested"."level1_col_int";
+
+--#[struct-27]
+-- Left join with nested struct field in condition
+SELECT "t1"."col_struct_simple" AS "col_struct_simple", "T2"."col_struct_nested"."level1_col_struct"."level2_col_int" AS "level2_col_int" FROM "default"."T_ALL_TYPES" AS "t1" LEFT JOIN "default"."T_ALL_TYPES" AS "T2" ON "t1"."col_struct_simple"."level1_col_string" = "T2"."col_struct_nested"."level1_col_struct"."level2_col_string";
+
+-- ----------------------------------------
+--  Struct in subquery
+-- ----------------------------------------
+
+--#[struct-28]
+-- Subquery selecting struct fields
+SELECT "T"."col_struct_simple"."level1_col_int" AS "level1_col_int" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_struct_simple"."level1_col_int" > (SELECT "T2"."col_struct_nested"."level1_col_struct"."level2_col_int" AS "level2_col_int" FROM "default"."T_ALL_TYPES" AS "T2" WHERE "T2"."col_struct_nested"."level1_col_struct"."level2_col_int" = 1);
+
+--#[struct-29]
+-- Struct field in IN subquery
+SELECT "T"."col_struct_nested"."level1_col_struct"."level2_col_int" AS "level2_col_int" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_struct_simple"."level1_col_int" IN (SELECT "T2"."col_struct_nested"."level1_col_struct"."level2_col_int" AS "level2_col_int" FROM "default"."T_ALL_TYPES" AS "T2");
+
+-- ----------------------------------------
+--  Struct construction with real values
+-- ----------------------------------------
+
+--#[struct-30]
+-- Construct struct with mixed literal types
+SELECT CAST(ROW(42, 3.14, 'hello', false) AS ROW("count" INTEGER, "rate" DECIMAL(3, 2), "message" VARCHAR, "enabled" BOOLEAN)) AS "config" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-31]
+-- Construct nested struct with literal values
+SELECT CAST(ROW(CAST(ROW(100, 'test@example.com') AS ROW("id" INTEGER, "email" VARCHAR)), '2023-01-01T00:00:00Z') AS ROW("user" ROW("id" INTEGER, "email" VARCHAR), "timestamp" VARCHAR)) AS "record" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- --#[struct-32]
+-- -- Construct struct with null values, Unknown type NULL cannot be converted trino.
+-- SELECT CAST(ROW(123, NULL, 'test') AS ROW("value" INTEGER, "optional_field" NULL, "description" VARCHAR)) AS "data" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[struct-33]
+-- Construct struct with arithmetic expressions
+SELECT CAST(ROW(10 + 5, 3 * 7, 100.0 / CAST(4 AS DECIMAL(10,0))) AS ROW("sum" INTEGER, "product" INTEGER, "ratio" DECIMAL(15, 12))) AS "calculations" FROM "default"."T_ALL_TYPES" AS "T";

--- a/src/test/resources/outputs/trino/basics/struct.sql
+++ b/src/test/resources/outputs/trino/basics/struct.sql
@@ -11,26 +11,18 @@ SELECT "T"."col_struct_simple" AS "col_struct_simple" FROM "default"."T_ALL_TYPE
 SELECT "T"."col_struct_nested" AS "col_struct_nested" FROM "default"."T_ALL_TYPES" AS "T";
 
 --#[struct-02]
--- Select both struct columns
-SELECT "T"."col_struct_simple" AS "col_struct_simple", "T"."col_struct_nested" AS "col_struct_nested" FROM "default"."T_ALL_TYPES" AS "T";
-
---#[struct-03]
 -- Select struct alongside scalar columns
-SELECT "T"."col_int32" AS "col_int32", "T"."col_string" AS "col_string", "T"."col_struct_simple" AS "col_struct_simple" FROM "default"."T_ALL_TYPES" AS "T";
+SELECT "T"."col_int32" AS "col_int32", "T"."col_string" AS "col_string", "T"."col_struct_simple" AS "col_struct_simple", "T"."col_struct_nested" AS "col_struct_nested" FROM "default"."T_ALL_TYPES" AS "T";
 
 -- ----------------------------------------
 --  Path navigation — simple struct
 -- ----------------------------------------
 
---#[struct-04]
--- Access a field of a simple struct
-SELECT "T"."col_struct_simple"."level1_col_int" AS "level1_col_int" FROM "default"."T_ALL_TYPES" AS "T";
-
---#[struct-05]
+--#[struct-03]
 -- Access multiple fields of a simple struct
 SELECT "T"."col_struct_simple"."level1_col_int" AS "level1_col_int", "T"."col_struct_simple"."level1_col_string" AS "level1_col_string" FROM "default"."T_ALL_TYPES" AS "T";
 
---#[struct-06]
+--#[struct-04]
 -- Access all fields of a simple struct
 SELECT "T"."col_struct_simple"."level1_col_int" AS "level1_col_int", "T"."col_struct_simple"."level1_col_double" AS "level1_col_double", "T"."col_struct_simple"."level1_col_string" AS "level1_col_string", "T"."col_struct_simple"."level1_col_timestamp" AS "level1_col_timestamp" FROM "default"."T_ALL_TYPES" AS "T";
 
@@ -38,21 +30,11 @@ SELECT "T"."col_struct_simple"."level1_col_int" AS "level1_col_int", "T"."col_st
 --  Path navigation — nested struct
 -- ----------------------------------------
 
--- Single field access on nested struct (e.g. T.col_struct_nested.level1_col_int) covered by struct-04 pattern
-
---#[struct-07]
--- Access the nested struct itself
-SELECT "T"."col_struct_nested"."level1_col_struct" AS "level1_col_struct" FROM "default"."T_ALL_TYPES" AS "T";
-
---#[struct-08]
--- Access a field within the nested struct (2-level path)
-SELECT "T"."col_struct_nested"."level1_col_struct"."level2_col_int" AS "level2_col_int" FROM "default"."T_ALL_TYPES" AS "T";
-
---#[struct-09]
+--#[struct-05]
 -- Access multiple fields within the nested struct
 SELECT "T"."col_struct_nested"."level1_col_struct"."level2_col_int" AS "level2_col_int", "T"."col_struct_nested"."level1_col_struct"."level2_col_string" AS "level2_col_string" FROM "default"."T_ALL_TYPES" AS "T";
 
---#[struct-10]
+--#[struct-06]
 -- Mix top-level and nested field access
 SELECT "T"."col_struct_nested"."level1_col_int" AS "level1_col_int", "T"."col_struct_nested"."level1_col_struct"."level2_col_double" AS "level2_col_double" FROM "default"."T_ALL_TYPES" AS "T";
 
@@ -60,19 +42,19 @@ SELECT "T"."col_struct_nested"."level1_col_int" AS "level1_col_int", "T"."col_st
 --  Struct wildcard (dot-star)
 -- ----------------------------------------
 
---#[struct-11]
+--#[struct-07]
 -- Wildcard on simple struct
 SELECT "T"."col_struct_simple"."level1_col_int" AS "level1_col_int", "T"."col_struct_simple"."level1_col_double" AS "level1_col_double", "T"."col_struct_simple"."level1_col_string" AS "level1_col_string", "T"."col_struct_simple"."level1_col_timestamp" AS "level1_col_timestamp" FROM "default"."T_ALL_TYPES" AS "T";
 
---#[struct-12]
+--#[struct-08]
 -- Wildcard on nested struct
 SELECT "T"."col_struct_nested"."level1_col_int" AS "level1_col_int", "T"."col_struct_nested"."level1_col_double" AS "level1_col_double", "T"."col_struct_nested"."level1_col_string" AS "level1_col_string", "T"."col_struct_nested"."level1_col_timestamp" AS "level1_col_timestamp", "T"."col_struct_nested"."level1_col_struct" AS "level1_col_struct" FROM "default"."T_ALL_TYPES" AS "T";
 
---#[struct-13]
+--#[struct-09]
 -- Wildcard on inner nested struct
 SELECT "T"."col_struct_nested"."level1_col_struct"."level2_col_int" AS "level2_col_int", "T"."col_struct_nested"."level1_col_struct"."level2_col_double" AS "level2_col_double", "T"."col_struct_nested"."level1_col_struct"."level2_col_string" AS "level2_col_string", "T"."col_struct_nested"."level1_col_struct"."level2_col_timestamp" AS "level2_col_timestamp" FROM "default"."T_ALL_TYPES" AS "T";
 
---#[struct-14]
+--#[struct-10]
 -- Wildcard with other columns
 SELECT "T"."col_int32" AS "col_int32", "T"."col_struct_simple"."level1_col_int" AS "level1_col_int", "T"."col_struct_simple"."level1_col_double" AS "level1_col_double", "T"."col_struct_simple"."level1_col_string" AS "level1_col_string", "T"."col_struct_simple"."level1_col_timestamp" AS "level1_col_timestamp" FROM "default"."T_ALL_TYPES" AS "T";
 
@@ -80,15 +62,15 @@ SELECT "T"."col_int32" AS "col_int32", "T"."col_struct_simple"."level1_col_int" 
 --  Struct construction in SELECT
 -- ----------------------------------------
 
---#[struct-15]
+--#[struct-11]
 -- Construct a struct literal in SELECT
 SELECT CAST(ROW("T"."col_int32", "T"."col_string") AS ROW("a" INTEGER, "b" VARCHAR)) AS "constructed" FROM "default"."T_ALL_TYPES" AS "T";
 
---#[struct-16]
+--#[struct-12]
 -- Construct a struct from struct fields
 SELECT CAST(ROW("T"."col_struct_simple"."level1_col_int", "T"."col_struct_simple"."level1_col_string") AS ROW("x" INTEGER, "y" VARCHAR)) AS "constructed" FROM "default"."T_ALL_TYPES" AS "T";
 
---#[struct-17]
+--#[struct-13]
 -- Construct a nested struct literal
 SELECT CAST(ROW(CAST(ROW("T"."col_struct_nested"."level1_col_struct"."level2_col_int") AS ROW("inner_val" INTEGER))) AS ROW("outer" ROW("inner_val" INTEGER))) AS "constructed" FROM "default"."T_ALL_TYPES" AS "T";
 
@@ -96,33 +78,31 @@ SELECT CAST(ROW(CAST(ROW("T"."col_struct_nested"."level1_col_struct"."level2_col
 --  Filtering on struct fields
 -- ----------------------------------------
 
---#[struct-18]
+--#[struct-14]
 -- WHERE on a simple struct field
-SELECT "T"."col_bool" AS "col_bool", "T"."col_int16" AS "col_int16", "T"."col_int32" AS "col_int32", "T"."col_int64" AS "col_int64", "T"."col_float32" AS "col_float32", "T"."col_float64" AS "col_float64", "T"."col_decimal" AS "col_decimal", "T"."col_string" AS "col_string", "T"."col_char" AS "col_char", "T"."col_date" AS "col_date", "T"."col_time" AS "col_time", "T"."col_timez" AS "col_timez", "T"."col_timestamp" AS "col_timestamp", "T"."col_timestampz" AS "col_timestampz", "T"."col_blob" AS "col_blob", "T"."col_clob" AS "col_clob", "T"."col_list" AS "col_list", "T"."col_bag" AS "col_bag", "T"."col_struct_simple" AS "col_struct_simple", "T"."col_struct_nested" AS "col_struct_nested", "T"."col_any" AS "col_any" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_struct_simple"."level1_col_int" > 10;
+SELECT "T"."col_int32" AS "col_int32", "T"."col_string" AS "col_string", "T"."col_struct_simple"."level1_col_int" AS "level1_col_int", "T"."col_struct_nested"."level1_col_struct"."level2_col_string" AS "level2_col_string" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_struct_simple"."level1_col_int" > 10;
 
---#[struct-19]
+--#[struct-15]
 -- WHERE on a nested struct field
-SELECT "T"."col_bool" AS "col_bool", "T"."col_int16" AS "col_int16", "T"."col_int32" AS "col_int32", "T"."col_int64" AS "col_int64", "T"."col_float32" AS "col_float32", "T"."col_float64" AS "col_float64", "T"."col_decimal" AS "col_decimal", "T"."col_string" AS "col_string", "T"."col_char" AS "col_char", "T"."col_date" AS "col_date", "T"."col_time" AS "col_time", "T"."col_timez" AS "col_timez", "T"."col_timestamp" AS "col_timestamp", "T"."col_timestampz" AS "col_timestampz", "T"."col_blob" AS "col_blob", "T"."col_clob" AS "col_clob", "T"."col_list" AS "col_list", "T"."col_bag" AS "col_bag", "T"."col_struct_simple" AS "col_struct_simple", "T"."col_struct_nested" AS "col_struct_nested", "T"."col_any" AS "col_any" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_struct_nested"."level1_col_struct"."level2_col_string" = 'hello';
+SELECT "T"."col_int32" AS "col_int32", "T"."col_string" AS "col_string", "T"."col_struct_simple"."level1_col_int" AS "level1_col_int", "T"."col_struct_nested"."level1_col_struct"."level2_col_string" AS "level2_col_string" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_struct_nested"."level1_col_struct"."level2_col_string" = 'hello';
 
---#[struct-20]
+--#[struct-16]
 -- WHERE with multiple struct field conditions
-SELECT "T"."col_bool" AS "col_bool", "T"."col_int16" AS "col_int16", "T"."col_int32" AS "col_int32", "T"."col_int64" AS "col_int64", "T"."col_float32" AS "col_float32", "T"."col_float64" AS "col_float64", "T"."col_decimal" AS "col_decimal", "T"."col_string" AS "col_string", "T"."col_char" AS "col_char", "T"."col_date" AS "col_date", "T"."col_time" AS "col_time", "T"."col_timez" AS "col_timez", "T"."col_timestamp" AS "col_timestamp", "T"."col_timestampz" AS "col_timestampz", "T"."col_blob" AS "col_blob", "T"."col_clob" AS "col_clob", "T"."col_list" AS "col_list", "T"."col_bag" AS "col_bag", "T"."col_struct_simple" AS "col_struct_simple", "T"."col_struct_nested" AS "col_struct_nested", "T"."col_any" AS "col_any" FROM "default"."T_ALL_TYPES" AS "T" WHERE ("T"."col_struct_simple"."level1_col_int" > 0) AND ("T"."col_struct_nested"."level1_col_double" < 100.0);
+SELECT "T"."col_int32" AS "col_int32", "T"."col_string" AS "col_string", "T"."col_struct_simple"."level1_col_int" AS "level1_col_int", "T"."col_struct_nested"."level1_col_struct"."level2_col_string" AS "level2_col_string" FROM "default"."T_ALL_TYPES" AS "T" WHERE ("T"."col_struct_simple"."level1_col_int" > 0) AND ("T"."col_struct_nested"."level1_col_double" < 100.0);
 
---#[struct-21]
+--#[struct-17]
 -- IS NULL check on struct field
-SELECT "T"."col_bool" AS "col_bool", "T"."col_int16" AS "col_int16", "T"."col_int32" AS "col_int32", "T"."col_int64" AS "col_int64", "T"."col_float32" AS "col_float32", "T"."col_float64" AS "col_float64", "T"."col_decimal" AS "col_decimal", "T"."col_string" AS "col_string", "T"."col_char" AS "col_char", "T"."col_date" AS "col_date", "T"."col_time" AS "col_time", "T"."col_timez" AS "col_timez", "T"."col_timestamp" AS "col_timestamp", "T"."col_timestampz" AS "col_timestampz", "T"."col_blob" AS "col_blob", "T"."col_clob" AS "col_clob", "T"."col_list" AS "col_list", "T"."col_bag" AS "col_bag", "T"."col_struct_simple" AS "col_struct_simple", "T"."col_struct_nested" AS "col_struct_nested", "T"."col_any" AS "col_any" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_struct_simple"."level1_col_string" IS NULL;
+SELECT "T"."col_int32" AS "col_int32", "T"."col_string" AS "col_string", "T"."col_struct_simple"."level1_col_int" AS "level1_col_int", "T"."col_struct_nested"."level1_col_struct"."level2_col_string" AS "level2_col_string" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_struct_simple"."level1_col_string" IS NULL;
 
---#[struct-22]
+--#[struct-18]
 -- IS NOT NULL check on nested struct field
-SELECT "T"."col_bool" AS "col_bool", "T"."col_int16" AS "col_int16", "T"."col_int32" AS "col_int32", "T"."col_int64" AS "col_int64", "T"."col_float32" AS "col_float32", "T"."col_float64" AS "col_float64", "T"."col_decimal" AS "col_decimal", "T"."col_string" AS "col_string", "T"."col_char" AS "col_char", "T"."col_date" AS "col_date", "T"."col_time" AS "col_time", "T"."col_timez" AS "col_timez", "T"."col_timestamp" AS "col_timestamp", "T"."col_timestampz" AS "col_timestampz", "T"."col_blob" AS "col_blob", "T"."col_clob" AS "col_clob", "T"."col_list" AS "col_list", "T"."col_bag" AS "col_bag", "T"."col_struct_simple" AS "col_struct_simple", "T"."col_struct_nested" AS "col_struct_nested", "T"."col_any" AS "col_any" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_struct_nested"."level1_col_struct"."level2_col_timestamp" IS NOT NULL;
+SELECT "T"."col_int32" AS "col_int32", "T"."col_string" AS "col_string", "T"."col_struct_simple"."level1_col_int" AS "level1_col_int", "T"."col_struct_nested"."level1_col_struct"."level2_col_string" AS "level2_col_string" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_struct_nested"."level1_col_struct"."level2_col_timestamp" IS NOT NULL;
 
 -- ----------------------------------------
 --  Aliasing struct fields
 -- ----------------------------------------
 
--- Single alias on struct path (e.g. T.col_struct_simple.level1_col_int AS x) covered by struct-04 pattern
-
---#[struct-23]
+--#[struct-19]
 -- Alias multiple struct paths at different nesting levels
 SELECT "T"."col_struct_simple"."level1_col_int" AS "s_int", "T"."col_struct_nested"."level1_col_struct"."level2_col_string" AS "n_str" FROM "default"."T_ALL_TYPES" AS "T";
 
@@ -130,11 +110,11 @@ SELECT "T"."col_struct_simple"."level1_col_int" AS "s_int", "T"."col_struct_nest
 --  Struct fields in ORDER BY / GROUP BY
 -- ----------------------------------------
 
---#[struct-24]
+--#[struct-20]
 -- ORDER BY a struct field
 SELECT "T"."col_struct_simple"."level1_col_int" AS "level1_col_int", "T"."col_string" AS "col_string" FROM "default"."T_ALL_TYPES" AS "T" ORDER BY "T"."col_struct_simple"."level1_col_int" ASC NULLS LAST;
 
---#[struct-25]
+--#[struct-21]
 -- GROUP BY a struct field
 SELECT "T"."col_struct_simple"."level1_col_string" AS "level1_col_string", count(1) AS "cnt" FROM "default"."T_ALL_TYPES" AS "T" GROUP BY "T"."col_struct_simple"."level1_col_string";
 
@@ -142,11 +122,11 @@ SELECT "T"."col_struct_simple"."level1_col_string" AS "level1_col_string", count
 --  Struct with JOIN
 -- ----------------------------------------
 
---#[struct-26]
+--#[struct-22]
 -- Join on struct fields
 SELECT "t1"."col_struct_simple"."level1_col_int" AS "level1_col_int", "T2"."col_struct_nested"."level1_col_string" AS "level1_col_string" FROM "default"."T_ALL_TYPES" AS "t1" INNER JOIN "default"."T_ALL_TYPES" AS "T2" ON "t1"."col_struct_simple"."level1_col_int" = "T2"."col_struct_nested"."level1_col_int";
 
---#[struct-27]
+--#[struct-23]
 -- Left join with nested struct field in condition
 SELECT "t1"."col_struct_simple" AS "col_struct_simple", "T2"."col_struct_nested"."level1_col_struct"."level2_col_int" AS "level2_col_int" FROM "default"."T_ALL_TYPES" AS "t1" LEFT JOIN "default"."T_ALL_TYPES" AS "T2" ON "t1"."col_struct_simple"."level1_col_string" = "T2"."col_struct_nested"."level1_col_struct"."level2_col_string";
 
@@ -154,11 +134,11 @@ SELECT "t1"."col_struct_simple" AS "col_struct_simple", "T2"."col_struct_nested"
 --  Struct in subquery
 -- ----------------------------------------
 
---#[struct-28]
+--#[struct-24]
 -- Subquery selecting struct fields
 SELECT "T"."col_struct_simple"."level1_col_int" AS "level1_col_int" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_struct_simple"."level1_col_int" > (SELECT "T2"."col_struct_nested"."level1_col_struct"."level2_col_int" AS "level2_col_int" FROM "default"."T_ALL_TYPES" AS "T2" WHERE "T2"."col_struct_nested"."level1_col_struct"."level2_col_int" = 1);
 
---#[struct-29]
+--#[struct-25]
 -- Struct field in IN subquery
 SELECT "T"."col_struct_nested"."level1_col_struct"."level2_col_int" AS "level2_col_int" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_struct_simple"."level1_col_int" IN (SELECT "T2"."col_struct_nested"."level1_col_struct"."level2_col_int" AS "level2_col_int" FROM "default"."T_ALL_TYPES" AS "T2");
 
@@ -166,18 +146,18 @@ SELECT "T"."col_struct_nested"."level1_col_struct"."level2_col_int" AS "level2_c
 --  Struct construction with real values
 -- ----------------------------------------
 
---#[struct-30]
+--#[struct-26]
 -- Construct struct with mixed literal types
 SELECT CAST(ROW(42, 3.14, 'hello', false) AS ROW("count" INTEGER, "rate" DECIMAL(3, 2), "message" VARCHAR, "enabled" BOOLEAN)) AS "config" FROM "default"."T_ALL_TYPES" AS "T";
 
---#[struct-31]
+--#[struct-27]
 -- Construct nested struct with literal values
 SELECT CAST(ROW(CAST(ROW(100, 'test@example.com') AS ROW("id" INTEGER, "email" VARCHAR)), '2023-01-01T00:00:00Z') AS ROW("user" ROW("id" INTEGER, "email" VARCHAR), "timestamp" VARCHAR)) AS "record" FROM "default"."T_ALL_TYPES" AS "T";
 
--- --#[struct-32]
+-- --#[struct-28]
 -- -- Construct struct with null values, Unknown type NULL cannot be converted trino.
 -- SELECT CAST(ROW(123, NULL, 'test') AS ROW("value" INTEGER, "optional_field" NULL, "description" VARCHAR)) AS "data" FROM "default"."T_ALL_TYPES" AS "T";
 
---#[struct-33]
+--#[struct-29]
 -- Construct struct with arithmetic expressions
 SELECT CAST(ROW(10 + 5, 3 * 7, 100.0 / CAST(4 AS DECIMAL(10,0))) AS ROW("sum" INTEGER, "product" INTEGER, "ratio" DECIMAL(15, 12))) AS "calculations" FROM "default"."T_ALL_TYPES" AS "T";


### PR DESCRIPTION
*Issue #, if available:*
None
*Description of changes:*
Adds support for transpiling PartiQL struct types into multiple SQL dialects, including struct field navigation and struct construction, and expands golden test coverage for these cases.

Changes:

Add new struct.sql input fixture plus expected outputs for PartiQL, Trino, Spark, and Redshift.
Update Spark struct construction to use NAMED_STRUCT, and adjust Spark EXCLUDE golden outputs accordingly.
Extend Trino/Redshift rewrites to handle constructed structs (and, for Redshift, to hard-fail unsupported constructed-struct field access).

Each Tests are manually tested on each sql engine.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
