### PR TITLE
[DRAFT] fix: Constant-fold inline struct literal path access in TrinoRewriter

### DIFF
--- a/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoRewriter.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoRewriter.kt
@@ -75,8 +75,28 @@ public open class TrinoRewriter(internal val context: ScribeContext) : OperatorR
         rex: RexPathKey,
         ctx: ScribeContext,
     ): Operator {
-        if (rex.operand.type.pType.code() != PType.ROW) {
-            error("Trino path expression must be on a ROW type (PartiQL STRUCT), found ${rex.operand.type}")
+        // First, visit the operand so nested rewrites are applied
+        val operand = rex.operand.accept(this, ctx) as org.partiql.plan.rex.Rex
+
+        // Constant-fold: if operand is an inline struct literal, resolve the field at rewrite time.
+        // This handles the case where PartiQL's `{'x': expr1, 'y': expr2}."x"` is simplified to `expr1`.
+        // None of Scribe's transpilation targets support inline struct literal path access.
+        if (operand is RexStruct) {
+            if (rex.key !is RexLit || rex.key.type.pType.code() != PType.STRING) {
+                error("Trino path expression on struct literal must use a string literal key.")
+            }
+            val keyName = (rex.key as RexLit).datum.string
+            for (field in operand.fields) {
+                val fieldKey = field.key
+                if (fieldKey is RexLit && fieldKey.datum.string == keyName) {
+                    return field.value
+                }
+            }
+            error("Struct literal does not contain field '$keyName'.")
+        }
+
+        if (operand.type.pType.code() != PType.ROW) {
+            error("Trino path expression must be on a ROW type (PartiQL STRUCT), found ${operand.type}")
         }
         if (rex.key !is RexLit) {
             error("Trino does not support path non-literal path expressions, found ${rex.key}")
@@ -84,7 +104,10 @@ public open class TrinoRewriter(internal val context: ScribeContext) : OperatorR
         if (rex.key.type.pType.code() != PType.STRING) {
             error("Trino path expression must be a string literal.")
         }
-        return super.visitPathKey(rex, ctx)
+        // Rebuild with the visited operand
+        val result = RexPathKey.create(operand, rex.key)
+        result.type = rex.type
+        return result
     }
 
     override fun visitPathSymbol(

--- a/src/test/kotlin/org/partiql/scribe/targets/trinosandbox/TrinoSandboxTargetSuite.kt
+++ b/src/test/kotlin/org/partiql/scribe/targets/trinosandbox/TrinoSandboxTargetSuite.kt
@@ -1,0 +1,18 @@
+package org.partiql.scribe.targets.trinosandbox
+
+import org.partiql.scribe.targets.SqlTargetSuite
+import org.partiql.scribe.targets.trino.TrinoTarget
+import org.partiql.scribe.utils.SessionProvider
+import kotlin.io.path.toPath
+
+/**
+ * Trino sandbox test suite for reproducing:
+ * UNION ALL with inline struct literal path access does not transpile correctly.
+ */
+class TrinoSandboxTargetSuite : SqlTargetSuite() {
+    override val target = TrinoTarget()
+
+    override val root = this::class.java.getResource("/outputs/trino-sandbox")!!.toURI().toPath()
+
+    override val sessions = SessionProvider()
+}

--- a/src/test/resources/inputs/trino-sandbox/trino-sandbox.sql
+++ b/src/test/resources/inputs/trino-sandbox/trino-sandbox.sql
@@ -1,0 +1,26 @@
+-- Reproduce: UNION ALL with inline struct literal path access
+-- The inline struct literal `{'x': t1.b, 'y': t1.c}."x"` should be constant-folded to `t1.b`
+
+-- Basic case: struct literal path access in first leg of UNION ALL
+--#[trino-sandbox-00]
+SELECT {'x': t1.b, 'y': t1.c}."x" AS a FROM SIMPLE_T AS t1 UNION ALL SELECT t2.b AS a FROM SIMPLE_T AS t2;
+
+-- Selecting the LAST field (not the first) to verify correct field matching
+--#[trino-sandbox-01]
+SELECT {'x': t1.b, 'y': t1.c}."y" AS a FROM SIMPLE_T AS t1 UNION ALL SELECT t2.c AS a FROM SIMPLE_T AS t2;
+
+-- Struct literal with only literal values (no column references)
+--#[trino-sandbox-02]
+SELECT {'x': 1, 'y': 'hello'}."y" AS a FROM SIMPLE_T AS t1 UNION ALL SELECT t2.c AS a FROM SIMPLE_T AS t2;
+
+-- Multiple struct literal path accesses in the same SELECT
+--#[trino-sandbox-03]
+SELECT {'x': t1.b, 'y': t1.c}."x" AS a, {'p': t1.c, 'q': t1.a}."p" AS b FROM SIMPLE_T AS t1 UNION ALL SELECT t2.b AS a, t2.c AS b FROM SIMPLE_T AS t2;
+
+-- Struct literal path access WITHOUT UNION ALL (plain SELECT)
+--#[trino-sandbox-04]
+SELECT {'x': t1.b, 'y': t1.c}."x" AS a FROM SIMPLE_T AS t1;
+
+-- Nested: struct literal resolves to a struct column, then path into that
+--#[trino-sandbox-05]
+SELECT {'inner': t1.d}."inner"."e" AS a FROM T AS t1 UNION ALL SELECT t2.c AS a FROM SIMPLE_T AS t2;

--- a/src/test/resources/outputs/trino-sandbox/trino-sandbox/trino-sandbox.sql
+++ b/src/test/resources/outputs/trino-sandbox/trino-sandbox/trino-sandbox.sql
@@ -1,0 +1,23 @@
+-- Basic case: struct literal path access in first leg of UNION ALL
+--#[trino-sandbox-00]
+(SELECT "t1"."b" AS "a" FROM "default"."SIMPLE_T" AS "t1") UNION ALL (SELECT "t2"."b" AS "a" FROM "default"."SIMPLE_T" AS "t2");
+
+-- Selecting the LAST field (not the first) to verify correct field matching
+--#[trino-sandbox-01]
+(SELECT "t1"."c" AS "a" FROM "default"."SIMPLE_T" AS "t1") UNION ALL (SELECT "t2"."c" AS "a" FROM "default"."SIMPLE_T" AS "t2");
+
+-- Struct literal with only literal values (no column references)
+--#[trino-sandbox-02]
+(SELECT 'hello' AS "a" FROM "default"."SIMPLE_T" AS "t1") UNION ALL (SELECT "t2"."c" AS "a" FROM "default"."SIMPLE_T" AS "t2");
+
+-- Multiple struct literal path accesses in the same SELECT
+--#[trino-sandbox-03]
+(SELECT "t1"."b" AS "a", "t1"."c" AS "b" FROM "default"."SIMPLE_T" AS "t1") UNION ALL (SELECT "t2"."b" AS "a", "t2"."c" AS "b" FROM "default"."SIMPLE_T" AS "t2");
+
+-- Struct literal path access WITHOUT UNION ALL (plain SELECT)
+--#[trino-sandbox-04]
+SELECT "t1"."b" AS "a" FROM "default"."SIMPLE_T" AS "t1";
+
+-- Nested: struct literal resolves to a struct column, then path into that
+--#[trino-sandbox-05]
+(SELECT "t1"."d"."e" AS "a" FROM "default"."T" AS "t1") UNION ALL (SELECT "t2"."c" AS "a" FROM "default"."SIMPLE_T" AS "t2");


### PR DESCRIPTION
When a UNION ALL query contains inline struct literal path access like `{'x': t1.b, 'y': t1.c}."x"`, the TrinoRewriter now resolves it at rewrite time to the matching field value (e.g., `t1.b`). This is necessary because none of Scribe's transpilation targets (Trino, Spark, Redshift) support PartiQL's `{key: value, ...}` struct literal syntax.

The issue was specifically triggered for UNION ALL queries where SQL Select columns get transcribed to a literal struct.

Added a Trino sandbox test suite to reproduce and verify the fix.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
