### PR TITLE
Add support to transcirbe MAP data type in Scibe

### DIFF
--- a/api/Scribe.api
+++ b/api/Scribe.api
@@ -242,6 +242,8 @@ public class org/partiql/scribe/sql/RexConverter : org/partiql/plan/OperatorVisi
 	public fun visitError (Lorg/partiql/plan/rex/RexError;Lkotlin/Unit;)Lorg/partiql/ast/expr/Expr;
 	public synthetic fun visitLit (Lorg/partiql/plan/rex/RexLit;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitLit (Lorg/partiql/plan/rex/RexLit;Lkotlin/Unit;)Lorg/partiql/ast/expr/Expr;
+	public synthetic fun visitMap (Lorg/partiql/plan/rex/RexMap;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitMap (Lorg/partiql/plan/rex/RexMap;Lkotlin/Unit;)Lorg/partiql/ast/expr/Expr;
 	public synthetic fun visitNullIf (Lorg/partiql/plan/rex/RexNullIf;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitNullIf (Lorg/partiql/plan/rex/RexNullIf;Lkotlin/Unit;)Lorg/partiql/ast/expr/Expr;
 	public synthetic fun visitPathIndex (Lorg/partiql/plan/rex/RexPathIndex;Ljava/lang/Object;)Ljava/lang/Object;
@@ -373,6 +375,8 @@ public class org/partiql/scribe/targets/redshift/RedshiftAstToSql : org/partiql/
 	public fun visitExprBag (Lorg/partiql/ast/expr/ExprBag;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExprCall (Lorg/partiql/ast/expr/ExprCall;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprCall (Lorg/partiql/ast/expr/ExprCall;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
+	public synthetic fun visitExprMap (Lorg/partiql/ast/expr/ExprMap;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitExprMap (Lorg/partiql/ast/expr/ExprMap;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExprQuerySet (Lorg/partiql/ast/expr/ExprQuerySet;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprQuerySet (Lorg/partiql/ast/expr/ExprQuerySet;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExprStruct (Lorg/partiql/ast/expr/ExprStruct;Ljava/lang/Object;)Ljava/lang/Object;
@@ -449,6 +453,8 @@ public class org/partiql/scribe/targets/redshift/RedshiftRexConverter : org/part
 	public fun visitDispatch (Lorg/partiql/plan/rex/RexDispatch;Lkotlin/Unit;)Lorg/partiql/ast/expr/Expr;
 	public synthetic fun visitLit (Lorg/partiql/plan/rex/RexLit;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitLit (Lorg/partiql/plan/rex/RexLit;Lkotlin/Unit;)Lorg/partiql/ast/expr/Expr;
+	public synthetic fun visitMap (Lorg/partiql/plan/rex/RexMap;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitMap (Lorg/partiql/plan/rex/RexMap;Lkotlin/Unit;)Lorg/partiql/ast/expr/Expr;
 	public synthetic fun visitNullIf (Lorg/partiql/plan/rex/RexNullIf;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitNullIf (Lorg/partiql/plan/rex/RexNullIf;Lkotlin/Unit;)Lorg/partiql/ast/expr/Expr;
 }
@@ -480,6 +486,8 @@ public class org/partiql/scribe/targets/spark/SparkAstToSql : org/partiql/scribe
 	public fun visitExprBag (Lorg/partiql/ast/expr/ExprBag;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExprCall (Lorg/partiql/ast/expr/ExprCall;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprCall (Lorg/partiql/ast/expr/ExprCall;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
+	public synthetic fun visitExprMap (Lorg/partiql/ast/expr/ExprMap;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitExprMap (Lorg/partiql/ast/expr/ExprMap;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExprQuerySet (Lorg/partiql/ast/expr/ExprQuerySet;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprQuerySet (Lorg/partiql/ast/expr/ExprQuerySet;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExprStruct (Lorg/partiql/ast/expr/ExprStruct;Ljava/lang/Object;)Ljava/lang/Object;
@@ -552,6 +560,8 @@ public class org/partiql/scribe/targets/spark/SparkRexConverter : org/partiql/sc
 	public fun visitCall (Lorg/partiql/plan/rex/RexCall;Lkotlin/Unit;)Lorg/partiql/ast/expr/Expr;
 	public synthetic fun visitLit (Lorg/partiql/plan/rex/RexLit;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitLit (Lorg/partiql/plan/rex/RexLit;Lkotlin/Unit;)Lorg/partiql/ast/expr/Expr;
+	public synthetic fun visitPathKey (Lorg/partiql/plan/rex/RexPathKey;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitPathKey (Lorg/partiql/plan/rex/RexPathKey;Lkotlin/Unit;)Lorg/partiql/ast/expr/Expr;
 }
 
 public class org/partiql/scribe/targets/spark/SparkTarget : org/partiql/scribe/sql/SqlTarget {
@@ -585,6 +595,8 @@ public class org/partiql/scribe/targets/trino/TrinoAstToSql : org/partiql/scribe
 	public fun visitExprCast (Lorg/partiql/ast/expr/ExprCast;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExprLit (Lorg/partiql/ast/expr/ExprLit;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprLit (Lorg/partiql/ast/expr/ExprLit;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
+	public synthetic fun visitExprMap (Lorg/partiql/ast/expr/ExprMap;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitExprMap (Lorg/partiql/ast/expr/ExprMap;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExprQuerySet (Lorg/partiql/ast/expr/ExprQuerySet;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprQuerySet (Lorg/partiql/ast/expr/ExprQuerySet;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExprSessionAttribute (Lorg/partiql/ast/expr/ExprSessionAttribute;Ljava/lang/Object;)Ljava/lang/Object;
@@ -652,6 +664,8 @@ public class org/partiql/scribe/targets/trino/TrinoRexConverter : org/partiql/sc
 	public fun <init> (Lorg/partiql/scribe/sql/PlanToAst;Lorg/partiql/scribe/sql/Locals;Lorg/partiql/scribe/ScribeContext;)V
 	public synthetic fun visitLit (Lorg/partiql/plan/rex/RexLit;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitLit (Lorg/partiql/plan/rex/RexLit;Lkotlin/Unit;)Lorg/partiql/ast/expr/Expr;
+	public synthetic fun visitPathKey (Lorg/partiql/plan/rex/RexPathKey;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitPathKey (Lorg/partiql/plan/rex/RexPathKey;Lkotlin/Unit;)Lorg/partiql/ast/expr/Expr;
 }
 
 public class org/partiql/scribe/targets/trino/TrinoTarget : org/partiql/scribe/sql/SqlTarget {

--- a/src/main/kotlin/org/partiql/scribe/sql/RexConverter.kt
+++ b/src/main/kotlin/org/partiql/scribe/sql/RexConverter.kt
@@ -26,6 +26,7 @@ import org.partiql.ast.Literal
 import org.partiql.ast.SetOpType
 import org.partiql.ast.SetQuantifier
 import org.partiql.ast.expr.Expr
+import org.partiql.ast.expr.ExprMap
 import org.partiql.ast.expr.ExprPath
 import org.partiql.plan.Operator
 import org.partiql.plan.OperatorVisitor
@@ -40,6 +41,7 @@ import org.partiql.plan.rex.RexCoalesce
 import org.partiql.plan.rex.RexDispatch
 import org.partiql.plan.rex.RexError
 import org.partiql.plan.rex.RexLit
+import org.partiql.plan.rex.RexMap
 import org.partiql.plan.rex.RexNullIf
 import org.partiql.plan.rex.RexPathIndex
 import org.partiql.plan.rex.RexPathKey
@@ -490,6 +492,15 @@ public open class RexConverter(
                         )
                 }
             }
+            PType.MAP -> {
+                val keyType = pType.keyType.toDataType()
+                val valueType = pType.valueType.toDataType()
+                if (keyType == null || valueType == null) {
+                    null
+                } else {
+                    DataType.MAP(keyType, valueType)
+                }
+            }
             else -> null
         }
     }
@@ -882,6 +893,21 @@ public open class RexConverter(
                 )
             }
         return exprStruct(fields)
+    }
+
+    @Suppress("DEPRECATION")
+    override fun visitMap(
+        rex: RexMap,
+        ctx: Unit,
+    ): Expr {
+        val entries =
+            rex.entries.map {
+                ExprMap.Entry(
+                    visitRex(it.key, ctx),
+                    visitRex(it.value, ctx),
+                )
+            }
+        return ExprMap(entries)
     }
 
     override fun visitSubquery(

--- a/src/main/kotlin/org/partiql/scribe/sql/utils/ConversionUtils.kt
+++ b/src/main/kotlin/org/partiql/scribe/sql/utils/ConversionUtils.kt
@@ -166,27 +166,27 @@ internal fun removePathRoot(expr: Expr): Expr {
         is ExprPath -> {
             val steps = expr.steps
             val first = expr.steps.first()
-            if (first is PathStep.Element && first.element is ExprLit) {
+            if (first is PathStep.Element && first.element is ExprLit) { // e.g. T['a'] — bracket notation with literal key
                 val newFirst = exprVarRef(Identifier.delimited((first.element as ExprLit).lit.stringValue()), isQualified = false)
-                if (steps.size == 1) {
+                if (steps.size == 1) { // T['a'] -> "a"
                     newFirst
-                } else {
+                } else { // T['a']['b'] -> "a"['b']
                     exprPath(
                         newFirst,
                         steps.drop(1),
                     )
                 }
-            } else if (first is PathStep.Field) {
+            } else if (first is PathStep.Field) { // e.g. T.a — dot notation field access
                 val newFirst = exprVarRef(Identifier.delimited(first.field.text), isQualified = false)
-                if (steps.size == 1) {
+                if (steps.size == 1) { // T.a -> "a"
                     newFirst
-                } else {
+                } else { // T.a.b -> "a".b
                     exprPath(
                         newFirst,
                         steps.drop(1),
                     )
                 }
-            } else {
+            } else { // unsupported path step type (e.g. wildcard), return as-is
                 expr
             }
         }

--- a/src/main/kotlin/org/partiql/scribe/sql/utils/ConversionUtils.kt
+++ b/src/main/kotlin/org/partiql/scribe/sql/utils/ConversionUtils.kt
@@ -169,10 +169,18 @@ internal fun removePathRoot(expr: Expr): Expr {
             if (first is PathStep.Element && first.element is ExprLit) {
                 val newFirst = exprVarRef(Identifier.delimited((first.element as ExprLit).lit.stringValue()), isQualified = false)
                 if (steps.size == 1) {
-                    // One path step so just return that expr
                     newFirst
                 } else {
-                    // Create a new path
+                    exprPath(
+                        newFirst,
+                        steps.drop(1),
+                    )
+                }
+            } else if (first is PathStep.Field) {
+                val newFirst = exprVarRef(Identifier.delimited(first.field.text), isQualified = false)
+                if (steps.size == 1) {
+                    newFirst
+                } else {
                     exprPath(
                         newFirst,
                         steps.drop(1),

--- a/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftAstToSql.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftAstToSql.kt
@@ -17,6 +17,7 @@ import org.partiql.ast.expr.ExprArray
 import org.partiql.ast.expr.ExprBag
 import org.partiql.ast.expr.ExprCall
 import org.partiql.ast.expr.ExprLit
+import org.partiql.ast.expr.ExprMap
 import org.partiql.ast.expr.ExprPath
 import org.partiql.ast.expr.ExprQuerySet
 import org.partiql.ast.expr.ExprStruct
@@ -77,6 +78,26 @@ public open class RedshiftAstToSql(context: ScribeContext) : AstToSql(context) {
         t = visitExprWrapped(node.name, t)
         t = t concat ", "
         t = visitExprWrapped(node.value, t)
+        return t
+    }
+
+    // Redshift's equivalent for PartiQL's MAP type is SUPER OBJECT. Use the `OBJECT` function.
+    // https://docs.aws.amazon.com/redshift/latest/dg/r_object_function.html
+    @Suppress("DEPRECATION")
+    override fun visitExprMap(
+        node: ExprMap,
+        tail: SqlBlock,
+    ): SqlBlock {
+        var t = tail concat "OBJECT("
+        node.entries.forEachIndexed { index, entry ->
+            t = visitExprWrapped(entry.key, t)
+            t = t concat ", "
+            t = visitExprWrapped(entry.value, t)
+            if (index < node.entries.size - 1) {
+                t = t concat ", "
+            }
+        }
+        t = t concat ")"
         return t
     }
 
@@ -213,6 +234,17 @@ public open class RedshiftAstToSql(context: ScribeContext) : AstToSql(context) {
                     ),
                 )
                 tail concat type("VARCHAR", 65535, gap = false)
+            }
+            DataType.MAP -> {
+                listener.report(
+                    ScribeProblem.simpleInfo(
+                        code = ScribeProblem.TRANSLATION_INFO,
+                        message =
+                            "Redshift does not support PartiQL's MAP type. " +
+                                "Replaced with SUPER.",
+                    ),
+                )
+                tail concat "SUPER"
             }
 
             // Redshift does not honor the precision but store values with up to a maximum of six digits of precision for fractional seconds.

--- a/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftCalls.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftCalls.kt
@@ -1,10 +1,16 @@
 package org.partiql.scribe.targets.redshift
 
 import org.partiql.ast.Ast.exprCall
+import org.partiql.ast.Ast.exprNullPredicate
+import org.partiql.ast.Ast.exprPath
+import org.partiql.ast.Ast.exprPathStepElement
 import org.partiql.ast.Ast.exprVarRef
 import org.partiql.ast.DatetimeField
 import org.partiql.ast.Identifier
+import org.partiql.ast.Literal
 import org.partiql.ast.expr.Expr
+import org.partiql.ast.expr.ExprLit
+import org.partiql.ast.expr.ExprPath
 import org.partiql.scribe.ScribeContext
 import org.partiql.scribe.problems.ScribeProblem
 import org.partiql.scribe.sql.SqlArg
@@ -157,7 +163,7 @@ public open class RedshiftCalls(context: ScribeContext) : SqlCalls(context) {
     private fun mapGet(args: SqlArgs): Expr {
         val mapExpr = args[0].expr
         val keyExpr = args[1].expr
-        if (keyExpr !is org.partiql.ast.expr.ExprLit || keyExpr.lit.code() != org.partiql.ast.Literal.STRING) {
+        if (keyExpr !is ExprLit || keyExpr.lit.code() != Literal.STRING) {
             listener.reportAndThrow(
                 ScribeProblem.simpleError(
                     ScribeProblem.UNSUPPORTED_OPERATION,
@@ -171,21 +177,39 @@ public open class RedshiftCalls(context: ScribeContext) : SqlCalls(context) {
                 message = "PartiQL `map_get` was replaced by Redshift dot notation access on SUPER type",
             ),
         )
-        val step = org.partiql.ast.Ast.exprPathStepElement(keyExpr)
-        return if (mapExpr is org.partiql.ast.expr.ExprPath) {
-            org.partiql.ast.Ast.exprPath(mapExpr.root, mapExpr.steps + step)
+        val step = exprPathStepElement(keyExpr)
+        return if (mapExpr is ExprPath) {
+            exprPath(mapExpr.root, mapExpr.steps + step)
         } else {
-            org.partiql.ast.Ast.exprPath(mapExpr, listOf(step))
+            exprPath(mapExpr, listOf(step))
         }
     }
 
     private fun mapContainsKey(args: SqlArgs): Expr {
-        listener.reportAndThrow(
-            ScribeProblem.simpleError(
-                ScribeProblem.UNSUPPORTED_OPERATION,
-                "Redshift does not support `map_contains_key`. No equivalent function available for SUPER type.",
+        val mapExpr = args[0].expr
+        val keyExpr = args[1].expr
+        if (keyExpr !is ExprLit || keyExpr.lit.code() != Literal.STRING) {
+            listener.reportAndThrow(
+                ScribeProblem.simpleError(
+                    ScribeProblem.UNSUPPORTED_OPERATION,
+                    "Redshift `map_contains_key` only supports string literal keys.",
+                ),
+            )
+        }
+        listener.report(
+            ScribeProblem.simpleInfo(
+                code = ScribeProblem.TRANSLATION_INFO,
+                message = "PartiQL `map_contains_key` was replaced by Redshift `map.\"key\" IS NOT NULL`",
             ),
         )
+        val step = exprPathStepElement(keyExpr)
+        val pathExpr =
+            if (mapExpr is ExprPath) {
+                exprPath(mapExpr.root, mapExpr.steps + step)
+            } else {
+                exprPath(mapExpr, listOf(step))
+            }
+        return exprNullPredicate(pathExpr, not = true)
     }
 
     private fun sizeFn(args: SqlArgs): Expr {

--- a/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftCalls.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftCalls.kt
@@ -28,6 +28,7 @@ public open class RedshiftCalls(context: ScribeContext) : SqlCalls(context) {
             this["map_values"] = ::mapValues
             this["map_entries"] = ::mapEntries
             this["map_get"] = ::mapGet
+            this["map_contains_key"] = ::mapContainsKey
         }
 
     /**
@@ -178,11 +179,11 @@ public open class RedshiftCalls(context: ScribeContext) : SqlCalls(context) {
         }
     }
 
-    private fun containsKey(args: SqlArgs): Expr {
+    private fun mapContainsKey(args: SqlArgs): Expr {
         listener.reportAndThrow(
             ScribeProblem.simpleError(
                 ScribeProblem.UNSUPPORTED_OPERATION,
-                "Redshift does not support `contains_key`. No equivalent function available for SUPER type.",
+                "Redshift does not support `map_contains_key`. No equivalent function available for SUPER type.",
             ),
         )
     }

--- a/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftCalls.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftCalls.kt
@@ -23,6 +23,11 @@ public open class RedshiftCalls(context: ScribeContext) : SqlCalls(context) {
             // Extensions
             this["split"] = ::split
             this["OBJECT_TRANSFORM"] = ::objectTransform
+            // MAP functions
+            this["map_keys"] = ::mapKeys
+            this["map_values"] = ::mapValues
+            this["map_entries"] = ::mapEntries
+            this["map_get"] = ::mapGet
         }
 
     /**
@@ -115,6 +120,98 @@ public open class RedshiftCalls(context: ScribeContext) : SqlCalls(context) {
         val arg1 = args[0].expr
         val arg2 = args[1].expr
         return exprCall(id, listOf(arg0, arg1, arg2))
+    }
+
+    private fun mapKeys(args: SqlArgs): Expr {
+        listener.reportAndThrow(
+            ScribeProblem.simpleError(
+                ScribeProblem.UNSUPPORTED_OPERATION,
+                "Redshift does not support `map_keys` on SUPER type. No equivalent function available.",
+            ),
+        )
+    }
+
+    private fun mapValues(args: SqlArgs): Expr {
+        listener.reportAndThrow(
+            ScribeProblem.simpleError(
+                ScribeProblem.UNSUPPORTED_OPERATION,
+                "Redshift does not support `map_values` on SUPER type. No equivalent function available.",
+            ),
+        )
+    }
+
+    private fun mapEntries(args: SqlArgs): Expr {
+        listener.reportAndThrow(
+            ScribeProblem.simpleError(
+                ScribeProblem.UNSUPPORTED_OPERATION,
+                "Redshift does not support `map_entries` on SUPER type. No equivalent function available.",
+            ),
+        )
+    }
+
+    /**
+     * PartiQL `map_get(map, key)` -> Redshift dot notation `map.key`
+     * Only supports string literal keys since Redshift SUPER uses dot notation.
+     */
+    private fun mapGet(args: SqlArgs): Expr {
+        val mapExpr = args[0].expr
+        val keyExpr = args[1].expr
+        if (keyExpr !is org.partiql.ast.expr.ExprLit || keyExpr.lit.code() != org.partiql.ast.Literal.STRING) {
+            listener.reportAndThrow(
+                ScribeProblem.simpleError(
+                    ScribeProblem.UNSUPPORTED_OPERATION,
+                    "Redshift `map_get` only supports string literal keys. Use dot notation (e.g. map.key) for static key access.",
+                ),
+            )
+        }
+        listener.report(
+            ScribeProblem.simpleInfo(
+                code = ScribeProblem.TRANSLATION_INFO,
+                message = "PartiQL `map_get` was replaced by Redshift dot notation access on SUPER type",
+            ),
+        )
+        val step = org.partiql.ast.Ast.exprPathStepElement(keyExpr)
+        return if (mapExpr is org.partiql.ast.expr.ExprPath) {
+            org.partiql.ast.Ast.exprPath(mapExpr.root, mapExpr.steps + step)
+        } else {
+            org.partiql.ast.Ast.exprPath(mapExpr, listOf(step))
+        }
+    }
+
+    private fun containsKey(args: SqlArgs): Expr {
+        listener.reportAndThrow(
+            ScribeProblem.simpleError(
+                ScribeProblem.UNSUPPORTED_OPERATION,
+                "Redshift does not support `contains_key`. No equivalent function available for SUPER type.",
+            ),
+        )
+    }
+
+    private fun sizeFn(args: SqlArgs): Expr {
+        listener.reportAndThrow(
+            ScribeProblem.simpleError(
+                ScribeProblem.UNSUPPORTED_OPERATION,
+                "Redshift does not support `size` on SUPER map type. No equivalent function available.",
+            ),
+        )
+    }
+
+    private fun cardinalityFn(args: SqlArgs): Expr {
+        listener.reportAndThrow(
+            ScribeProblem.simpleError(
+                ScribeProblem.UNSUPPORTED_OPERATION,
+                "Redshift does not support `cardinality` on SUPER map type. No equivalent function available.",
+            ),
+        )
+    }
+
+    private fun existsFn(args: SqlArgs): Expr {
+        listener.reportAndThrow(
+            ScribeProblem.simpleError(
+                ScribeProblem.UNSUPPORTED_OPERATION,
+                "Redshift does not support `exists` on SUPER map type. No equivalent function available.",
+            ),
+        )
     }
 
     override fun overlaps(args: SqlArgs): Expr {

--- a/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftRexConverter.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/redshift/RedshiftRexConverter.kt
@@ -14,6 +14,7 @@ import org.partiql.plan.rex.RexCase
 import org.partiql.plan.rex.RexCast
 import org.partiql.plan.rex.RexDispatch
 import org.partiql.plan.rex.RexLit
+import org.partiql.plan.rex.RexMap
 import org.partiql.plan.rex.RexNullIf
 import org.partiql.plan.rex.RexPathIndex
 import org.partiql.plan.rex.RexPathKey
@@ -81,6 +82,22 @@ public open class RedshiftRexConverter(
                 exprCaseBranch(condition, result)
             }
         return exprCase(matchExpr, branches, default)
+    }
+
+    @Suppress("DEPRECATION")
+    override fun visitMap(
+        rex: RexMap,
+        ctx: Unit,
+    ): Expr {
+        if (rex.keyType.code() != PType.STRING && rex.keyType.code() != PType.VARCHAR && rex.keyType.code() != PType.CHAR) {
+            listener.reportAndThrow(
+                ScribeProblem.simpleError(
+                    code = ScribeProblem.UNSUPPORTED_OPERATION,
+                    message = "Redshift SUPER OBJECT requires string keys. Found key type: ${rex.keyType}",
+                ),
+            )
+        }
+        return super.visitMap(rex, ctx)
     }
 
     override fun visitLit(

--- a/src/main/kotlin/org/partiql/scribe/targets/spark/SparkAstToSql.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/spark/SparkAstToSql.kt
@@ -1,6 +1,5 @@
 package org.partiql.scribe.targets.spark
 
-import org.partiql.ast.Ast.exprPathStepField
 import org.partiql.ast.Ast.exprQuerySet
 import org.partiql.ast.Ast.orderBy
 import org.partiql.ast.Ast.sort
@@ -16,7 +15,7 @@ import org.partiql.ast.WithListElement
 import org.partiql.ast.expr.ExprArray
 import org.partiql.ast.expr.ExprBag
 import org.partiql.ast.expr.ExprCall
-import org.partiql.ast.expr.ExprLit
+import org.partiql.ast.expr.ExprMap
 import org.partiql.ast.expr.ExprQuerySet
 import org.partiql.ast.expr.ExprStruct
 import org.partiql.ast.expr.ExprTrim
@@ -111,29 +110,11 @@ public open class SparkAstToSql(context: ScribeContext) : AstToSql(context) {
         return h
     }
 
-    /**
-     * Spark does not support x['y'] syntax; replace with x.y
-     */
     override fun visitPathStepElement(
         node: PathStep.Element,
         tail: SqlBlock,
     ): SqlBlock {
-        val key = node.element
-        return if (key is ExprLit && key.lit.code() == Literal.STRING) {
-            listener.report(
-                ScribeProblem.simpleInfo(
-                    code = ScribeProblem.TRANSLATION_INFO,
-                    message =
-                        "SparkSQL does not support PartiQL's path element syntax (e.g. x['y']). " +
-                            "Replaced with path step field syntax (e.g. x.y)",
-                ),
-            )
-            val elemString = key.lit.stringValue()
-            val stepField = exprPathStepField(Identifier.Simple.regular(elemString))
-            visitPathStepField(stepField, tail)
-        } else {
-            super.visitPathStepElement(node, tail)
-        }
+        return super.visitPathStepElement(node, tail)
     }
 
     override fun visitPathStepField(
@@ -160,6 +141,26 @@ public open class SparkAstToSql(context: ScribeContext) : AstToSql(context) {
         t = visitExprWrapped(node.name, t)
         t = t concat ", "
         t = visitExprWrapped(node.value, t)
+        return t
+    }
+
+    // Spark's MAP constructor: MAP(key1, val1, key2, val2, ...)
+    // https://spark.apache.org/docs/latest/api/sql/#map
+    @Suppress("DEPRECATION")
+    override fun visitExprMap(
+        node: ExprMap,
+        tail: SqlBlock,
+    ): SqlBlock {
+        var t = tail concat "MAP("
+        node.entries.forEachIndexed { index, entry ->
+            t = visitExprWrapped(entry.key, t)
+            t = t concat ", "
+            t = visitExprWrapped(entry.value, t)
+            if (index < node.entries.size - 1) {
+                t = t concat ", "
+            }
+        }
+        t = t concat ")"
         return t
     }
 
@@ -280,6 +281,14 @@ public open class SparkAstToSql(context: ScribeContext) : AstToSql(context) {
                         "TIME WITH TIME ZONE type is not supported in Spark.",
                     ),
                 )
+            DataType.MAP -> {
+                var t = tail concat "MAP<"
+                t = visitDataType(node.keyType, t)
+                t = t concat ", "
+                t = visitDataType(node.elementType, t)
+                t = t concat ">"
+                t
+            }
             else -> super.visitDataType(node, tail)
         }
     }

--- a/src/main/kotlin/org/partiql/scribe/targets/spark/SparkCalls.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/spark/SparkCalls.kt
@@ -24,7 +24,6 @@ public open class SparkCalls(context: ScribeContext) : SqlCalls(context) {
             this["utcnow"] = ::utcnow
             this["current_user"] = ::currentUser
             this["transform"] = ::transform
-            this["contains_key"] = ::containsKey
             this["map_get"] = ::mapGet
             this["cardinality"] = ::cardinalityFn
             this["exists"] = ::existsFn
@@ -243,20 +242,6 @@ public open class SparkCalls(context: ScribeContext) : SqlCalls(context) {
                     ),
                 )
         }
-
-    /**
-     * PartiQL `contains_key(map, key)` -> Spark `map_contains_key(map, key)`
-     */
-    private fun containsKey(args: SqlArgs): Expr {
-        val id = Identifier.regular("map_contains_key")
-        listener.report(
-            ScribeProblem.simpleInfo(
-                code = ScribeProblem.TRANSLATION_INFO,
-                message = "PartiQL `contains_key` was replaced by Spark `map_contains_key`",
-            ),
-        )
-        return exprCall(id, listOf(args[0].expr, args[1].expr))
-    }
 
     /**
      * PartiQL `map_get(map, key)` -> Spark `element_at(map, key)`

--- a/src/main/kotlin/org/partiql/scribe/targets/spark/SparkCalls.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/spark/SparkCalls.kt
@@ -24,6 +24,10 @@ public open class SparkCalls(context: ScribeContext) : SqlCalls(context) {
             this["utcnow"] = ::utcnow
             this["current_user"] = ::currentUser
             this["transform"] = ::transform
+            this["contains_key"] = ::containsKey
+            this["map_get"] = ::mapGet
+            this["cardinality"] = ::cardinalityFn
+            this["exists"] = ::existsFn
         }
 
     private fun currentUser(args: List<SqlArg>): Expr {
@@ -239,6 +243,63 @@ public open class SparkCalls(context: ScribeContext) : SqlCalls(context) {
                     ),
                 )
         }
+
+    /**
+     * PartiQL `contains_key(map, key)` -> Spark `map_contains_key(map, key)`
+     */
+    private fun containsKey(args: SqlArgs): Expr {
+        val id = Identifier.regular("map_contains_key")
+        listener.report(
+            ScribeProblem.simpleInfo(
+                code = ScribeProblem.TRANSLATION_INFO,
+                message = "PartiQL `contains_key` was replaced by Spark `map_contains_key`",
+            ),
+        )
+        return exprCall(id, listOf(args[0].expr, args[1].expr))
+    }
+
+    /**
+     * PartiQL `map_get(map, key)` -> Spark `element_at(map, key)`
+     */
+    private fun mapGet(args: SqlArgs): Expr {
+        val id = Identifier.regular("element_at")
+        listener.report(
+            ScribeProblem.simpleInfo(
+                code = ScribeProblem.TRANSLATION_INFO,
+                message = "PartiQL `map_get` was replaced by Spark `element_at`",
+            ),
+        )
+        return exprCall(id, listOf(args[0].expr, args[1].expr))
+    }
+
+    /**
+     * PartiQL `cardinality(collection)` -> Spark `size(collection)`
+     */
+    private fun cardinalityFn(args: SqlArgs): Expr {
+        val id = Identifier.regular("size")
+        listener.report(
+            ScribeProblem.simpleInfo(
+                code = ScribeProblem.TRANSLATION_INFO,
+                message = "PartiQL `cardinality` was replaced by Spark `size`",
+            ),
+        )
+        return exprCall(id, listOf(args[0].expr))
+    }
+
+    /**
+     * PartiQL `exists(collection)` -> Spark `size(collection) > 0`
+     */
+    private fun existsFn(args: SqlArgs): Expr {
+        val sizeId = Identifier.regular("size")
+        listener.report(
+            ScribeProblem.simpleInfo(
+                code = ScribeProblem.TRANSLATION_INFO,
+                message = "PartiQL `exists` was replaced by Spark `size(...) > 0`",
+            ),
+        )
+        val sizeCall = exprCall(sizeId, listOf(args[0].expr))
+        return exprOperator(">", sizeCall, exprLit(Literal.intNum(0)))
+    }
 
     override fun overlaps(args: SqlArgs): Expr {
         listener.reportAndThrow(

--- a/src/main/kotlin/org/partiql/scribe/targets/spark/SparkRexConverter.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/spark/SparkRexConverter.kt
@@ -1,9 +1,15 @@
 package org.partiql.scribe.targets.spark
 
+import org.partiql.ast.Ast.exprPath
+import org.partiql.ast.Ast.exprPathStepElement
+import org.partiql.ast.Ast.exprPathStepField
+import org.partiql.ast.Identifier
 import org.partiql.ast.expr.Expr
+import org.partiql.ast.expr.ExprPath
 import org.partiql.ast.expr.ExprVarRef
 import org.partiql.plan.rex.RexCall
 import org.partiql.plan.rex.RexLit
+import org.partiql.plan.rex.RexPathKey
 import org.partiql.scribe.ScribeContext
 import org.partiql.scribe.problems.ScribeProblem
 import org.partiql.scribe.sql.Locals
@@ -36,6 +42,44 @@ public open class SparkRexConverter(
                 }
             }
             else -> super.visitLit(rex, ctx)
+        }
+    }
+
+    /**
+     * For MAP operands, keep bracket notation (SparkSQL requires `map_col['key']`).
+     * For STRUCT operands, use dot notation via [exprPathStepField] (SparkSQL uses `struct_col.field`).
+     */
+    override fun visitPathKey(
+        rex: RexPathKey,
+        ctx: Unit,
+    ): Expr {
+        val operandType =
+            try {
+                rex.operand.type.pType
+            } catch (_: UnsupportedOperationException) {
+                null
+            }
+        if (operandType != null && operandType.code() == PType.MAP) {
+            val prev = visitRex(rex.operand, ctx)
+            val step = exprPathStepElement(visitRex(rex.key, ctx))
+            return if (prev is ExprPath) {
+                exprPath(prev.root, prev.steps + step)
+            } else {
+                exprPath(prev, listOf(step))
+            }
+        }
+        val prev = visitRex(rex.operand, ctx)
+        val keyRex = rex.key
+        val step =
+            if (keyRex is RexLit && keyRex.type.pType.code() == PType.STRING) {
+                exprPathStepField(Identifier.Simple.regular(keyRex.datum.string))
+            } else {
+                exprPathStepElement(visitRex(keyRex, ctx))
+            }
+        return if (prev is ExprPath) {
+            exprPath(prev.root, prev.steps + step)
+        } else {
+            exprPath(prev, listOf(step))
         }
     }
 

--- a/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoAstToSql.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoAstToSql.kt
@@ -2,13 +2,11 @@ package org.partiql.scribe.targets.trino
 
 import org.partiql.ast.Ast.exprCast
 import org.partiql.ast.Ast.exprLit
-import org.partiql.ast.Ast.exprPathStepField
 import org.partiql.ast.Ast.exprQuerySet
 import org.partiql.ast.Ast.orderBy
 import org.partiql.ast.Ast.sort
 import org.partiql.ast.DataType
 import org.partiql.ast.DatetimeField
-import org.partiql.ast.Identifier
 import org.partiql.ast.IntervalQualifier
 import org.partiql.ast.Literal
 import org.partiql.ast.QueryBody
@@ -17,6 +15,7 @@ import org.partiql.ast.expr.ExprBag
 import org.partiql.ast.expr.ExprCall
 import org.partiql.ast.expr.ExprCast
 import org.partiql.ast.expr.ExprLit
+import org.partiql.ast.expr.ExprMap
 import org.partiql.ast.expr.ExprQuerySet
 import org.partiql.ast.expr.ExprSessionAttribute
 import org.partiql.ast.expr.ExprStruct
@@ -42,32 +41,14 @@ public open class TrinoAstToSql(context: ScribeContext) : AstToSql(context) {
     }
 
     /**
-     * Trino does not support x['y'] syntax; replace with x.y.
-     *
-     * @param node
-     * @param tail
-     * @return
+     * Bracket notation is kept as-is for MAP subscript access.
+     * For ROW field access, the conversion to dot notation is done at plan level in [TrinoRexConverter].
      */
     override fun visitPathStepElement(
         node: PathStep.Element,
         tail: SqlBlock,
     ): SqlBlock {
-        val key = node.element
-        return if (key is ExprLit && key.lit.code() == Literal.STRING) {
-            listener.report(
-                ScribeProblem.simpleInfo(
-                    code = ScribeProblem.TRANSLATION_INFO,
-                    message =
-                        "Trino does not support PartiQL's path element syntax (e.g. x['y']). " +
-                            "Replaced with path step field syntax (e.g. x.y)",
-                ),
-            )
-            val elemString = key.lit.stringValue()
-            val stepField = exprPathStepField(Identifier.Simple.delimited(elemString))
-            visitPathStepField(stepField, tail)
-        } else {
-            super.visitPathStepElement(node, tail)
-        }
+        return super.visitPathStepElement(node, tail)
     }
 
     override fun visitExprLit(
@@ -169,6 +150,14 @@ public open class TrinoAstToSql(context: ScribeContext) : AstToSql(context) {
             DataType.TIME_WITH_TIME_ZONE -> tail concat "TIME WITH TIME ZONE"
             DataType.TIMESTAMP -> tail concat "TIMESTAMP"
             DataType.TIMESTAMP_WITH_TIME_ZONE -> tail concat "TIMESTAMP WITH TIME ZONE"
+            DataType.MAP -> {
+                var t = tail concat "MAP("
+                t = visitDataType(node.keyType, t)
+                t = t concat ", "
+                t = visitDataType(node.elementType, t)
+                t = t concat ")"
+                t
+            }
             else -> super.visitDataType(node, tail)
         }
     }
@@ -404,5 +393,30 @@ public open class TrinoAstToSql(context: ScribeContext) : AstToSql(context) {
             ),
         )
         return tail
+    }
+
+    // Trino's MAP constructor: MAP(ARRAY[key1, key2, ...], ARRAY[val1, val2, ...])
+    // https://trino.io/docs/current/functions/map.html
+    @Suppress("DEPRECATION")
+    override fun visitExprMap(
+        node: ExprMap,
+        tail: SqlBlock,
+    ): SqlBlock {
+        var t = tail concat "MAP(ARRAY["
+        node.entries.forEachIndexed { index, entry ->
+            t = visitExprWrapped(entry.key, t)
+            if (index < node.entries.size - 1) {
+                t = t concat ", "
+            }
+        }
+        t = t concat "], ARRAY["
+        node.entries.forEachIndexed { index, entry ->
+            t = visitExprWrapped(entry.value, t)
+            if (index < node.entries.size - 1) {
+                t = t concat ", "
+            }
+        }
+        t = t concat "])"
+        return t
     }
 }

--- a/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoCalls.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoCalls.kt
@@ -30,7 +30,7 @@ public open class TrinoCalls(context: ScribeContext) : SqlCalls(context) {
             this.remove("bitwise_and")
             this["cast_row"] = ::castrow
             this["transform"] = ::transform
-            this["contains_key"] = ::containsKey
+            this["map_contains_key"] = ::mapContainsKey
             this["map_get"] = ::mapGet
             this["size"] = ::sizeFn
             this["cardinality"] = ::cardinalityFn
@@ -184,15 +184,15 @@ public open class TrinoCalls(context: ScribeContext) : SqlCalls(context) {
     }
 
     /**
-     * PartiQL `contains_key(map, key)` -> Trino `contains(map_keys(map), key)`
+     * PartiQL `map_contains_key(map, key)` -> Trino `contains(map_keys(map), key)`
      */
-    private fun containsKey(args: SqlArgs): Expr {
+    private fun mapContainsKey(args: SqlArgs): Expr {
         val containsId = Identifier.regular("contains")
         val mapKeysId = Identifier.regular("map_keys")
         listener.report(
             ScribeProblem.simpleInfo(
                 code = ScribeProblem.TRANSLATION_INFO,
-                message = "PartiQL `contains_key` was replaced by Trino `contains(map_keys(...), ...)`",
+                message = "PartiQL `map_contains_key` was replaced by Trino `contains(map_keys(...), ...)`",
             ),
         )
         val mapExpr = args[0].expr

--- a/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoCalls.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoCalls.kt
@@ -3,6 +3,7 @@ package org.partiql.scribe.targets.trino
 import org.partiql.ast.Ast.exprCall
 import org.partiql.ast.Ast.exprCast
 import org.partiql.ast.Ast.exprLit
+import org.partiql.ast.Ast.exprOperator
 import org.partiql.ast.DataType
 import org.partiql.ast.DatetimeField
 import org.partiql.ast.Identifier
@@ -29,6 +30,11 @@ public open class TrinoCalls(context: ScribeContext) : SqlCalls(context) {
             this.remove("bitwise_and")
             this["cast_row"] = ::castrow
             this["transform"] = ::transform
+            this["contains_key"] = ::containsKey
+            this["map_get"] = ::mapGet
+            this["size"] = ::sizeFn
+            this["cardinality"] = ::cardinalityFn
+            this["exists"] = ::existsFn
         }
 
     /**
@@ -175,6 +181,75 @@ public open class TrinoCalls(context: ScribeContext) : SqlCalls(context) {
             )
         }
         return super.minusFn(args)
+    }
+
+    /**
+     * PartiQL `contains_key(map, key)` -> Trino `contains(map_keys(map), key)`
+     */
+    private fun containsKey(args: SqlArgs): Expr {
+        val containsId = Identifier.regular("contains")
+        val mapKeysId = Identifier.regular("map_keys")
+        listener.report(
+            ScribeProblem.simpleInfo(
+                code = ScribeProblem.TRANSLATION_INFO,
+                message = "PartiQL `contains_key` was replaced by Trino `contains(map_keys(...), ...)`",
+            ),
+        )
+        val mapExpr = args[0].expr
+        val keyExpr = args[1].expr
+        val mapKeysCall = exprCall(mapKeysId, listOf(mapExpr))
+        return exprCall(containsId, listOf(mapKeysCall, keyExpr))
+    }
+
+    /**
+     * PartiQL `map_get(map, key)` -> Trino `element_at(map, key)`
+     */
+    private fun mapGet(args: SqlArgs): Expr {
+        val id = Identifier.regular("element_at")
+        listener.report(
+            ScribeProblem.simpleInfo(
+                code = ScribeProblem.TRANSLATION_INFO,
+                message = "PartiQL `map_get` was replaced by Trino `element_at`",
+            ),
+        )
+        return exprCall(id, listOf(args[0].expr, args[1].expr))
+    }
+
+    /**
+     * PartiQL `size(collection)` -> Trino `cardinality(collection)`
+     */
+    private fun sizeFn(args: SqlArgs): Expr {
+        val id = Identifier.regular("cardinality")
+        listener.report(
+            ScribeProblem.simpleInfo(
+                code = ScribeProblem.TRANSLATION_INFO,
+                message = "PartiQL `size` was replaced by Trino `cardinality`",
+            ),
+        )
+        return exprCall(id, listOf(args[0].expr))
+    }
+
+    /**
+     * PartiQL `cardinality(collection)` -> Trino `cardinality(collection)` (native)
+     */
+    private fun cardinalityFn(args: SqlArgs): Expr {
+        val id = Identifier.regular("cardinality")
+        return exprCall(id, listOf(args[0].expr))
+    }
+
+    /**
+     * PartiQL `exists(collection)` -> Trino `cardinality(collection) > 0`
+     */
+    private fun existsFn(args: SqlArgs): Expr {
+        val cardId = Identifier.regular("cardinality")
+        listener.report(
+            ScribeProblem.simpleInfo(
+                code = ScribeProblem.TRANSLATION_INFO,
+                message = "PartiQL `exists` was replaced by Trino `cardinality(...) > 0`",
+            ),
+        )
+        val cardCall = exprCall(cardId, listOf(args[0].expr))
+        return exprOperator(">", cardCall, exprLit(Literal.intNum(0)))
     }
 
     override fun overlaps(args: SqlArgs): Expr {

--- a/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoRewriter.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoRewriter.kt
@@ -75,8 +75,8 @@ public open class TrinoRewriter(internal val context: ScribeContext) : OperatorR
         rex: RexPathKey,
         ctx: ScribeContext,
     ): Operator {
-        if (rex.operand.type.pType.code() != PType.ROW) {
-            error("Trino path expression must be on a ROW type (PartiQL STRUCT), found ${rex.operand.type}")
+        if (rex.operand.type.pType.code() != PType.ROW && rex.operand.type.pType.code() != PType.MAP) {
+            error("Trino path expression must be on a ROW or MAP type, found ${rex.operand.type}")
         }
         if (rex.key !is RexLit) {
             error("Trino does not support path non-literal path expressions, found ${rex.key}")
@@ -100,8 +100,8 @@ public open class TrinoRewriter(internal val context: ScribeContext) : OperatorR
         rex: RexPathSymbol,
         ctx: ScribeContext,
     ): Operator {
-        if (rex.operand.type.pType.code() != PType.ROW) {
-            error("Trino path expression must be on a ROW type (PartiQL STRUCT), found ${rex.operand.type}")
+        if (rex.operand.type.pType.code() != PType.ROW && rex.operand.type.pType.code() != PType.MAP) {
+            error("Trino path expression must be on a ROW or MAP type, found ${rex.operand.type}")
         }
         val visited = super.visitPathSymbol(rex, ctx) as RexPathSymbol
         // Wrap RexStruct operand in CAST(ROW(...) AS ROW(...))
@@ -128,8 +128,13 @@ public open class TrinoRewriter(internal val context: ScribeContext) : OperatorR
         node: RexPathIndex,
         ctx: ScribeContext,
     ): Operator {
-        // Assert root type
+        // MAP subscript access — pass through without rewriting
         val type = node.operand.type
+        if (type.pType.code() == PType.MAP) {
+            return node
+        }
+
+        // Assert root type
         if (type.pType.code() != PType.ARRAY) {
             listener.reportAndThrow(
                 ScribeProblem.simpleError(

--- a/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoRexConverter.kt
+++ b/src/main/kotlin/org/partiql/scribe/targets/trino/TrinoRexConverter.kt
@@ -1,8 +1,13 @@
 package org.partiql.scribe.targets.trino
 
+import org.partiql.ast.Ast.exprPath
+import org.partiql.ast.Ast.exprPathStepField
+import org.partiql.ast.Identifier
 import org.partiql.ast.expr.Expr
+import org.partiql.ast.expr.ExprPath
 import org.partiql.ast.expr.ExprVarRef
 import org.partiql.plan.rex.RexLit
+import org.partiql.plan.rex.RexPathKey
 import org.partiql.scribe.ScribeContext
 import org.partiql.scribe.sql.Locals
 import org.partiql.scribe.sql.PlanToAst
@@ -35,5 +40,37 @@ public open class TrinoRexConverter(
             }
             else -> super.visitLit(rex, ctx)
         }
+    }
+
+    /**
+     * For MAP types, keep bracket notation (PathStep.Element) since Trino uses subscript for map access.
+     * For ROW/struct types, convert to dot notation (PathStep.Field) since Trino uses field dereference.
+     */
+    override fun visitPathKey(
+        rex: RexPathKey,
+        ctx: Unit,
+    ): Expr {
+        val operandType =
+            try {
+                rex.operand.type.pType.code()
+            } catch (_: UnsupportedOperationException) {
+                -1
+            }
+        if (operandType == PType.MAP) {
+            return super.visitPathKey(rex, ctx)
+        }
+        // For non-MAP (ROW/struct/other): convert bracket to dot notation
+        val key = rex.key
+        if (key is RexLit && key.type.pType.code() == PType.STRING) {
+            val prev = visitRex(rex.operand, ctx)
+            val fieldName = key.datum.string
+            val step = exprPathStepField(Identifier.Simple.delimited(fieldName))
+            return if (prev is ExprPath) {
+                exprPath(prev.root, prev.steps + step)
+            } else {
+                exprPath(prev, listOf(step))
+            }
+        }
+        return super.visitPathKey(rex, ctx)
     }
 }

--- a/src/test/kotlin/org/partiql/scribe/utils/LocalSchema.kt
+++ b/src/test/kotlin/org/partiql/scribe/utils/LocalSchema.kt
@@ -70,6 +70,7 @@ private object LocalSchema {
             "list" -> error("`list` is not an atomic type")
             "sexp" -> error("`sexp` is not an atomic type")
             "struct" -> error("`struct` is not an atomic type")
+            "map" -> error("`map` is not an atomic type")
             // unsupported
             "interval" -> error("`interval` is currently not supported")
             "symbol" -> error("`symbol` is currently not supported")
@@ -119,6 +120,7 @@ private object LocalSchema {
                     "bag" -> bag()
                     "list" -> list()
                     "struct" -> struct()
+                    "map" -> map()
                     "any" -> PType.dynamic()
                     "null", "missing" -> PType.unknown()
                     else -> error("Invalid type `$this`")
@@ -239,6 +241,13 @@ private object LocalSchema {
         PType.array(
             load(getAngry<IonElement>("items")),
         )
+
+    @Suppress("DEPRECATION")
+    private fun StructElement.map(): PType {
+        val keyType = load(getAngry<IonElement>("key"))
+        val valueType = load(getAngry<IonElement>("value"))
+        return PType.map(keyType, valueType)
+    }
 
     private fun StructElement.struct(): PType {
 // Constraints

--- a/src/test/resources/catalogs/default/T_ALL_TYPES.ion
+++ b/src/test/resources/catalogs/default/T_ALL_TYPES.ion
@@ -127,6 +127,22 @@
         },
       },
       {
+        name: "col_map_str_key",
+        type: {
+          type: "map",
+          key: "string",
+          value: "int32",
+        },
+      },
+      {
+        name: "col_map_float_key",
+        type: {
+          type: "map",
+          key: "float64",
+          value: "string",
+        },
+      },
+      {
         name: "col_any",
         type: "any",
       },

--- a/src/test/resources/inputs/basics/map.sql
+++ b/src/test/resources/inputs/basics/map.sql
@@ -48,15 +48,15 @@ SELECT T.col_map_float_key FROM T_ALL_TYPES AS T;
 
 --#[map-09]
 -- Lookup map with bracket notation (string key)
-SELECT T.col_map_str_key['a'] FROM T_ALL_TYPES AS T WHERE contains_key(T.col_map_str_key, 'a');
+SELECT T.col_map_str_key['a'] FROM T_ALL_TYPES AS T WHERE map_contains_key(T.col_map_str_key, 'a');
 
 --#[map-10]
 -- Lookup map with bracket notation (float key)
-SELECT T.col_map_float_key[1.0] FROM T_ALL_TYPES AS T WHERE contains_key(T.col_map_float_key, 1.0);
+SELECT T.col_map_float_key[1.0] FROM T_ALL_TYPES AS T WHERE map_contains_key(T.col_map_float_key, 1.0);
 
 --#[map-11]
 -- Lookup map with bracket notation using column as key
-SELECT T.col_map_str_key[T.col_string] FROM T_ALL_TYPES AS T WHERE contains_key(T.col_map_str_key, T.col_string);
+SELECT T.col_map_str_key[T.col_string] FROM T_ALL_TYPES AS T WHERE map_contains_key(T.col_map_str_key, T.col_string);
 
 -- ----------------------------------------
 --  Map functions — map_keys, map_values, map_entries
@@ -107,20 +107,20 @@ SELECT cardinality(T.col_map_str_key) FROM T_ALL_TYPES AS T;
 SELECT exists(T.col_map_str_key) FROM T_ALL_TYPES AS T;
 
 -- ----------------------------------------
---  Map functions — contains_key
+--  Map functions — map_contains_key
 -- ----------------------------------------
 
 --#[map-22]
--- contains_key with string key that exists
-SELECT contains_key(T.col_map_str_key, 'a') FROM T_ALL_TYPES AS T;
+-- map_contains_key with string key that exists
+SELECT map_contains_key(T.col_map_str_key, 'a') FROM T_ALL_TYPES AS T;
 
 --#[map-23]
--- contains_key with column reference as key
-SELECT contains_key(T.col_map_str_key, T.col_string) FROM T_ALL_TYPES AS T;
+-- map_contains_key with column reference as key
+SELECT map_contains_key(T.col_map_str_key, T.col_string) FROM T_ALL_TYPES AS T;
 
 --#[map-24]
--- contains_key with float key
-SELECT contains_key(T.col_map_float_key, T.col_float64) FROM T_ALL_TYPES AS T;
+-- map_contains_key with float key
+SELECT map_contains_key(T.col_map_float_key, T.col_float64) FROM T_ALL_TYPES AS T;
 
 -- ----------------------------------------
 --  Map functions — map_get
@@ -167,8 +167,8 @@ SELECT CAST(T.col_map_str_key AS MAP<STRING, BIGINT>) FROM T_ALL_TYPES AS T;
 SELECT T.col_int32 FROM T_ALL_TYPES AS T WHERE T.col_map_str_key['a'] > 10;
 
 --#[map-32]
--- Filter with contains_key
-SELECT T.col_int32 FROM T_ALL_TYPES AS T WHERE contains_key(T.col_map_str_key, 'a');
+-- Filter with map_contains_key
+SELECT T.col_int32 FROM T_ALL_TYPES AS T WHERE map_contains_key(T.col_map_str_key, 'a');
 
 --#[map-33]
 -- Filter with map size

--- a/src/test/resources/inputs/basics/map.sql
+++ b/src/test/resources/inputs/basics/map.sql
@@ -1,0 +1,195 @@
+-- ----------------------------------------
+--  Map construction — literal
+-- ----------------------------------------
+
+--#[map-00]
+-- Construct a map literal with string keys
+SELECT MAP {'a': 1, 'b': 2, 'c': 3} FROM T_ALL_TYPES AS T;
+
+--#[map-01]
+-- Construct a map literal with decimal keys
+SELECT MAP {1.1: 'x', 2.2: 'y', 3.3: 'z'} FROM T_ALL_TYPES AS T;
+
+--#[map-02]
+-- Construct a map literal referencing columns for values
+SELECT MAP {'x': T.col_int32, 'y': T.col_float64} FROM T_ALL_TYPES AS T;
+
+--#[map-03]
+-- Construct a map literal referencing columns for keys
+SELECT MAP {T.col_string: T.col_int32} FROM T_ALL_TYPES AS T;
+
+--#[map-04]
+-- Construct an empty map literal
+SELECT MAP {} FROM T_ALL_TYPES AS T;
+
+--#[map-05]
+-- Construct a map literal with integer keys
+SELECT MAP {1: 'a', 2: 'b', 3: 'c'} FROM T_ALL_TYPES AS T;
+
+--#[map-06]
+-- Construct a map literal with expression as key
+SELECT MAP {T.col_int32 + 1: T.col_string} FROM T_ALL_TYPES AS T;
+
+-- ----------------------------------------
+--  Select map columns
+-- ----------------------------------------
+
+--#[map-07]
+-- Select map alongside other columns
+SELECT T.col_int32, T.col_string, T.col_map_str_key FROM T_ALL_TYPES AS T;
+
+--#[map-08]
+-- Select map column with float key type
+SELECT T.col_map_float_key FROM T_ALL_TYPES AS T;
+
+-- ----------------------------------------
+--  Bracket notation lookup
+-- ----------------------------------------
+
+--#[map-09]
+-- Lookup map with bracket notation (string key)
+SELECT T.col_map_str_key['a'] FROM T_ALL_TYPES AS T WHERE contains_key(T.col_map_str_key, 'a');
+
+--#[map-10]
+-- Lookup map with bracket notation (float key)
+SELECT T.col_map_float_key[1.0] FROM T_ALL_TYPES AS T WHERE contains_key(T.col_map_float_key, 1.0);
+
+--#[map-11]
+-- Lookup map with bracket notation using column as key
+SELECT T.col_map_str_key[T.col_string] FROM T_ALL_TYPES AS T WHERE contains_key(T.col_map_str_key, T.col_string);
+
+-- ----------------------------------------
+--  Map functions — map_keys, map_values, map_entries
+-- ----------------------------------------
+
+--#[map-12]
+-- Get keys from a string-key map
+SELECT map_keys(T.col_map_str_key) FROM T_ALL_TYPES AS T;
+
+--#[map-13]
+-- Get keys from a float-key map
+SELECT map_keys(T.col_map_float_key) FROM T_ALL_TYPES AS T;
+
+--#[map-14]
+-- Get values from a string-key map
+SELECT map_values(T.col_map_str_key) FROM T_ALL_TYPES AS T;
+
+--#[map-15]
+-- Get values from a float-key map
+SELECT map_values(T.col_map_float_key) FROM T_ALL_TYPES AS T;
+
+--#[map-16]
+-- Get entries from a string-key map
+SELECT map_entries(T.col_map_str_key) FROM T_ALL_TYPES AS T;
+
+--#[map-17]
+-- Get entries from a float-key map
+SELECT map_entries(T.col_map_float_key) FROM T_ALL_TYPES AS T;
+
+-- ----------------------------------------
+--  Map functions — size, cardinality, exists
+-- ----------------------------------------
+
+--#[map-18]
+-- Size of a map column
+SELECT size(T.col_map_str_key) FROM T_ALL_TYPES AS T;
+
+--#[map-19]
+-- Size of a map literal
+SELECT size(MAP {'a': 1, 'b': 2, 'c': 3}) FROM T_ALL_TYPES AS T;
+
+--#[map-20]
+-- Cardinality of a map column
+SELECT cardinality(T.col_map_str_key) FROM T_ALL_TYPES AS T;
+
+--#[map-21]
+-- Exists on a map column
+SELECT exists(T.col_map_str_key) FROM T_ALL_TYPES AS T;
+
+-- ----------------------------------------
+--  Map functions — contains_key
+-- ----------------------------------------
+
+--#[map-22]
+-- contains_key with string key that exists
+SELECT contains_key(T.col_map_str_key, 'a') FROM T_ALL_TYPES AS T;
+
+--#[map-23]
+-- contains_key with column reference as key
+SELECT contains_key(T.col_map_str_key, T.col_string) FROM T_ALL_TYPES AS T;
+
+--#[map-24]
+-- contains_key with float key
+SELECT contains_key(T.col_map_float_key, T.col_float64) FROM T_ALL_TYPES AS T;
+
+-- ----------------------------------------
+--  Map functions — map_get
+-- ----------------------------------------
+
+--#[map-25]
+-- map_get with string key
+SELECT map_get(T.col_map_str_key, 'a') FROM T_ALL_TYPES AS T;
+
+--#[map-26]
+-- map_get with column reference as key
+SELECT map_get(T.col_map_str_key, T.col_string) FROM T_ALL_TYPES AS T;
+
+--#[map-27]
+-- map_get with float key
+SELECT map_get(T.col_map_float_key, 1.0) FROM T_ALL_TYPES AS T;
+
+-- ----------------------------------------
+--  Type predicate — IS MAP
+-- ----------------------------------------
+
+--#[map-28]
+-- IS MAP type predicate on a map column
+SELECT T.col_map_str_key IS MAP<STRING, INT> FROM T_ALL_TYPES AS T;
+
+-- ----------------------------------------
+--  CAST to MAP
+-- ----------------------------------------
+
+--#[map-29]
+-- CAST struct to MAP
+SELECT CAST(T.col_struct_simple AS MAP<STRING, ANY>) FROM T_ALL_TYPES AS T;
+
+--#[map-30]
+-- CAST map to different map type
+SELECT CAST(T.col_map_str_key AS MAP<STRING, BIGINT>) FROM T_ALL_TYPES AS T;
+
+-- ----------------------------------------
+--  Filtering
+-- ----------------------------------------
+
+--#[map-31]
+-- Filter with map lookup comparison
+SELECT T.col_int32 FROM T_ALL_TYPES AS T WHERE T.col_map_str_key['a'] > 10;
+
+--#[map-32]
+-- Filter with contains_key
+SELECT T.col_int32 FROM T_ALL_TYPES AS T WHERE contains_key(T.col_map_str_key, 'a');
+
+--#[map-33]
+-- Filter with map size
+SELECT T.col_int32 FROM T_ALL_TYPES AS T WHERE size(T.col_map_str_key) > 0;
+
+-- ----------------------------------------
+--  Aggregation
+-- ----------------------------------------
+
+--#[map-34]
+-- Group by map lookup
+SELECT T.col_map_str_key['a'], COUNT(*) FROM T_ALL_TYPES AS T GROUP BY T.col_map_str_key['a'];
+
+-- ----------------------------------------
+--  UNPIVOT with MAP
+-- ----------------------------------------
+
+--#[map-35]
+-- UNPIVOT map produces key-value rows
+SELECT k, v FROM UNPIVOT MAP {'a': 1, 'b': 2} AS v AT k;
+
+--#[map-36]
+-- UNPIVOT map column with correlated join
+SELECT T.col_int32, k, v FROM T_ALL_TYPES AS T, UNPIVOT T.col_map_str_key AS v AT k;

--- a/src/test/resources/outputs/partiql/basics/map.sql
+++ b/src/test/resources/outputs/partiql/basics/map.sql
@@ -1,0 +1,163 @@
+-- ----------------------------------------
+--  Map construction — literal
+-- ----------------------------------------
+
+--#[map-00]
+-- Construct a map literal with string keys
+SELECT MAP {'a': 1, 'b': 2, 'c': 3} AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-01]
+-- Construct a map literal with decimal keys
+SELECT MAP {1.1: 'x', 2.2: 'y', 3.3: 'z'} AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-02]
+-- Construct a map literal referencing columns for values
+SELECT MAP {'x': CAST("T"['col_int32'] AS DOUBLE PRECISION), 'y': "T"['col_float64']} AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-03]
+-- Construct a map literal referencing columns for keys
+SELECT MAP {"T"['col_string']: "T"['col_int32']} AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-04]
+-- Construct an empty map literal
+SELECT MAP {} AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-05]
+-- Construct a map literal with integer keys
+SELECT MAP {1: 'a', 2: 'b', 3: 'c'} AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-06]
+-- Construct a map literal with expression as key
+SELECT MAP {"T"['col_int32'] + 1: "T"['col_string']} AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Select map columns
+-- ----------------------------------------
+
+--#[map-07]
+-- Select map alongside other columns
+SELECT "T"['col_int32'] AS "col_int32", "T"['col_string'] AS "col_string", "T"['col_map_str_key'] AS "col_map_str_key" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-08]
+-- Select map column with float key type
+SELECT "T"['col_map_float_key'] AS "col_map_float_key" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Bracket notation lookup
+-- ----------------------------------------
+
+--#[map-09]
+-- Lookup map with bracket notation (string key)
+SELECT "T"['col_map_str_key']['a'] AS "a" FROM "default"."T_ALL_TYPES" AS "T" WHERE "contains_key"("T"['col_map_str_key'], 'a');
+
+--#[map-10]
+-- Lookup map with bracket notation (float key)
+SELECT "T"['col_map_float_key'][1.0] AS "_1" FROM "default"."T_ALL_TYPES" AS "T" WHERE "contains_key"("T"['col_map_float_key'], 1.0);
+
+--#[map-11]
+-- Lookup map with bracket notation using column as key
+SELECT "T"['col_map_str_key']["T"['col_string']] AS "_1" FROM "default"."T_ALL_TYPES" AS "T" WHERE "contains_key"("T"['col_map_str_key'], "T"['col_string']);
+
+-- ----------------------------------------
+--  Map functions — map_keys, map_values, map_entries
+-- ----------------------------------------
+
+--#[map-12]
+-- Get keys from a string-key map
+SELECT "map_keys"("T"['col_map_str_key']) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-13]
+-- Get keys from a float-key map
+SELECT "map_keys"("T"['col_map_float_key']) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-14]
+-- Get values from a string-key map
+SELECT "map_values"("T"['col_map_str_key']) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-15]
+-- Get values from a float-key map
+SELECT "map_values"("T"['col_map_float_key']) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-16]
+-- Get entries from a string-key map
+SELECT "map_entries"("T"['col_map_str_key']) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-17]
+-- Get entries from a float-key map
+SELECT "map_entries"("T"['col_map_float_key']) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Map functions — size, cardinality, exists
+-- ----------------------------------------
+
+--#[map-18]
+-- Size of a map column
+SELECT "size"("T"['col_map_str_key']) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-19]
+-- Size of a map literal
+SELECT "size"(MAP {'a': 1, 'b': 2, 'c': 3}) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-20]
+-- Cardinality of a map column
+SELECT "cardinality"("T"['col_map_str_key']) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-21]
+-- Exists on a map column
+SELECT "exists"("T"['col_map_str_key']) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Map functions — contains_key
+-- ----------------------------------------
+
+--#[map-22]
+-- contains_key with string key that exists
+SELECT "contains_key"("T"['col_map_str_key'], 'a') AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-23]
+-- contains_key with column reference as key
+SELECT "contains_key"("T"['col_map_str_key'], "T"['col_string']) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-24]
+-- contains_key with float key
+SELECT "contains_key"("T"['col_map_float_key'], "T"['col_float64']) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Map functions — map_get
+-- ----------------------------------------
+
+--#[map-25]
+-- map_get with string key
+SELECT "map_get"("T"['col_map_str_key'], 'a') AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-26]
+-- map_get with column reference as key
+SELECT "map_get"("T"['col_map_str_key'], "T"['col_string']) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-27]
+-- map_get with float key
+SELECT "map_get"("T"['col_map_float_key'], 1.0) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Filtering
+-- ----------------------------------------
+
+--#[map-31]
+-- Filter with map lookup comparison
+SELECT "T"['col_int32'] AS "col_int32" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"['col_map_str_key']['a'] > 10;
+
+--#[map-32]
+-- Filter with contains_key
+SELECT "T"['col_int32'] AS "col_int32" FROM "default"."T_ALL_TYPES" AS "T" WHERE "contains_key"("T"['col_map_str_key'], 'a');
+
+--#[map-33]
+-- Filter with map size
+SELECT "T"['col_int32'] AS "col_int32" FROM "default"."T_ALL_TYPES" AS "T" WHERE "size"("T"['col_map_str_key']) > 0;
+
+-- ----------------------------------------
+--  Aggregation
+-- ----------------------------------------
+
+--#[map-34]
+-- Group by map lookup
+SELECT "T"['col_map_str_key']['a'] AS "a", count(1) AS "_1" FROM "default"."T_ALL_TYPES" AS "T" GROUP BY "T"['col_map_str_key']['a'];

--- a/src/test/resources/outputs/partiql/basics/map.sql
+++ b/src/test/resources/outputs/partiql/basics/map.sql
@@ -48,15 +48,15 @@ SELECT "T"['col_map_float_key'] AS "col_map_float_key" FROM "default"."T_ALL_TYP
 
 --#[map-09]
 -- Lookup map with bracket notation (string key)
-SELECT "T"['col_map_str_key']['a'] AS "a" FROM "default"."T_ALL_TYPES" AS "T" WHERE "contains_key"("T"['col_map_str_key'], 'a');
+SELECT "T"['col_map_str_key']['a'] AS "a" FROM "default"."T_ALL_TYPES" AS "T" WHERE "map_contains_key"("T"['col_map_str_key'], 'a');
 
 --#[map-10]
 -- Lookup map with bracket notation (float key)
-SELECT "T"['col_map_float_key'][1.0] AS "_1" FROM "default"."T_ALL_TYPES" AS "T" WHERE "contains_key"("T"['col_map_float_key'], 1.0);
+SELECT "T"['col_map_float_key'][CAST(1.0 AS DOUBLE PRECISION)] AS "_1" FROM "default"."T_ALL_TYPES" AS "T" WHERE "map_contains_key"("T"['col_map_float_key'], CAST(1.0 AS DOUBLE PRECISION));
 
 --#[map-11]
 -- Lookup map with bracket notation using column as key
-SELECT "T"['col_map_str_key']["T"['col_string']] AS "_1" FROM "default"."T_ALL_TYPES" AS "T" WHERE "contains_key"("T"['col_map_str_key'], "T"['col_string']);
+SELECT "T"['col_map_str_key']["T"['col_string']] AS "_1" FROM "default"."T_ALL_TYPES" AS "T" WHERE "map_contains_key"("T"['col_map_str_key'], "T"['col_string']);
 
 -- ----------------------------------------
 --  Map functions — map_keys, map_values, map_entries
@@ -107,20 +107,20 @@ SELECT "cardinality"("T"['col_map_str_key']) AS "_1" FROM "default"."T_ALL_TYPES
 SELECT "exists"("T"['col_map_str_key']) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
 
 -- ----------------------------------------
---  Map functions — contains_key
+--  Map functions — map_contains_key
 -- ----------------------------------------
 
 --#[map-22]
--- contains_key with string key that exists
-SELECT "contains_key"("T"['col_map_str_key'], 'a') AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+-- map_contains_key with string key that exists
+SELECT "map_contains_key"("T"['col_map_str_key'], 'a') AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
 
 --#[map-23]
--- contains_key with column reference as key
-SELECT "contains_key"("T"['col_map_str_key'], "T"['col_string']) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+-- map_contains_key with column reference as key
+SELECT "map_contains_key"("T"['col_map_str_key'], "T"['col_string']) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
 
 --#[map-24]
--- contains_key with float key
-SELECT "contains_key"("T"['col_map_float_key'], "T"['col_float64']) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+-- map_contains_key with float key
+SELECT "map_contains_key"("T"['col_map_float_key'], "T"['col_float64']) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
 
 -- ----------------------------------------
 --  Map functions — map_get
@@ -136,7 +136,7 @@ SELECT "map_get"("T"['col_map_str_key'], "T"['col_string']) AS "_1" FROM "defaul
 
 --#[map-27]
 -- map_get with float key
-SELECT "map_get"("T"['col_map_float_key'], 1.0) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+SELECT "map_get"("T"['col_map_float_key'], CAST(1.0 AS DOUBLE PRECISION)) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
 
 -- ----------------------------------------
 --  Filtering
@@ -147,8 +147,8 @@ SELECT "map_get"("T"['col_map_float_key'], 1.0) AS "_1" FROM "default"."T_ALL_TY
 SELECT "T"['col_int32'] AS "col_int32" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"['col_map_str_key']['a'] > 10;
 
 --#[map-32]
--- Filter with contains_key
-SELECT "T"['col_int32'] AS "col_int32" FROM "default"."T_ALL_TYPES" AS "T" WHERE "contains_key"("T"['col_map_str_key'], 'a');
+-- Filter with map_contains_key
+SELECT "T"['col_int32'] AS "col_int32" FROM "default"."T_ALL_TYPES" AS "T" WHERE "map_contains_key"("T"['col_map_str_key'], 'a');
 
 --#[map-33]
 -- Filter with map size

--- a/src/test/resources/outputs/redshift/basics/map.sql
+++ b/src/test/resources/outputs/redshift/basics/map.sql
@@ -36,7 +36,9 @@ SELECT "T"."col_int32", "T"."col_string", "T"."col_map_str_key" FROM "default"."
 -- Select map column with float key type
 SELECT "T"."col_map_float_key" FROM "default"."T_ALL_TYPES" AS "T";
 
--- map-09 (bracket lookup with map_contains_key guard) is not supported — Redshift does not have map_contains_key
+--#[map-09]
+-- Bracket lookup (string key) with map_contains_key guard
+SELECT "T"."col_map_str_key"."a" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_map_str_key"."a" IS NOT NULL;
 
 -- map-10 (float key bracket lookup) is not supported — Redshift SUPER uses dot notation for string keys only
 
@@ -46,7 +48,12 @@ SELECT "T"."col_map_float_key" FROM "default"."T_ALL_TYPES" AS "T";
 
 -- map-18 to map-21 (size, cardinality, exists) are not supported — Redshift does not have equivalent functions for SUPER map type
 
--- map-22 to map-24 (map_contains_key) are not supported — Redshift does not have equivalent functions for SUPER map type
+--#[map-22]
+-- map_contains_key with string key
+SELECT "T"."col_map_str_key"."a" IS NOT NULL AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- map-23 (map_contains_key with column reference) is not supported — Redshift only supports string literal keys
+-- map-24 (map_contains_key with float key) is not supported — Redshift only supports string literal keys
 
 -- ----------------------------------------
 --  Map functions — map_get
@@ -67,7 +74,9 @@ SELECT "T"."col_map_str_key"."a" AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
 -- Filter with map lookup comparison
 SELECT "T"."col_int32" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_map_str_key"."a" > 10;
 
--- map-32 (filter with map_contains_key) is not supported — Redshift does not have equivalent function
+--#[map-32]
+-- Filter with map_contains_key
+SELECT "T"."col_int32" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_map_str_key"."a" IS NOT NULL;
 
 -- map-33 (filter with size) is not supported — Redshift does not have equivalent function
 

--- a/src/test/resources/outputs/redshift/basics/map.sql
+++ b/src/test/resources/outputs/redshift/basics/map.sql
@@ -36,7 +36,7 @@ SELECT "T"."col_int32", "T"."col_string", "T"."col_map_str_key" FROM "default"."
 -- Select map column with float key type
 SELECT "T"."col_map_float_key" FROM "default"."T_ALL_TYPES" AS "T";
 
--- map-09 (bracket lookup with contains_key guard) is not supported — Redshift does not have contains_key
+-- map-09 (bracket lookup with map_contains_key guard) is not supported — Redshift does not have map_contains_key
 
 -- map-10 (float key bracket lookup) is not supported — Redshift SUPER uses dot notation for string keys only
 
@@ -46,7 +46,7 @@ SELECT "T"."col_map_float_key" FROM "default"."T_ALL_TYPES" AS "T";
 
 -- map-18 to map-21 (size, cardinality, exists) are not supported — Redshift does not have equivalent functions for SUPER map type
 
--- map-22 to map-24 (contains_key) are not supported — Redshift does not have equivalent functions for SUPER map type
+-- map-22 to map-24 (map_contains_key) are not supported — Redshift does not have equivalent functions for SUPER map type
 
 -- ----------------------------------------
 --  Map functions — map_get
@@ -67,7 +67,7 @@ SELECT "T"."col_map_str_key"."a" AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
 -- Filter with map lookup comparison
 SELECT "T"."col_int32" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_map_str_key"."a" > 10;
 
--- map-32 (filter with contains_key) is not supported — Redshift does not have equivalent function
+-- map-32 (filter with map_contains_key) is not supported — Redshift does not have equivalent function
 
 -- map-33 (filter with size) is not supported — Redshift does not have equivalent function
 

--- a/src/test/resources/outputs/redshift/basics/map.sql
+++ b/src/test/resources/outputs/redshift/basics/map.sql
@@ -1,0 +1,80 @@
+-- ----------------------------------------
+--  Map construction — literal
+-- ----------------------------------------
+
+--#[map-00]
+-- Construct a map literal with string keys
+SELECT OBJECT('a', 1, 'b', 2, 'c', 3) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- map-01 (decimal keys) is not supported — Redshift SUPER OBJECT requires string keys
+
+--#[map-02]
+-- Construct a map literal referencing columns for values
+SELECT OBJECT('x', CAST("T"."col_int32" AS DOUBLE PRECISION), 'y', "T"."col_float64") AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-03]
+-- Construct a map literal referencing columns for keys
+SELECT OBJECT("T"."col_string", "T"."col_int32") AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-04]
+-- Construct an empty map literal
+SELECT OBJECT() AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- map-05 (integer keys) is not supported — Redshift SUPER OBJECT requires string keys
+
+-- map-06 (expression as key with integer type) is not supported — Redshift SUPER OBJECT requires string keys
+
+-- ----------------------------------------
+--  Select map columns
+-- ----------------------------------------
+
+--#[map-07]
+-- Select map alongside other columns
+SELECT "T"."col_int32", "T"."col_string", "T"."col_map_str_key" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-08]
+-- Select map column with float key type
+SELECT "T"."col_map_float_key" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- map-09 (bracket lookup with contains_key guard) is not supported — Redshift does not have contains_key
+
+-- map-10 (float key bracket lookup) is not supported — Redshift SUPER uses dot notation for string keys only
+
+-- map-11 (column as key bracket lookup) is not supported — Redshift SUPER does not support dynamic key access
+
+-- map-12 to map-17 (map_keys, map_values, map_entries) are not supported — Redshift does not have these functions for SUPER type
+
+-- map-18 to map-21 (size, cardinality, exists) are not supported — Redshift does not have equivalent functions for SUPER map type
+
+-- map-22 to map-24 (contains_key) are not supported — Redshift does not have equivalent functions for SUPER map type
+
+-- ----------------------------------------
+--  Map functions — map_get
+-- ----------------------------------------
+
+--#[map-25]
+-- map_get with string key
+SELECT "T"."col_map_str_key"."a" AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- map-26 (map_get with column reference as key) is not supported — Redshift only supports string literal keys
+-- map-27 (map_get with float key) is not supported — Redshift only supports string literal keys
+
+-- ----------------------------------------
+--  Filtering
+-- ----------------------------------------
+
+--#[map-31]
+-- Filter with map lookup comparison
+SELECT "T"."col_int32" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_map_str_key"."a" > 10;
+
+-- map-32 (filter with contains_key) is not supported — Redshift does not have equivalent function
+
+-- map-33 (filter with size) is not supported — Redshift does not have equivalent function
+
+-- ----------------------------------------
+--  Aggregation
+-- ----------------------------------------
+
+--#[map-34]
+-- Group by map lookup
+SELECT "T"."col_map_str_key"."a", count(1) AS "_1" FROM "default"."T_ALL_TYPES" AS "T" GROUP BY "T"."col_map_str_key"."a";

--- a/src/test/resources/outputs/spark/basics/map.sql
+++ b/src/test/resources/outputs/spark/basics/map.sql
@@ -52,7 +52,7 @@ SELECT `T`.`col_map_str_key`['a'] AS `a` FROM `default`.`T_ALL_TYPES` AS `T` WHE
 
 --#[map-10]
 -- Lookup map with bracket notation (float key)
-SELECT `T`.`col_map_float_key`[1.0] AS `_1` FROM `default`.`T_ALL_TYPES` AS `T` WHERE `map_contains_key`(`T`.`col_map_float_key`, 1.0);
+SELECT `T`.`col_map_float_key`[CAST(1.0 AS DOUBLE)] AS `_1` FROM `default`.`T_ALL_TYPES` AS `T` WHERE `map_contains_key`(`T`.`col_map_float_key`, CAST(1.0 AS DOUBLE));
 
 --#[map-11]
 -- Lookup map with bracket notation using column as key
@@ -107,19 +107,19 @@ SELECT `size`(`T`.`col_map_str_key`) AS `_1` FROM `default`.`T_ALL_TYPES` AS `T`
 SELECT `size`(`T`.`col_map_str_key`) > 0 AS `_1` FROM `default`.`T_ALL_TYPES` AS `T`;
 
 -- ----------------------------------------
---  Map functions — contains_key
+--  Map functions — map_contains_key
 -- ----------------------------------------
 
 --#[map-22]
--- contains_key with string key that exists
+-- map_contains_key with string key that exists
 SELECT `map_contains_key`(`T`.`col_map_str_key`, 'a') AS `_1` FROM `default`.`T_ALL_TYPES` AS `T`;
 
 --#[map-23]
--- contains_key with column reference as key
+-- map_contains_key with column reference as key
 SELECT `map_contains_key`(`T`.`col_map_str_key`, `T`.`col_string`) AS `_1` FROM `default`.`T_ALL_TYPES` AS `T`;
 
 --#[map-24]
--- contains_key with float key
+-- map_contains_key with float key
 SELECT `map_contains_key`(`T`.`col_map_float_key`, `T`.`col_float64`) AS `_1` FROM `default`.`T_ALL_TYPES` AS `T`;
 
 -- ----------------------------------------
@@ -136,7 +136,7 @@ SELECT `element_at`(`T`.`col_map_str_key`, `T`.`col_string`) AS `_1` FROM `defau
 
 --#[map-27]
 -- map_get with float key
-SELECT `element_at`(`T`.`col_map_float_key`, 1.0) AS `_1` FROM `default`.`T_ALL_TYPES` AS `T`;
+SELECT `element_at`(`T`.`col_map_float_key`, CAST(1.0 AS DOUBLE)) AS `_1` FROM `default`.`T_ALL_TYPES` AS `T`;
 
 -- ----------------------------------------
 --  Filtering
@@ -147,7 +147,7 @@ SELECT `element_at`(`T`.`col_map_float_key`, 1.0) AS `_1` FROM `default`.`T_ALL_
 SELECT `T`.`col_int32` AS `col_int32` FROM `default`.`T_ALL_TYPES` AS `T` WHERE `T`.`col_map_str_key`['a'] > 10;
 
 --#[map-32]
--- Filter with contains_key
+-- Filter with map_contains_key
 SELECT `T`.`col_int32` AS `col_int32` FROM `default`.`T_ALL_TYPES` AS `T` WHERE `map_contains_key`(`T`.`col_map_str_key`, 'a');
 
 --#[map-33]

--- a/src/test/resources/outputs/spark/basics/map.sql
+++ b/src/test/resources/outputs/spark/basics/map.sql
@@ -1,0 +1,163 @@
+-- ----------------------------------------
+--  Map construction — literal
+-- ----------------------------------------
+
+--#[map-00]
+-- Construct a map literal with string keys
+SELECT MAP('a', 1, 'b', 2, 'c', 3) AS `_1` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[map-01]
+-- Construct a map literal with decimal keys
+SELECT MAP(1.1, 'x', 2.2, 'y', 3.3, 'z') AS `_1` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[map-02]
+-- Construct a map literal referencing columns for values
+SELECT MAP('x', CAST(`T`.`col_int32` AS DOUBLE), 'y', `T`.`col_float64`) AS `_1` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[map-03]
+-- Construct a map literal referencing columns for keys
+SELECT MAP(`T`.`col_string`, `T`.`col_int32`) AS `_1` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[map-04]
+-- Construct an empty map literal
+SELECT MAP() AS `_1` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[map-05]
+-- Construct a map literal with integer keys
+SELECT MAP(1, 'a', 2, 'b', 3, 'c') AS `_1` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[map-06]
+-- Construct a map literal with expression as key
+SELECT MAP(`T`.`col_int32` + 1, `T`.`col_string`) AS `_1` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+-- ----------------------------------------
+--  Select map columns
+-- ----------------------------------------
+
+--#[map-07]
+-- Select map alongside other columns
+SELECT `T`.`col_int32` AS `col_int32`, `T`.`col_string` AS `col_string`, `T`.`col_map_str_key` AS `col_map_str_key` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[map-08]
+-- Select map column with float key type
+SELECT `T`.`col_map_float_key` AS `col_map_float_key` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+-- ----------------------------------------
+--  Bracket notation lookup
+-- ----------------------------------------
+
+--#[map-09]
+-- Lookup map with bracket notation (string key)
+SELECT `T`.`col_map_str_key`['a'] AS `a` FROM `default`.`T_ALL_TYPES` AS `T` WHERE `map_contains_key`(`T`.`col_map_str_key`, 'a');
+
+--#[map-10]
+-- Lookup map with bracket notation (float key)
+SELECT `T`.`col_map_float_key`[1.0] AS `_1` FROM `default`.`T_ALL_TYPES` AS `T` WHERE `map_contains_key`(`T`.`col_map_float_key`, 1.0);
+
+--#[map-11]
+-- Lookup map with bracket notation using column as key
+SELECT `T`.`col_map_str_key`[`T`.`col_string`] AS `_1` FROM `default`.`T_ALL_TYPES` AS `T` WHERE `map_contains_key`(`T`.`col_map_str_key`, `T`.`col_string`);
+
+-- ----------------------------------------
+--  Map functions — map_keys, map_values, map_entries
+-- ----------------------------------------
+
+--#[map-12]
+-- Get keys from a string-key map
+SELECT `map_keys`(`T`.`col_map_str_key`) AS `_1` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[map-13]
+-- Get keys from a float-key map
+SELECT `map_keys`(`T`.`col_map_float_key`) AS `_1` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[map-14]
+-- Get values from a string-key map
+SELECT `map_values`(`T`.`col_map_str_key`) AS `_1` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[map-15]
+-- Get values from a float-key map
+SELECT `map_values`(`T`.`col_map_float_key`) AS `_1` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[map-16]
+-- Get entries from a string-key map
+SELECT `map_entries`(`T`.`col_map_str_key`) AS `_1` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[map-17]
+-- Get entries from a float-key map
+SELECT `map_entries`(`T`.`col_map_float_key`) AS `_1` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+-- ----------------------------------------
+--  Map functions — size, cardinality, exists
+-- ----------------------------------------
+
+--#[map-18]
+-- Size of a map column
+SELECT `size`(`T`.`col_map_str_key`) AS `_1` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[map-19]
+-- Size of a map literal
+SELECT `size`(MAP('a', 1, 'b', 2, 'c', 3)) AS `_1` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[map-20]
+-- Cardinality of a map column
+SELECT `size`(`T`.`col_map_str_key`) AS `_1` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[map-21]
+-- Exists on a map column
+SELECT `size`(`T`.`col_map_str_key`) > 0 AS `_1` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+-- ----------------------------------------
+--  Map functions — contains_key
+-- ----------------------------------------
+
+--#[map-22]
+-- contains_key with string key that exists
+SELECT `map_contains_key`(`T`.`col_map_str_key`, 'a') AS `_1` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[map-23]
+-- contains_key with column reference as key
+SELECT `map_contains_key`(`T`.`col_map_str_key`, `T`.`col_string`) AS `_1` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[map-24]
+-- contains_key with float key
+SELECT `map_contains_key`(`T`.`col_map_float_key`, `T`.`col_float64`) AS `_1` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+-- ----------------------------------------
+--  Map functions — map_get
+-- ----------------------------------------
+
+--#[map-25]
+-- map_get with string key
+SELECT `element_at`(`T`.`col_map_str_key`, 'a') AS `_1` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[map-26]
+-- map_get with column reference as key
+SELECT `element_at`(`T`.`col_map_str_key`, `T`.`col_string`) AS `_1` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+--#[map-27]
+-- map_get with float key
+SELECT `element_at`(`T`.`col_map_float_key`, 1.0) AS `_1` FROM `default`.`T_ALL_TYPES` AS `T`;
+
+-- ----------------------------------------
+--  Filtering
+-- ----------------------------------------
+
+--#[map-31]
+-- Filter with map lookup comparison
+SELECT `T`.`col_int32` AS `col_int32` FROM `default`.`T_ALL_TYPES` AS `T` WHERE `T`.`col_map_str_key`['a'] > 10;
+
+--#[map-32]
+-- Filter with contains_key
+SELECT `T`.`col_int32` AS `col_int32` FROM `default`.`T_ALL_TYPES` AS `T` WHERE `map_contains_key`(`T`.`col_map_str_key`, 'a');
+
+--#[map-33]
+-- Filter with map size
+SELECT `T`.`col_int32` AS `col_int32` FROM `default`.`T_ALL_TYPES` AS `T` WHERE `size`(`T`.`col_map_str_key`) > 0;
+
+-- ----------------------------------------
+--  Aggregation
+-- ----------------------------------------
+
+--#[map-34]
+-- Group by map lookup
+SELECT `T`.`col_map_str_key`['a'] AS `a`, `count`(1) AS `_1` FROM `default`.`T_ALL_TYPES` AS `T` GROUP BY `T`.`col_map_str_key`['a'];

--- a/src/test/resources/outputs/trino/basics/map.sql
+++ b/src/test/resources/outputs/trino/basics/map.sql
@@ -52,7 +52,7 @@ SELECT "T"."col_map_str_key"['a'] AS "a" FROM "default"."T_ALL_TYPES" AS "T" WHE
 
 --#[map-10]
 -- Lookup map with bracket notation (float key)
-SELECT "T"."col_map_float_key"[1.0] AS "_1" FROM "default"."T_ALL_TYPES" AS "T" WHERE contains(map_keys("T"."col_map_float_key"), 1.0);
+SELECT "T"."col_map_float_key"[CAST(1.0 AS DOUBLE)] AS "_1" FROM "default"."T_ALL_TYPES" AS "T" WHERE contains(map_keys("T"."col_map_float_key"), CAST(1.0 AS DOUBLE));
 
 --#[map-11]
 -- Lookup map with bracket notation using column as key
@@ -107,19 +107,19 @@ SELECT cardinality("T"."col_map_str_key") AS "_1" FROM "default"."T_ALL_TYPES" A
 SELECT cardinality("T"."col_map_str_key") > 0 AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
 
 -- ----------------------------------------
---  Map functions — contains_key
+--  Map functions — map_contains_key
 -- ----------------------------------------
 
 --#[map-22]
--- contains_key with string key that exists
+-- map_contains_key with string key that exists
 SELECT contains(map_keys("T"."col_map_str_key"), 'a') AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
 
 --#[map-23]
--- contains_key with column reference as key
+-- map_contains_key with column reference as key
 SELECT contains(map_keys("T"."col_map_str_key"), "T"."col_string") AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
 
 --#[map-24]
--- contains_key with float key
+-- map_contains_key with float key
 SELECT contains(map_keys("T"."col_map_float_key"), "T"."col_float64") AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
 
 -- ----------------------------------------
@@ -136,7 +136,7 @@ SELECT element_at("T"."col_map_str_key", "T"."col_string") AS "_1" FROM "default
 
 --#[map-27]
 -- map_get with float key
-SELECT element_at("T"."col_map_float_key", 1.0) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+SELECT element_at("T"."col_map_float_key", CAST(1.0 AS DOUBLE)) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
 
 -- ----------------------------------------
 --  Filtering
@@ -147,7 +147,7 @@ SELECT element_at("T"."col_map_float_key", 1.0) AS "_1" FROM "default"."T_ALL_TY
 SELECT "T"."col_int32" AS "col_int32" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_map_str_key"['a'] > 10;
 
 --#[map-32]
--- Filter with contains_key
+-- Filter with map_contains_key
 SELECT "T"."col_int32" AS "col_int32" FROM "default"."T_ALL_TYPES" AS "T" WHERE contains(map_keys("T"."col_map_str_key"), 'a');
 
 --#[map-33]

--- a/src/test/resources/outputs/trino/basics/map.sql
+++ b/src/test/resources/outputs/trino/basics/map.sql
@@ -1,0 +1,163 @@
+-- ----------------------------------------
+--  Map construction — literal
+-- ----------------------------------------
+
+--#[map-00]
+-- Construct a map literal with string keys
+SELECT MAP(ARRAY['a', 'b', 'c'], ARRAY[1, 2, 3]) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-01]
+-- Construct a map literal with decimal keys
+SELECT MAP(ARRAY[1.1, 2.2, 3.3], ARRAY['x', 'y', 'z']) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-02]
+-- Construct a map literal referencing columns for values
+SELECT MAP(ARRAY['x', 'y'], ARRAY[CAST("T"."col_int32" AS DOUBLE), "T"."col_float64"]) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-03]
+-- Construct a map literal referencing columns for keys
+SELECT MAP(ARRAY["T"."col_string"], ARRAY["T"."col_int32"]) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-04]
+-- Construct an empty map literal
+SELECT MAP(ARRAY[], ARRAY[]) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-05]
+-- Construct a map literal with integer keys
+SELECT MAP(ARRAY[1, 2, 3], ARRAY['a', 'b', 'c']) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-06]
+-- Construct a map literal with expression as key
+SELECT MAP(ARRAY["T"."col_int32" + 1], ARRAY["T"."col_string"]) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Select map columns
+-- ----------------------------------------
+
+--#[map-07]
+-- Select map alongside other columns
+SELECT "T"."col_int32" AS "col_int32", "T"."col_string" AS "col_string", "T"."col_map_str_key" AS "col_map_str_key" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-08]
+-- Select map column with float key type
+SELECT "T"."col_map_float_key" AS "col_map_float_key" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Bracket notation lookup
+-- ----------------------------------------
+
+--#[map-09]
+-- Lookup map with bracket notation (string key)
+SELECT "T"."col_map_str_key"['a'] AS "a" FROM "default"."T_ALL_TYPES" AS "T" WHERE contains(map_keys("T"."col_map_str_key"), 'a');
+
+--#[map-10]
+-- Lookup map with bracket notation (float key)
+SELECT "T"."col_map_float_key"[1.0] AS "_1" FROM "default"."T_ALL_TYPES" AS "T" WHERE contains(map_keys("T"."col_map_float_key"), 1.0);
+
+--#[map-11]
+-- Lookup map with bracket notation using column as key
+SELECT "T"."col_map_str_key"["T"."col_string"] AS "_1" FROM "default"."T_ALL_TYPES" AS "T" WHERE contains(map_keys("T"."col_map_str_key"), "T"."col_string");
+
+-- ----------------------------------------
+--  Map functions — map_keys, map_values, map_entries
+-- ----------------------------------------
+
+--#[map-12]
+-- Get keys from a string-key map
+SELECT "map_keys"("T"."col_map_str_key") AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-13]
+-- Get keys from a float-key map
+SELECT "map_keys"("T"."col_map_float_key") AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-14]
+-- Get values from a string-key map
+SELECT "map_values"("T"."col_map_str_key") AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-15]
+-- Get values from a float-key map
+SELECT "map_values"("T"."col_map_float_key") AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-16]
+-- Get entries from a string-key map
+SELECT "map_entries"("T"."col_map_str_key") AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-17]
+-- Get entries from a float-key map
+SELECT "map_entries"("T"."col_map_float_key") AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Map functions — size, cardinality, exists
+-- ----------------------------------------
+
+--#[map-18]
+-- Size of a map column
+SELECT cardinality("T"."col_map_str_key") AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-19]
+-- Size of a map literal
+SELECT cardinality(MAP(ARRAY['a', 'b', 'c'], ARRAY[1, 2, 3])) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-20]
+-- Cardinality of a map column
+SELECT cardinality("T"."col_map_str_key") AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-21]
+-- Exists on a map column
+SELECT cardinality("T"."col_map_str_key") > 0 AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Map functions — contains_key
+-- ----------------------------------------
+
+--#[map-22]
+-- contains_key with string key that exists
+SELECT contains(map_keys("T"."col_map_str_key"), 'a') AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-23]
+-- contains_key with column reference as key
+SELECT contains(map_keys("T"."col_map_str_key"), "T"."col_string") AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-24]
+-- contains_key with float key
+SELECT contains(map_keys("T"."col_map_float_key"), "T"."col_float64") AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Map functions — map_get
+-- ----------------------------------------
+
+--#[map-25]
+-- map_get with string key
+SELECT element_at("T"."col_map_str_key", 'a') AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-26]
+-- map_get with column reference as key
+SELECT element_at("T"."col_map_str_key", "T"."col_string") AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+--#[map-27]
+-- map_get with float key
+SELECT element_at("T"."col_map_float_key", 1.0) AS "_1" FROM "default"."T_ALL_TYPES" AS "T";
+
+-- ----------------------------------------
+--  Filtering
+-- ----------------------------------------
+
+--#[map-31]
+-- Filter with map lookup comparison
+SELECT "T"."col_int32" AS "col_int32" FROM "default"."T_ALL_TYPES" AS "T" WHERE "T"."col_map_str_key"['a'] > 10;
+
+--#[map-32]
+-- Filter with contains_key
+SELECT "T"."col_int32" AS "col_int32" FROM "default"."T_ALL_TYPES" AS "T" WHERE contains(map_keys("T"."col_map_str_key"), 'a');
+
+--#[map-33]
+-- Filter with map size
+SELECT "T"."col_int32" AS "col_int32" FROM "default"."T_ALL_TYPES" AS "T" WHERE cardinality("T"."col_map_str_key") > 0;
+
+-- ----------------------------------------
+--  Aggregation
+-- ----------------------------------------
+
+--#[map-34]
+-- Group by map lookup
+SELECT "T"."col_map_str_key"['a'] AS "a", count(1) AS "_1" FROM "default"."T_ALL_TYPES" AS "T" GROUP BY "T"."col_map_str_key"['a'];


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
  - SparkRexConverter: Override visitPathKey to emit bracket notation (PathStep.Element) for MAP operands and dot notation (PathStep.Field) for STRUCT operands
  - SparkAstToSql: Simplify visitPathStepElement to delegate to super (bracket→dot conversion now handled at plan level)
  - TrinoRewriter: Allow MAP operands in visitPathIndex (pass through without array index rewriting)
  - TrinoRexConverter: Override visitPathKey to distinguish MAP vs STRUCT access
  - TrinoCalls/SparkCalls/RedshiftCalls: Add function rewrite rules for map operations
  - RedshiftCalls: Throw UNSUPPORTED_OPERATION for functions with no Redshift equivalent

## Runtime Validation Status

| Test | Description | Redshift | Spark | Trino |
|------|-------------|----------|-------|-------|
| map-00 | MAP literal with string keys | PASS | PASS | PASS |
| map-01 | MAP literal with decimal keys | UNSUPPORTED | PASS | PASS |
| map-02 | MAP literal referencing columns for values | PASS | PASS | PASS |
| map-03 | MAP literal referencing columns for keys | PASS | PASS | PASS |
| map-04 | Empty MAP literal | PASS | PASS | PASS |
| map-05 | MAP literal with integer keys | UNSUPPORTED | PASS | PASS |
| map-06 | MAP literal with expression as key | UNSUPPORTED | PASS | PASS |
| map-07 | Select map alongside other columns | PASS | PASS | PASS |
| map-08 | Select map column with float key type | UNSUPPORTED | PASS | PASS |
| map-09 | Bracket lookup (string key) | PASS | PASS | PASS |
| map-10 | Bracket lookup (float key)| UNSUPPORTED | PASS | PASS |
| map-11 | Bracket lookup (column as key) | UNSUPPORTED | PASS | PASS |
| map-12 | map_keys (string-key map) | UNSUPPORTED | PASS | PASS |
| map-13 | map_keys (float-key map) | UNSUPPORTED | PASS | PASS |
| map-14 | map_values (string-key map) | UNSUPPORTED | PASS | PASS |
| map-15 | map_values (float-key map) | UNSUPPORTED | PASS | PASS |
| map-16 | map_entries (string-key map) | UNSUPPORTED | PASS | PASS |
| map-17 | map_entries (float-key map) | UNSUPPORTED | PASS | PASS |
| map-18 | size of map column | UNSUPPORTED | PASS | PASS |
| map-19 | size of map literal | UNSUPPORTED | PASS | PASS |
| map-20 | cardinality of map column | UNSUPPORTED | PASS | PASS |
| map-21 | exists on map column | UNSUPPORTED | PASS | PASS |
| map-22 | map_contains_key with string key | PASS | PASS | PASS |
| map-23 | map_contains_key with column reference | UNSUPPORTED | PASS | PASS |
| map-24 | map_contains_key with float key | UNSUPPORTED | PASS | PASS |
| map-25 | map_get with string key | PASS | PASS | PASS |
| map-26 | map_get with column reference | UNSUPPORTED | PASS | PASS |
| map-27 | map_get with float key | UNSUPPORTED | PASS | PASS |
| map-28 | IS MAP type predicate | NOT IMPL | NOT IMPL | NOT IMPL |
| map-29 | CAST struct to MAP | NOT IMPL | NOT IMPL | NOT IMPL |
| map-30 | CAST map to different map type | NOT IMPL | NOT IMPL | NOT IMPL |
| map-31 | Filter with map lookup comparison | PASS | PASS | PASS |
| map-32 | Filter with map_contains_key | PASS | PASS | PASS |
| map-33 | Filter with map size | UNSUPPORTED | PASS | PASS |
| map-34 | Group by map lookup | PASS | PASS | PASS |
| map-35 | UNPIVOT map literal | NOT IMPL | NOT IMPL | NOT IMPL |
| map-36 | UNPIVOT map column with correlated join | NOT IMPL | NOT IMPL | NOT IMPL |

## Legend

- **PASS** — Transpiled query executes successfully on the target engine
- **FAIL*** — Transpilation correct but runtime type mismatch
- **UNSUPPORTED** — Transpiler throws `ScribeProblem.UNSUPPORTED_OPERATION` (no equivalent in target)
- **NOT IMPL** — Planner/transpiler does not yet support this operation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
