### PR TITLE
fix: Convert LHS ExprArray to exprRowValue in IN collection

### DIFF
--- a/src/main/kotlin/org/partiql/scribe/sql/SqlCalls.kt
+++ b/src/main/kotlin/org/partiql/scribe/sql/SqlCalls.kt
@@ -246,12 +246,17 @@ public abstract class SqlCalls(context: ScribeContext) {
             }
             is ExprBetween -> exprBetween(arg.value, arg.from, arg.to, arg.isNot.flip())
             is ExprInCollection -> {
-                val collection =
+                val lhs =
+                    when (val l = arg.lhs) {
+                        is ExprArray -> exprRowValue(l.values)
+                        else -> l
+                    }
+                val rhs =
                     when (val coll = arg.rhs) {
-                        is ExprArray -> exprRowValue(coll.values)
+                        is ExprArray -> exprRowValue(coll.values.map { arrayToRowValue(it) })
                         else -> coll
                     }
-                exprInCollection(arg.lhs, collection, arg.isNot.flip())
+                exprInCollection(lhs, rhs, arg.isNot.flip())
             }
             is ExprIsType -> exprIsType(arg.value, arg.type, arg.isNot.flip())
             is ExprLike -> exprLike(arg.value, arg.pattern, arg.escape, arg.isNot.flip())
@@ -319,13 +324,24 @@ public abstract class SqlCalls(context: ScribeContext) {
 
     // functions to operator
     public open fun inCollection(args: SqlArgs): Expr {
-        val collection =
+        val lhs =
+            when (val arg0 = args[0].expr) {
+                is ExprArray -> exprRowValue(arg0.values)
+                else -> arg0
+            }
+        val rhs =
             when (val arg1 = args[1].expr) {
-                is ExprArray -> exprRowValue(arg1.values)
+                is ExprArray -> exprRowValue(arg1.values.map { arrayToRowValue(it) })
                 else -> arg1
             }
-        return exprInCollection(args[0].expr, collection, false)
+        return exprInCollection(lhs, rhs, false)
     }
+
+    private fun arrayToRowValue(expr: Expr): Expr =
+        when (expr) {
+            is ExprArray -> exprRowValue(expr.values)
+            else -> expr
+        }
 
     public open fun between(args: SqlArgs): Expr = exprBetween(args[0].expr, args[1].expr, args[2].expr, false)
 

--- a/src/test/resources/inputs/operators/in.sql
+++ b/src/test/resources/inputs/operators/in.sql
@@ -15,3 +15,9 @@ SELECT * FROM T WHERE b NOT IN [1, 2];
 
 --#[in-05]
 SELECT * FROM T WHERE b NOT IN << 1, 2 >>;
+
+--#[in-06]
+SELECT * FROM T WHERE (b, c) IN ((1, 'hello'), (2, 'world'));
+
+--#[in-07]
+SELECT * FROM T WHERE (b, c) NOT IN ((1, 'hello'), (2, 'world'));

--- a/src/test/resources/outputs/redshift/operators/in.sql
+++ b/src/test/resources/outputs/redshift/operators/in.sql
@@ -15,3 +15,9 @@ SELECT "T"."a", "T"."b", "T"."c", "T"."d", "T"."x", "T"."array", "T"."z", "T"."v
 
 --#[in-05]
 SELECT "T"."a", "T"."b", "T"."c", "T"."d", "T"."x", "T"."array", "T"."z", "T"."v", "T"."timestamp_1", "T"."timestamp_2" FROM "default"."T" AS "T" WHERE "T"."b" NOT IN (1, 2);
+
+--#[in-06]
+SELECT "T"."a", "T"."b", "T"."c", "T"."d", "T"."x", "T"."array", "T"."z", "T"."v", "T"."timestamp_1", "T"."timestamp_2" FROM "default"."T" AS "T" WHERE ("T"."b", "T"."c") IN ((1, 'hello'), (2, 'world'));
+
+--#[in-07]
+SELECT "T"."a", "T"."b", "T"."c", "T"."d", "T"."x", "T"."array", "T"."z", "T"."v", "T"."timestamp_1", "T"."timestamp_2" FROM "default"."T" AS "T" WHERE ("T"."b", "T"."c") NOT IN ((1, 'hello'), (2, 'world'));

--- a/src/test/resources/outputs/spark/operators/in.sql
+++ b/src/test/resources/outputs/spark/operators/in.sql
@@ -15,3 +15,9 @@ SELECT `T`.`a` AS `a`, `T`.`b` AS `b`, `T`.`c` AS `c`, `T`.`d` AS `d`, `T`.`x` A
 
 --#[in-05]
 SELECT `T`.`a` AS `a`, `T`.`b` AS `b`, `T`.`c` AS `c`, `T`.`d` AS `d`, `T`.`x` AS `x`, `T`.`array` AS `array`, `T`.`z` AS `z`, `T`.`v` AS `v`, `T`.`timestamp_1` AS `timestamp_1`, `T`.`timestamp_2` AS `timestamp_2` FROM `default`.`T` AS `T` WHERE `T`.`b` NOT IN (1, 2);
+
+--#[in-06]
+SELECT `T`.`a` AS `a`, `T`.`b` AS `b`, `T`.`c` AS `c`, `T`.`d` AS `d`, `T`.`x` AS `x`, `T`.`array` AS `array`, `T`.`z` AS `z`, `T`.`v` AS `v`, `T`.`timestamp_1` AS `timestamp_1`, `T`.`timestamp_2` AS `timestamp_2` FROM `default`.`T` AS `T` WHERE (`T`.`b`, `T`.`c`) IN ((1, 'hello'), (2, 'world'));
+
+--#[in-07]
+SELECT `T`.`a` AS `a`, `T`.`b` AS `b`, `T`.`c` AS `c`, `T`.`d` AS `d`, `T`.`x` AS `x`, `T`.`array` AS `array`, `T`.`z` AS `z`, `T`.`v` AS `v`, `T`.`timestamp_1` AS `timestamp_1`, `T`.`timestamp_2` AS `timestamp_2` FROM `default`.`T` AS `T` WHERE (`T`.`b`, `T`.`c`) NOT IN ((1, 'hello'), (2, 'world'));

--- a/src/test/resources/outputs/trino/operators/in.sql
+++ b/src/test/resources/outputs/trino/operators/in.sql
@@ -15,3 +15,9 @@ SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" A
 
 --#[in-05]
 SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T" WHERE "T"."b" NOT IN (1, 2);
+
+--#[in-06]
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T" WHERE ("T"."b", "T"."c") IN ((1, 'hello'), (2, 'world'));
+
+--#[in-07]
+SELECT "T"."a" AS "a", "T"."b" AS "b", "T"."c" AS "c", "T"."d" AS "d", "T"."x" AS "x", "T"."array" AS "array", "T"."z" AS "z", "T"."v" AS "v", "T"."timestamp_1" AS "timestamp_1", "T"."timestamp_2" AS "timestamp_2" FROM "default"."T" AS "T" WHERE ("T"."b", "T"."c") NOT IN ((1, 'hello'), (2, 'world'));


### PR DESCRIPTION
## Problem

  `WHERE (col1, col2, col3) IN (SELECT ...)` emits `ARRAY[col1, col2, col3] IN (SELECT ...)`, Trino/Athena rejects with `All ARRAY elements must be the same type` when columns have heterogeneous types.

  ## Fix

  Convert `ExprArray` to `exprRowValue` for both LHS and RHS (including nested tuples) in `inCollection()` and `notFn()`.

  Test cases added for Trino, Spark and Redshift.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
