### PR TITLE
chore: Upgrade partiql-lang-kotlin submodule to v1.3.10

### DIFF
--- a/src/test/resources/outputs/partiql/builtins/datetime.sql
+++ b/src/test/resources/outputs/partiql/builtins/datetime.sql
@@ -2,22 +2,22 @@
 CURRENT_DATE;
 
 --#[datetime-01]
-INTERVAL '5' SECOND (9, 0) + TIME '12:34:56';
+DATE_ADD(SECOND, 5, TIME '12:34:56');
 
 --#[datetime-02]
-INTERVAL '5' MINUTE (9) + TIME '12:34:56';
+DATE_ADD(MINUTE, 5, TIME '12:34:56');
 
 --#[datetime-03]
-INTERVAL '5' HOUR (9) + TIME '12:34:56';
+DATE_ADD(HOUR, 5, TIME '12:34:56');
 
 --#[datetime-04]
-INTERVAL '5' DAY (9) + CURRENT_DATE;
+DATE_ADD(DAY, 5, CURRENT_DATE);
 
 --#[datetime-05]
-INTERVAL '5' MONTH (9) + CURRENT_DATE;
+DATE_ADD(MONTH, 5, CURRENT_DATE);
 
 --#[datetime-06]
-INTERVAL '5' YEAR (9) + CURRENT_DATE;
+DATE_ADD(YEAR, 5, CURRENT_DATE);
 
 --#[datetime-07]
 DATE_DIFF(DAY, CURRENT_DATE, CURRENT_DATE);
@@ -26,22 +26,22 @@ DATE_DIFF(DAY, CURRENT_DATE, CURRENT_DATE);
 SELECT CURRENT_DATE AS "CURRENT_DATE" FROM "default"."T" AS "T";
 
 --#[datetime-09]
-SELECT INTERVAL '5' SECOND (9, 0) + "T"['timestamp_1'] AS "_1" FROM "default"."T" AS "T";
+SELECT DATE_ADD(SECOND, 5, "T"['timestamp_1']) AS "_1" FROM "default"."T" AS "T";
 
 --#[datetime-10]
-SELECT INTERVAL '5' MINUTE (9) + "T"['timestamp_1'] AS "_1" FROM "default"."T" AS "T";
+SELECT DATE_ADD(MINUTE, 5, "T"['timestamp_1']) AS "_1" FROM "default"."T" AS "T";
 
 --#[datetime-11]
-SELECT INTERVAL '5' HOUR (9) + "T"['timestamp_1'] AS "_1" FROM "default"."T" AS "T";
+SELECT DATE_ADD(HOUR, 5, "T"['timestamp_1']) AS "_1" FROM "default"."T" AS "T";
 
 --#[datetime-12]
-SELECT INTERVAL '5' DAY (9) + CURRENT_DATE AS "_1" FROM "default"."T" AS "T";
+SELECT DATE_ADD(DAY, 5, CURRENT_DATE) AS "_1" FROM "default"."T" AS "T";
 
 --#[datetime-13]
-SELECT INTERVAL '5' MONTH (9) + CURRENT_DATE AS "_1" FROM "default"."T" AS "T";
+SELECT DATE_ADD(MONTH, 5, CURRENT_DATE) AS "_1" FROM "default"."T" AS "T";
 
 --#[datetime-14]
-SELECT INTERVAL '5' YEAR (9) + CURRENT_DATE AS "_1" FROM "default"."T" AS "T";
+SELECT DATE_ADD(YEAR, 5, CURRENT_DATE) AS "_1" FROM "default"."T" AS "T";
 
 --#[datetime-15]
 SELECT DATE_DIFF(YEAR, "T"['timestamp_1'], "T"['timestamp_2']) AS "_1" FROM "default"."T" AS "T";
@@ -62,7 +62,7 @@ SELECT DATE_DIFF(MINUTE, "T"['timestamp_1'], "T"['timestamp_2']) AS "_1" FROM "d
 SELECT DATE_DIFF(SECOND, "T"['timestamp_1'], "T"['timestamp_2']) AS "_1" FROM "default"."T" AS "T";
 
 --#[datetime-21]
-SELECT INTERVAL '1' SECOND (9, 0) + TIMESTAMP '2017-01-02 03:04:05.006' AS "_1" FROM "default"."T" AS "T";
+SELECT DATE_ADD(SECOND, 1, TIMESTAMP '2017-01-02 03:04:05.006') AS "_1" FROM "default"."T" AS "T";
 
 --#[datetime-22]
 SELECT DATE_DIFF(SECOND, TIMESTAMP '2017-01-02 03:04:05.006', TIMESTAMP '2017-01-02 03:04:20.006') AS "_1" FROM "default"."T" AS "T";

--- a/src/test/resources/outputs/redshift/builtins/datetime.sql
+++ b/src/test/resources/outputs/redshift/builtins/datetime.sql
@@ -4,22 +4,22 @@
 SELECT CURRENT_DATE AS "CURRENT_DATE" FROM "default"."T" AS "T";
 
 --#[datetime-09]
