### PR TITLE
Add set operation with relaxed type matching Trino tests 

### DIFF
--- a/src/test/resources/inputs/basics/setop.sql
+++ b/src/test/resources/inputs/basics/setop.sql
@@ -18,3 +18,43 @@ SELECT c, b, a FROM SIMPLE_T AS t1 UNION ALL (SELECT c, b, a FROM SIMPLE_T AS t2
 
 --#[setop-05]
 SELECT * FROM SIMPLE_T AS t1 UNION ALL SELECT * FROM SIMPLE_T AS t2 UNION SELECT * FROM SIMPLE_T AS t3;
+
+-- Set operations on columns of compatible but distinct types, requiring type coercion
+
+-- No column aliases
+--#[setop-06]
+SELECT col_int32, col_timestamp, col_float64 FROM T_ALL_TYPES AS t1 UNION SELECT col_int64, col_date, col_decimal FROM T_ALL_TYPES AS t2;
+
+-- Explicit column aliases
+--#[setop-07]
+SELECT col_int32 AS a, col_timestamp AS b, col_float64 AS c FROM T_ALL_TYPES AS t1 UNION SELECT col_int64 AS a, col_date AS b, col_decimal AS c FROM T_ALL_TYPES AS t2;
+
+--#[setop-08]
+SELECT col_int32, col_timestamp, col_float64 FROM T_ALL_TYPES AS t1 UNION ALL SELECT col_int64, col_date, col_decimal FROM T_ALL_TYPES AS t2;
+
+--#[setop-09]
+SELECT col_int32, col_timestamp, col_float64 FROM T_ALL_TYPES AS t1 EXCEPT SELECT col_int64, col_date, col_decimal FROM T_ALL_TYPES AS t2;
+
+--#[setop-10]
+SELECT col_int32, col_timestamp, col_float64 FROM T_ALL_TYPES AS t1 EXCEPT ALL SELECT col_int64, col_date, col_decimal FROM T_ALL_TYPES AS t2;
+
+--#[setop-11]
+SELECT col_int32, col_timestamp, col_float64 FROM T_ALL_TYPES AS t1 INTERSECT SELECT col_int64, col_date, col_decimal FROM T_ALL_TYPES AS t2;
+
+--#[setop-12]
+SELECT col_int32, col_timestamp, col_float64 FROM T_ALL_TYPES AS t1 INTERSECT ALL SELECT col_int64, col_date, col_decimal FROM T_ALL_TYPES AS t2;
+
+-- Different kinds of expressions with relaxed type matching
+--#[setop-13]
+SELECT
+    CASE WHEN col_int32 = 0 THEN 0. ELSE 1. / col_int32 END,
+    DATE '2026-04-15',
+    (col_float64 * 3) - 10
+FROM T_ALL_TYPES AS t1
+
+INTERSECT ALL SELECT
+    CHAR_LENGTH(col_string),
+    col_timestamp,
+    (SELECT 123.45 FROM T_ALL_TYPES)
+FROM T_ALL_TYPES AS t2;
+

--- a/src/test/resources/outputs/trino/basics/setop.sql
+++ b/src/test/resources/outputs/trino/basics/setop.sql
@@ -18,3 +18,27 @@
 
 --#[setop-05]
 ((SELECT "t1"."a" AS "a", "t1"."b" AS "b", "t1"."c" AS "c" FROM "default"."SIMPLE_T" AS "t1") UNION ALL (SELECT "t2"."a" AS "a", "t2"."b" AS "b", "t2"."c" AS "c" FROM "default"."SIMPLE_T" AS "t2")) UNION DISTINCT (SELECT "t3"."a" AS "a", "t3"."b" AS "b", "t3"."c" AS "c" FROM "default"."SIMPLE_T" AS "t3");
+
+--#[setop-06]
+(SELECT CAST("t1"."col_int32" AS BIGINT) AS "_", "t1"."col_timestamp" AS "_", "t1"."col_float64" AS "_" FROM "default"."T_ALL_TYPES" AS "t1") UNION DISTINCT (SELECT "t2"."col_int64" AS "_", CAST("t2"."col_date" AS TIMESTAMP) AS "_", CAST("t2"."col_decimal" AS DOUBLE) AS "_" FROM "default"."T_ALL_TYPES" AS "t2");
+
+--#[setop-07]
+(SELECT CAST("t1"."col_int32" AS BIGINT) AS "a", "t1"."col_timestamp" AS "b", "t1"."col_float64" AS "c" FROM "default"."T_ALL_TYPES" AS "t1") UNION DISTINCT (SELECT "t2"."col_int64" AS "a", CAST("t2"."col_date" AS TIMESTAMP) AS "b", CAST("t2"."col_decimal" AS DOUBLE) AS "c" FROM "default"."T_ALL_TYPES" AS "t2");
+
+--#[setop-08]
+(SELECT CAST("t1"."col_int32" AS BIGINT) AS "_", "t1"."col_timestamp" AS "_", "t1"."col_float64" AS "_" FROM "default"."T_ALL_TYPES" AS "t1") UNION ALL (SELECT "t2"."col_int64" AS "_", CAST("t2"."col_date" AS TIMESTAMP) AS "_", CAST("t2"."col_decimal" AS DOUBLE) AS "_" FROM "default"."T_ALL_TYPES" AS "t2");
+
+--#[setop-09]
+(SELECT CAST("t1"."col_int32" AS BIGINT) AS "_", "t1"."col_timestamp" AS "_", "t1"."col_float64" AS "_" FROM "default"."T_ALL_TYPES" AS "t1") EXCEPT DISTINCT (SELECT "t2"."col_int64" AS "_", CAST("t2"."col_date" AS TIMESTAMP) AS "_", CAST("t2"."col_decimal" AS DOUBLE) AS "_" FROM "default"."T_ALL_TYPES" AS "t2");
+
+--#[setop-10]
+(SELECT CAST("t1"."col_int32" AS BIGINT) AS "_", "t1"."col_timestamp" AS "_", "t1"."col_float64" AS "_" FROM "default"."T_ALL_TYPES" AS "t1") EXCEPT ALL (SELECT "t2"."col_int64" AS "_", CAST("t2"."col_date" AS TIMESTAMP) AS "_", CAST("t2"."col_decimal" AS DOUBLE) AS "_" FROM "default"."T_ALL_TYPES" AS "t2");
+
+--#[setop-11]
+(SELECT CAST("t1"."col_int32" AS BIGINT) AS "_", "t1"."col_timestamp" AS "_", "t1"."col_float64" AS "_" FROM "default"."T_ALL_TYPES" AS "t1") INTERSECT DISTINCT (SELECT "t2"."col_int64" AS "_", CAST("t2"."col_date" AS TIMESTAMP) AS "_", CAST("t2"."col_decimal" AS DOUBLE) AS "_" FROM "default"."T_ALL_TYPES" AS "t2");
+
+--#[setop-12]
+(SELECT CAST("t1"."col_int32" AS BIGINT) AS "_", "t1"."col_timestamp" AS "_", "t1"."col_float64" AS "_" FROM "default"."T_ALL_TYPES" AS "t1") INTERSECT ALL (SELECT "t2"."col_int64" AS "_", CAST("t2"."col_date" AS TIMESTAMP) AS "_", CAST("t2"."col_decimal" AS DOUBLE) AS "_" FROM "default"."T_ALL_TYPES" AS "t2");
+
+--#[setop-13]
+(SELECT CAST(CASE WHEN "t1"."col_int32" = 0 THEN 0 ELSE 1 / CAST("t1"."col_int32" AS DECIMAL(10,0)) END AS DECIMAL(21,11)) AS "_1", CAST(DATE '2026-04-15' AS TIMESTAMP) AS "_", ("t1"."col_float64" * CAST(3 AS DOUBLE)) - CAST(10 AS DOUBLE) AS "_" FROM "default"."T_ALL_TYPES" AS "t1") INTERSECT ALL (SELECT CAST("char_length"("t2"."col_string") AS DECIMAL(21,11)) AS "_1", "t2"."col_timestamp" AS "_", CAST((SELECT 123.45 AS "_1" FROM "default"."T_ALL_TYPES" AS "T_ALL_TYPES") AS DOUBLE) AS "_" FROM "default"."T_ALL_TYPES" AS "t2")


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Add tests for `UNION/EXCEPT/INTERSECT` with relaxed type matching transpilation to Trino.

See core fix in partiql-lang-kotlin: https://github.com/partiql/partiql-lang-kotlin/pull/1904

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