-SELECT INTERVAL '5' SECOND + CAST("T"."timestamp_1" AS TIMESTAMP) AS "_1" FROM "default"."T" AS "T";
+SELECT DATEADD(SECOND, 5, CAST("T"."timestamp_1" AS TIMESTAMP)) AS "_1" FROM "default"."T" AS "T";
 
 --#[datetime-10]
-SELECT INTERVAL '5' MINUTE + CAST("T"."timestamp_1" AS TIMESTAMP) AS "_1" FROM "default"."T" AS "T";
+SELECT DATEADD(MINUTE, 5, CAST("T"."timestamp_1" AS TIMESTAMP)) AS "_1" FROM "default"."T" AS "T";
 
 --#[datetime-11]
-SELECT INTERVAL '5' HOUR + CAST("T"."timestamp_1" AS TIMESTAMP) AS "_1" FROM "default"."T" AS "T";
+SELECT DATEADD(HOUR, 5, CAST("T"."timestamp_1" AS TIMESTAMP)) AS "_1" FROM "default"."T" AS "T";
 
 --#[datetime-12]
-SELECT INTERVAL '5' DAY + CURRENT_DATE AS "_1" FROM "default"."T" AS "T";
+SELECT DATEADD(DAY, 5, CURRENT_DATE) AS "_1" FROM "default"."T" AS "T";
 
 --#[datetime-13]
-SELECT INTERVAL '5' MONTH + CURRENT_DATE AS "_1" FROM "default"."T" AS "T";
+SELECT DATEADD(MONTH, 5, CURRENT_DATE) AS "_1" FROM "default"."T" AS "T";
 
 --#[datetime-14]
-SELECT INTERVAL '5' YEAR + CURRENT_DATE AS "_1" FROM "default"."T" AS "T";
+SELECT DATEADD(YEAR, 5, CURRENT_DATE) AS "_1" FROM "default"."T" AS "T";
 
 --#[datetime-15]
 SELECT DATEDIFF(YEAR, CAST("T"."timestamp_1" AS TIMESTAMP), CAST("T"."timestamp_2" AS TIMESTAMP)) AS "_1" FROM "default"."T" AS "T"
@@ -40,7 +40,7 @@ SELECT DATEDIFF(MINUTE, CAST("T"."timestamp_1" AS TIMESTAMP), CAST("T"."timestam
 SELECT DATEDIFF(SECOND, CAST("T"."timestamp_1" AS TIMESTAMP), CAST("T"."timestamp_2" AS TIMESTAMP)) AS "_1" FROM "default"."T" AS "T"
 
 --#[datetime-21]
-SELECT INTERVAL '1' SECOND + TIMESTAMP '2017-01-02 03:04:05.006' AS "_1" FROM "default"."T" AS "T";
+SELECT DATEADD(SECOND, 1, TIMESTAMP '2017-01-02 03:04:05.006') AS "_1" FROM "default"."T" AS "T";
 
 --#[datetime-22]
 SELECT DATEDIFF(SECOND, TIMESTAMP '2017-01-02 03:04:05.006', TIMESTAMP '2017-01-02 03:04:20.006') AS "_1" FROM "default"."T" AS "T";

--- a/src/test/resources/outputs/spark/builtins/builtins.sql
+++ b/src/test/resources/outputs/spark/builtins/builtins.sql
@@ -2,22 +2,22 @@
 SELECT CURRENT_DATE AS `CURRENT_DATE` FROM `default`.`T` AS `T`;
 
 --#[datetime-09]
-SELECT INTERVAL '5' SECOND + `T`.`timestamp_1` AS `_1` FROM `default`.`T` AS `T`;
+SELECT `T`.`timestamp_1` + `make_interval`(0, 0, 0, 0, 0, 0, 5) AS `_1` FROM `default`.`T` AS `T`;
 
 --#[datetime-10]
-SELECT INTERVAL '5' MINUTE + `T`.`timestamp_1` AS `_1` FROM `default`.`T` AS `T`;
+SELECT `T`.`timestamp_1` + `make_interval`(0, 0, 0, 0, 0, 5, 0) AS `_1` FROM `default`.`T` AS `T`;
 
 --#[datetime-11]
-SELECT INTERVAL '5' HOUR + `T`.`timestamp_1` AS `_1` FROM `default`.`T` AS `T`;
+SELECT `T`.`timestamp_1` + `make_interval`(0, 0, 0, 0, 5, 0, 0) AS `_1` FROM `default`.`T` AS `T`;
 
 --#[datetime-12]
-SELECT INTERVAL '5' DAY + CURRENT_DATE AS `_1` FROM `default`.`T` AS `T`;
+SELECT CURRENT_DATE + `make_interval`(0, 0, 0, 5, 0, 0, 0) AS `_1` FROM `default`.`T` AS `T`;
 
 --#[datetime-13]
-SELECT INTERVAL '5' MONTH + CURRENT_DATE AS `_1` FROM `default`.`T` AS `T`;
+SELECT CURRENT_DATE + `make_interval`(0, 5, 0, 0, 0, 0, 0) AS `_1` FROM `default`.`T` AS `T`;
 
 --#[datetime-14]
-SELECT INTERVAL '5' YEAR + CURRENT_DATE AS `_1` FROM `default`.`T` AS `T`;
+SELECT CURRENT_DATE + `make_interval`(5, 0, 0, 0, 0, 0, 0) AS `_1` FROM `default`.`T` AS `T`;
 
 --#[datetime-15]
 SELECT CAST(`months_between`(`T`.`timestamp_2`, `T`.`timestamp_1`) / 12 AS BIGINT) AS `_1` FROM `default`.`T` AS `T`;

--- a/src/test/resources/outputs/spark/builtins/datetime.sql
+++ b/src/test/resources/outputs/spark/builtins/datetime.sql
@@ -1,5 +1,5 @@
 --#[datetime-21]
-SELECT INTERVAL '1' SECOND + TIMESTAMP_NTZ '2017-01-02 03:04:05.006' AS `_1` FROM `default`.`T` AS `T`;
+SELECT TIMESTAMP_NTZ '2017-01-02 03:04:05.006' + `make_interval`(0, 0, 0, 0, 0, 0, 1) AS `_1` FROM `default`.`T` AS `T`;
 
 --#[datetime-22]
 SELECT `unix_timestamp`(TIMESTAMP_NTZ '2017-01-02 03:04:20.006') - `unix_timestamp`(TIMESTAMP_NTZ '2017-01-02 03:04:05.006') AS `_1` FROM `default`.`T` AS `T`;

--- a/src/test/resources/outputs/trino/builtins/datetime.sql
+++ b/src/test/resources/outputs/trino/builtins/datetime.sql
@@ -2,22 +2,22 @@
 SELECT current_date AS "CURRENT_DATE" FROM "default"."T" AS "T";
 
 --#[datetime-09]
-SELECT INTERVAL '5' SECOND + "T"."timestamp_1" AS "_1" FROM "default"."T" AS "T";
+SELECT date_add('second', 5, "T"."timestamp_1") AS "_1" FROM "default"."T" AS "T";
 
 --#[datetime-10]
-SELECT INTERVAL '5' MINUTE + "T"."timestamp_1" AS "_1" FROM "default"."T" AS "T";
+SELECT date_add('minute', 5, "T"."timestamp_1") AS "_1" FROM "default"."T" AS "T";
 
 --#[datetime-11]
-SELECT INTERVAL '5' HOUR + "T"."timestamp_1" AS "_1" FROM "default"."T" AS "T";
+SELECT date_add('hour', 5, "T"."timestamp_1") AS "_1" FROM "default"."T" AS "T";
 
 --#[datetime-12]
-SELECT INTERVAL '5' DAY + current_date AS "_1" FROM "default"."T" AS "T";
+SELECT date_add('day', 5, current_date) AS "_1" FROM "default"."T" AS "T";
 
 --#[datetime-13]
-SELECT INTERVAL '5' MONTH + current_date AS "_1" FROM "default"."T" AS "T";
+SELECT date_add('month', 5, current_date) AS "_1" FROM "default"."T" AS "T";
 
 --#[datetime-14]
-SELECT INTERVAL '5' YEAR + current_date AS "_1" FROM "default"."T" AS "T";
+SELECT date_add('year', 5, current_date) AS "_1" FROM "default"."T" AS "T";
 
 --#[datetime-15]
 SELECT date_diff('year', "T"."timestamp_1", "T"."timestamp_2") AS "_1" FROM "default"."T" AS "T";
@@ -38,7 +38,7 @@ SELECT date_diff('minute', "T"."timestamp_1", "T"."timestamp_2") AS "_1" FROM "d
 SELECT date_diff('second', "T"."timestamp_1", "T"."timestamp_2") AS "_1" FROM "default"."T" AS "T";
 
 --#[datetime-21]
-SELECT INTERVAL '1' SECOND + TIMESTAMP '2017-01-02 03:04:05.006' AS "_1" FROM "default"."T" AS "T";
+SELECT date_add('second', 1, TIMESTAMP '2017-01-02 03:04:05.006') AS "_1" FROM "default"."T" AS "T";
 
 --#[datetime-22]
 SELECT date_diff('second', TIMESTAMP '2017-01-02 03:04:05.006', TIMESTAMP '2017-01-02 03:04:20.006') AS "_1" FROM "default"."T" AS "T";


### PR DESCRIPTION
Update submodule to v1.3.10 which reverts the `DATE_ADD` to interval arithmetic lowering (partiql/partiql-lang-kotlin#1896). `DATE_ADD` now passes through as a function call rather than being rewritten to `INTERVAL + datetime` during planning.

Update expected test outputs for all targets (PartiQL, Trino, Spark, Redshift) to reflect the new DATE_ADD behavior:
- PartiQL: DATE_ADD passes through unchanged
- Trino: date_add('unit', n, expr)
- Redshift: DATEADD(UNIT, n, expr)
- Spark: expr + make_interval(...)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
